### PR TITLE
fix(export): SDK is working in node again

### DIFF
--- a/karma.base.conf.js
+++ b/karma.base.conf.js
@@ -2,7 +2,7 @@
 // Use karma.conf.local.js for local tests
 // Use karma.conf.saucelabs.js for saucelabs tests
 var _ = require('lodash')
-var webpackConfig = _.cloneDeep(require('./webpack.config.js'))
+var webpackConfig = _.cloneDeep(require('./webpack.config.js')[0])
 delete webpackConfig.entry
 delete webpackConfig.output
 webpackConfig.devtool = 'inline-source-map'

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Client for Contentful's Content Delivery API",
   "version": "4.1.0",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
-  "main": "./dist/contentful.js",
+  "main": "./dist/contentful.node.js",
+  "browser": "./dist/contentful.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/contentful/contentful.js.git"
@@ -15,8 +16,8 @@
     "clean": "rimraf dist && rimraf coverage",
     "build": "npm run clean && npm run build:ci",
     "build:ci": "npm run vendor:version && npm run build:standalone",
-    "build:standalone": "BABEL_ENV=webpack webpack && BABEL_ENV=webpack webpack -p --output-filename contentful.min.js",
-    "build:standalone:log": "BABEL_ENV=webpack npm run build && webpack -p --json --profile --output-filename contentful.min.js > webpack-build-log.json",
+    "build:standalone": "BABEL_ENV=webpack webpack && BABEL_ENV=webpack NODE_ENV=production webpack -p",
+    "build:standalone:log": "BABEL_ENV=webpack npm run build && BABEL_ENV=webpack NODE_ENV=production webpack -p --json --profile > webpack-build-log.json",
     "docs:build": "esdoc -c esdoc.json",
     "docs:dev": "npm run build && npm run docs:build",
     "docs:watch": "watchy -w lib npm run docs:dev",
@@ -47,7 +48,6 @@
   },
   "types": "./index.d.ts",
   "files": [
-    "index.js",
     "version.js",
     "index.d.ts",
     "dist",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,23 +37,42 @@ if (process.env.NODE_ENV === 'production') {
   )
 }
 
-module.exports = {
-  context: path.join(__dirname, 'lib'),
-  entry: './contentful.js',
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'contentful.js',
-    libraryTarget: 'umd',
-    library: 'contentful'
+const loaders = [
+  {
+    test: /\.js?$/,
+    exclude: /(node_modules|bower_components|dist)/,
+    loader: 'babel-loader'
+  }
+]
+
+module.exports = [
+  {
+    context: path.join(__dirname, 'lib'),
+    entry: './contentful.js',
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: `contentful${process.env.NODE_ENV === 'production' ? '.min' : ''}.js`,
+      libraryTarget: 'umd',
+      library: 'contentful'
+    },
+    module: {
+      loaders
+    },
+    plugins
   },
-  module: {
-    loaders: [
-      {
-        test: /\.js?$/,
-        exclude: /(node_modules|bower_components|dist)/,
-        loader: 'babel-loader'
-      }
-    ]
-  },
-  plugins: plugins
-}
+  {
+    context: path.join(__dirname, 'lib'),
+    entry: './contentful.js',
+    target: 'node',
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: `contentful.node${process.env.NODE_ENV === 'production' ? '.min' : ''}.js`,
+      libraryTarget: 'commonjs2',
+      library: 'contentful'
+    },
+    module: {
+      loaders
+    },
+    plugins
+  }
+]


### PR DESCRIPTION
Since Axios is not compatible with UMD builds that cover `node`  and `browser` environment, we decided to split it up into to versions.

Fixes #131 