### PR TITLE
Support building for a server-side target #59

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "browser": "./browser.js",
+  "node": "./browser.js",
   "files": [
     "browser.js",
     "index.js",


### PR DESCRIPTION
After our discussion in #59, I did a little digging and found what was wrong (I think?)

Unlike in your example app which is building for browsers, I am using webpack to build for a node target. Since there was no node option in the `package.json`, it would fall back to `index.js` and error trying to load `lib/contentful`.

This PR adds a node option to the package.json to support server-side builds such as this.