### PR TITLE
Import individual lodash modules to make the bundle smaller

### DIFF
--- a/lib/create-request-config.js
+++ b/lib/create-request-config.js
@@ -1,4 +1,4 @@
-import {cloneDeep} from 'lodash/lang'
+import cloneDeep from 'lodash/cloneDeep'
 
 /**
  * Creates request parameters configuration by parsing an existing query object

--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -1,4 +1,4 @@
-import {cloneDeep} from 'lodash/lang'
+import cloneDeep from 'lodash/cloneDeep'
 import mixinToPlainObject from '../mixins/to-plain-object'
 
 /**

--- a/lib/entities/content-type.js
+++ b/lib/entities/content-type.js
@@ -1,4 +1,4 @@
-import {cloneDeep} from 'lodash/lang'
+import cloneDeep from 'lodash/cloneDeep'
 import mixinToPlainObject from '../mixins/to-plain-object'
 
 /**

--- a/lib/entities/entry.js
+++ b/lib/entities/entry.js
@@ -1,5 +1,5 @@
-import {cloneDeep} from 'lodash/lang'
-import {uniq} from 'lodash/array'
+import cloneDeep from 'lodash/cloneDeep'
+import uniq from 'lodash/uniq'
 import mixinToPlainObject from '../mixins/to-plain-object'
 import mixinLinkGetters from '../mixins/link-getters'
 import mixinStringifySafe from '../mixins/stringify-safe'

--- a/lib/mixins/link-getters.js
+++ b/lib/mixins/link-getters.js
@@ -1,6 +1,9 @@
-import {map, each, find} from 'lodash/collection'
-import {get} from 'lodash/object'
-import {partial, memoize} from 'lodash/function'
+import map from 'lodash/map'
+import each from 'lodash/each'
+import find from 'lodash/find'
+import get from 'lodash/get'
+import partial from 'lodash/partial'
+import memoize from 'lodash/memoize'
 
 /**
  * Sets getters on links for a given response

--- a/lib/mixins/to-plain-object.js
+++ b/lib/mixins/to-plain-object.js
@@ -1,4 +1,4 @@
-import {cloneDeep} from 'lodash/lang'
+import cloneDeep from 'lodash/cloneDeep'
 
 /**
  * Mixes in a method to return just a plain object with no additional methods

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -2,8 +2,8 @@
  * See <a href="https://www.contentful.com/developers/docs/concepts/sync/">Synchronization</a> for more information.
  * @namespace Sync
  */
-import {filter} from 'lodash/collection'
-import {cloneDeep} from 'lodash/lang'
+import filter from 'lodash/filter'
+import cloneDeep from 'lodash/cloneDeep'
 import createRequestConfig from './create-request-config'
 import mixinLinkGetters from './mixins/link-getters'
 import mixinStringifySafe from './mixins/stringify-safe'


### PR DESCRIPTION
This cuts down the size of the minified and gzipped browser bundle by ~30% and helps me reduce the code size when using Contentful from npm in my webpack build.

I left the imports in test modules unchanged, because they won't be included in the final build.