### PR TITLE
fixed "fields" member of ContentType interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export interface ContentType {
     name: string;
     description: string;
     displayField: string;
-    Array: string;
+    fields: Array;
     toPlainObject(): ContentType;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export interface ContentType {
     name: string;
     description: string;
     displayField: string;
-    fields: Array;
+    fields: Array<Field>;
     toPlainObject(): ContentType;
 }
 
@@ -102,6 +102,16 @@ export interface ContentTypeLink {
     type: 'Link';
     linkType: 'ContentType';
     id: string;
+}
+
+export interface Field {
+    disabled: boolean;
+    id: string;
+    localized: boolean;
+    name: string;
+    omitted: boolean;
+    required: boolean;
+    type: string;
 }
 
 export function createClient(params: CreateClientParams): ContentfulClientApi;

--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ export interface ContentTypeLink {
 export interface Field {
     disabled: boolean;
     id: string;
+    linkType?: string;
     localized: boolean;
     name: string;
     omitted: boolean;


### PR DESCRIPTION
I want to be able to reference the `fields` array in my client-side code. 