### PR TITLE
fix(createClient): correct mismatched parameters

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -39,8 +39,8 @@ import createLinkResolver from './create-link-resolver'
  */
 export default function createClient (axios, params) {
   params = defaults(cloneDeep(params), {
-    rateLimit: 9,
-    rateLimitPeriod: 1000,
+    concurrency: 9,
+    delay: 1000,
     maxRetries: 5,
     retryOnTooManyRequests: true
   })
@@ -64,8 +64,8 @@ export default function createClient (axios, params) {
   })
 
   const http = wrapHttpClient(createHttpClient(axios, params), {
-    concurrency: params.rateLimit,
-    delay: params.rateLimitPeriod,
+    concurrency: params.concurrency,
+    delay: params.delay,
     maxRetries: params.maxRetries,
     retryOnTooManyRequests: params.retryOnTooManyRequests
   })


### PR DESCRIPTION
Rename configuration parameters to createClient that are proxied to `wrapHttpClient`.

Resolve #114.