### PR TITLE
fix: Bump babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tonic-example.js"
   ],
   "dependencies": {
-    "babel-runtime": "~6.3.19",
+    "babel-runtime": "~6.22.0",
     "contentful-sdk-core": "~2.5.0",
     "json-stringify-safe": "~5.0.1",
     "lodash": "~4.2.0"


### PR DESCRIPTION
This change bumps the babel-runtime dependency so that it in turn pulls in a newer minimatch. The version of minimatch used by this older babel-runtime is vulnerable to a regex DoS and causes vulnerability alerts from e.g. auditjs. Related babel PR: https://github.com/babel/babel/pull/3537