### PR TITLE
refactor(dependencies): replace lodash with smaller dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
+  "plugins": [
+    "transform-object-rest-spread"
+  ],
   "env": {
     "browser": {
       "presets": [

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -5,7 +5,6 @@
  * @see ContentfulClientAPI
  */
 
-import assign from 'lodash/assign'
 import axios from 'axios'
 import {createHttpClient, getUserAgentHeader} from 'contentful-sdk-core'
 import createContentfulApi from './create-contentful-api'
@@ -55,10 +54,11 @@ export function createClient (params) {
     params.integration
   )
   params.defaultHostname = 'cdn.contentful.com'
-  params.headers = assign(params.headers, {
+  params.headers = {
+    ...params.headers,
     'Content-Type': 'application/vnd.contentful.delivery.v1+json',
     'X-Contentful-User-Agent': userAgentHeader
-  })
+  }
 
   const http = createHttpClient(axios, params)
 

--- a/lib/entities/asset.js
+++ b/lib/entities/asset.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'clone'
 import {toPlainObject, freezeSys} from 'contentful-sdk-core'
 
 /**

--- a/lib/entities/content-type.js
+++ b/lib/entities/content-type.js
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'clone'
 import {toPlainObject, freezeSys} from 'contentful-sdk-core'
 
 /**

--- a/lib/entities/entry.js
+++ b/lib/entities/entry.js
@@ -1,5 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep'
-import uniq from 'lodash/uniq'
+import cloneDeep from 'clone'
 import {toPlainObject, freezeSys} from 'contentful-sdk-core'
 import mixinLinkGetters from '../mixins/link-getters'
 import mixinStringifySafe from '../mixins/stringify-safe'
@@ -108,6 +107,6 @@ export function wrapEntryCollection (data, resolveLinks, resolveForAllLocales) {
 
 function prepareIncludes (includes = {}, items) {
   includes.Entry = includes.Entry || []
-  includes.Entry = uniq(includes.Entry.concat(cloneDeep(items)))
+  includes.Entry = [ ...new Set([...includes.Entry, ...items]) ]
   return includes
 }

--- a/lib/mixins/link-getters.js
+++ b/lib/mixins/link-getters.js
@@ -1,9 +1,5 @@
-import map from 'lodash/map'
-import each from 'lodash/each'
-import find from 'lodash/find'
-import get from 'lodash/get'
-import partial from 'lodash/partial'
-import memoize from 'lodash/memoize'
+import deep from 'deep-get-set'
+import mem from 'mem'
 
 /**
  * Sets getters on links for a given response
@@ -12,8 +8,10 @@ import memoize from 'lodash/memoize'
  * @param {Object} includes - Object with lists of Entry, Asset, DeletedEntry and DeletedAsset
  */
 export default function mixinLinkGetters (items, includes) {
-  const linkGetter = memoize(getLinksFromIncludes, memoizationResolver)
-  each(items, (item) => {
+  const linkGetter = mem(getLinksFromIncludes, {
+    cacheKey: (a) => a.sys.id
+  })
+  items.forEach((item) => {
     setLocalizedFieldGetters(item.fields, !!item.sys.locale)
   })
 
@@ -29,7 +27,8 @@ export default function mixinLinkGetters (items, includes) {
     if (hasLocale) {
       setFieldGettersForFields(fields)
     } else {
-      each(fields, (localizedField) => setFieldGettersForFields(localizedField))
+      const fieldKeys = Object.keys(fields)
+      fieldKeys.forEach((fieldKey) => setFieldGettersForFields(fields[fieldKey]))
     }
   }
 
@@ -39,7 +38,9 @@ export default function mixinLinkGetters (items, includes) {
    * @param {Object} fields - Fields object
    */
   function setFieldGettersForFields (fields) {
-    each(fields, (field, fieldKey) => {
+    const fieldKeys = Object.keys(fields)
+    fieldKeys.forEach((fieldKey) => {
+      const field = fields[fieldKey]
       if (Array.isArray(field)) {
         addGetterForLinkArray(field, fieldKey, fields)
       } else {
@@ -56,9 +57,9 @@ export default function mixinLinkGetters (items, includes) {
    * @param {Object} fields - Fields object
    */
   function addGetterForLink (field, fieldKey, fields) {
-    if (get(field, 'sys.type') === 'Link') {
+    if (deep(field, 'sys.type') === 'Link') {
       Object.defineProperty(fields, fieldKey, {
-        get: partial(linkGetter, field)
+        get: (...args) => linkGetter(field, ...args)
       })
     }
   }
@@ -71,10 +72,10 @@ export default function mixinLinkGetters (items, includes) {
    * @param {Object} fields - Fields object
    */
   function addGetterForLinkArray (listField, fieldKey, fields) {
-    if (get(listField[0], 'sys.type') === 'Link') {
+    if (deep(listField[0], 'sys.type') === 'Link') {
       Object.defineProperty(fields, fieldKey, {
         get: function () {
-          return map(listField, partial(linkGetter))
+          return listField.map(linkGetter)
         }
       })
     }
@@ -91,15 +92,12 @@ export default function mixinLinkGetters (items, includes) {
    * @return {Object} Field, or link if field not resolved
    */
   function getLinksFromIncludes (field) {
-    var link = find(includes[field.sys.linkType], ['sys.id', field.sys.id])
+    const linkedEntities = includes[field.sys.linkType] || []
+    const link = linkedEntities.find((linkedEntity) => linkedEntity.sys.id === field.sys.id)
     if (link && link.fields) {
       setLocalizedFieldGetters(link.fields, !!link.sys.locale)
       return link
     }
     return field
-  }
-
-  function memoizationResolver (link) {
-    return link.sys.id
   }
 }

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -2,8 +2,7 @@
  * See <a href="https://www.contentful.com/developers/docs/concepts/sync/">Synchronization</a> for more information.
  * @namespace Sync
  */
-import filter from 'lodash/filter'
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'clone'
 import {createRequestConfig, freezeSys, toPlainObject} from 'contentful-sdk-core'
 import mixinLinkGetters from './mixins/link-getters'
 import mixinStringifySafe from './mixins/stringify-safe'
@@ -81,10 +80,10 @@ export default function pagedSync (http, query, resolveLinks) {
  */
 function mapResponseItems (items) {
   return {
-    entries: filter(items, ['sys.type', 'Entry']),
-    assets: filter(items, ['sys.type', 'Asset']),
-    deletedEntries: filter(items, ['sys.type', 'DeletedEntry']),
-    deletedAssets: filter(items, ['sys.type', 'DeletedAsset'])
+    entries: items.filter((item) => item.sys.type === 'Entry'),
+    assets: items.filter((item) => item.sys.type === 'Asset'),
+    deletedEntries: items.filter((item) => item.sys.type === 'DeletedEntry'),
+    deletedAssets: items.filter((item) => item.sys.type === 'DeletedAsset')
   }
 }
 
@@ -97,8 +96,8 @@ function mapResponseItems (items) {
  */
 function mapIncludeItems (items) {
   return {
-    Entry: filter(items, ['sys.type', 'Entry']),
-    Asset: filter(items, ['sys.type', 'Asset'])
+    Entry: items.filter((item) => item.sys.type === 'Entry'),
+    Asset: items.filter((item) => item.sys.type === 'Asset')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful",
   "description": "Client for Contentful's Content Delivery API",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
   "main": "./dist/contentful.node.js",
   "module": "./dist/es6-modules/contentful.js",

--- a/package.json
+++ b/package.json
@@ -125,11 +125,11 @@
   "bundlesize": [
     {
       "path": "./dist/contentful.js",
-      "maxSize": "75Kb"
+      "maxSize": "54Kb"
     },
     {
       "path": "./dist/contentful.min.js",
-      "maxSize": "26Kb"
+      "maxSize": "24Kb"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "axios": "contentful/axios#fix/https-via-http-proxy",
     "clone": "^2.1.1",
-    "contentful-sdk-core": "^3.13.2",
+    "contentful-sdk-core": "^3.13.3",
     "deep-get-set": "^1.1.0",
     "json-stringify-safe": "^5.0.1",
     "mem": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:cover": "BABEL_ENV=test babel-node ./node_modules/istanbul/lib/cli.js cover ./test/runner | tap-spec",
     "test:unit": "BABEL_ENV=test babel-node ./test/runner | tap-spec",
     "test:debug": "BABEL_ENV=test babel-node debug ./test/runner",
-    "test:integration": "BABEL_ENV=test babel-node ./test/integration/tests.js",
+    "test:integration": "BABEL_ENV=test babel-node ./test/integration/tests.js | tap-spec",
     "test:integration-debug": "BABEL_ENV=test babel-node debug ./test/integration/tests.js",
     "test:browser-local": "BABEL_ENV=test karma start karma.conf.local.js",
     "test:browser-remote": "BABEL_ENV=test karma start karma.conf.saucelabs.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful",
   "description": "Client for Contentful's Content Delivery API",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
   "main": "./dist/contentful.node.js",
   "module": "./dist/es6-modules/contentful.js",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,11 @@
   ],
   "dependencies": {
     "axios": "contentful/axios#fix/https-via-http-proxy",
+    "clone": "^2.1.1",
     "contentful-sdk-core": "^3.13.2",
-    "es6-promise": "^4.0.5",
+    "deep-get-set": "^1.1.0",
     "json-stringify-safe": "^5.0.1",
-    "lodash": "^4.17.4"
+    "mem": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
@@ -72,7 +73,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-rewire": "^1.0.0",
-    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-env": "^1.1.8",
     "babel-preset-es2015": "^6.6.0",
@@ -102,7 +103,6 @@
     "karma-sauce-launcher": "^1.1.0",
     "karma-tap": "^3.1.1",
     "karma-webpack": "^2.0.2",
-    "lodash-webpack-plugin": "^0.11.2",
     "mkdirp": "^0.5.1",
     "nodemon": "^1.11.0",
     "require-all": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful",
   "description": "Client for Contentful's Content Delivery API",
-  "version": "4.1.1",
+  "version": "4.5.0",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
   "main": "./dist/contentful.node.js",
   "module": "./dist/es6-modules/contentful.js",

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -1,8 +1,7 @@
 import test from 'blue-tape'
-import filter from 'lodash/filter'
-import map from 'lodash/map'
+
 import * as contentful from '../../lib/contentful'
-import Promise from 'es6-promise'
+
 const params = {
   accessToken: 'b4c0n73n7fu1',
   space: 'cfexampleapi'
@@ -159,7 +158,7 @@ test('Gets entries with content type query param', (t) => {
   return client.getEntries({content_type: 'cat'})
     .then((response) => {
       t.equal(response.total, 3)
-      t.looseEqual(map(response.items, 'sys.contentType.sys.id'), ['cat', 'cat', 'cat'])
+      t.looseEqual(response.items.map((item) => item.sys.contentType.sys.id), ['cat', 'cat', 'cat'])
     })
 })
 
@@ -177,7 +176,7 @@ test('Gets entries with inequality query', (t) => {
   return client.getEntries({'sys.id[ne]': 'nyancat'})
     .then((response) => {
       t.ok(response.total > 0)
-      t.equal(filter(response.items, ['sys.id', 'nyancat']).length, 0)
+      t.equal(response.items.filter((item) => item.sys.id === 'nyancat').length, 0)
     })
 })
 
@@ -189,7 +188,7 @@ test('Gets entries with array equality query', (t) => {
   })
     .then((response) => {
       t.equal(response.total, 1)
-      t.equal(filter(response.items[0].fields.likes, (i) => i === 'lasagna').length, 1)
+      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 1)
     })
 })
 
@@ -201,7 +200,7 @@ test('Gets entries with array inequality query', (t) => {
   })
     .then((response) => {
       t.ok(response.total > 0)
-      t.equal(filter(response.items[0].fields.likes, (i) => i === 'lasagna').length, 0)
+      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
     })
 })
 
@@ -210,8 +209,8 @@ test('Gets entries with inclusion query', (t) => {
   return client.getEntries({'sys.id[in]': 'finn,jake'})
     .then((response) => {
       t.equal(response.total, 2)
-      t.equal(filter(response.items, ['sys.id', 'finn']).length, 1)
-      t.equal(filter(response.items, ['sys.id', 'jake']).length, 1)
+      t.equal(response.items.filter((item) => item.sys.id === 'finn').length, 1)
+      t.equal(response.items.filter((item) => item.sys.id === 'jake').length, 1)
     })
 })
 
@@ -223,8 +222,8 @@ test('Gets entries with exclusion query', (t) => {
   })
     .then((response) => {
       t.ok(response.total > 0)
-      t.equal(filter(response.items[0].fields.likes, (i) => i === 'lasagna').length, 0)
-      t.equal(filter(response.items[0].fields.likes, (i) => i === 'rainbows').length, 0)
+      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
+      t.equal(response.items[0].fields.likes.filter((i) => i === 'rainbows').length, 0)
     })
 })
 
@@ -235,7 +234,7 @@ test('Gets entries with exists query', (t) => {
     'fields.likes[exists]': 'true'
   })
     .then((response) => {
-      t.equal(map(response.items, 'fields.likes').length, response.total)
+      t.equal(response.items.map((item) => item.fields.likes).length, response.total)
     })
 })
 
@@ -246,7 +245,7 @@ test('Gets entries with inverse exists query', (t) => {
     'fields.likes[exists]': 'false'
   })
     .then((response) => {
-      t.equal(map(response.items, 'fields.likes').length, 0)
+      t.equal(response.items.map((item) => item.fields.likes).length, 0)
     })
 })
 

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -1,6 +1,6 @@
 import test from 'blue-tape'
 import sinon from 'sinon'
-import Promise from 'es6-promise'
+
 import createContentfulApi, { __RewireAPI__ as createContentfulApiRewireApi } from '../../lib/create-contentful-api'
 import { contentTypeMock, assetMock, entryMock } from './mocks'
 

--- a/test/unit/entities/content-type-test.js
+++ b/test/unit/entities/content-type-test.js
@@ -1,12 +1,11 @@
 import test from 'tape'
-import assign from 'lodash/assign'
-import cloneDeep from 'lodash/cloneDeep'
-import {sysMock} from '../mocks'
+import cloneDeep from 'clone'
 
+import {sysMock} from '../mocks'
 import {wrapContentType, wrapContentTypeCollection} from '../../../lib/entities/content-type'
 
 const contentType = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType'
   }),
   name: 'ct',

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -1,7 +1,7 @@
 import test from 'tape'
+import cloneDeep from 'clone'
 
 import {entryMock, assetMock} from '../mocks'
-import cloneDeep from 'lodash/cloneDeep'
 import {wrapEntry, wrapEntryCollection} from '../../../lib/entities/entry'
 
 test('Entry is wrapped', (t) => {

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -1,5 +1,4 @@
-import assign from 'lodash/assign'
-import cloneDeep from 'lodash/cloneDeep'
+import cloneDeep from 'clone'
 
 const linkMock = {
   id: 'linkid',
@@ -17,7 +16,7 @@ const sysMock = {
 }
 
 const contentTypeMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'ContentType'
   }),
   name: 'name',
@@ -35,9 +34,9 @@ const contentTypeMock = {
 }
 
 const entryMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'Entry',
-    contentType: assign(cloneDeep(linkMock), {linkType: 'ContentType'}),
+    contentType: Object.assign(cloneDeep(linkMock), {linkType: 'ContentType'}),
     locale: 'locale'
   }),
   fields: {
@@ -46,7 +45,7 @@ const entryMock = {
 }
 
 const assetMock = {
-  sys: assign(cloneDeep(sysMock), {
+  sys: Object.assign(cloneDeep(sysMock), {
     type: 'Asset',
     locale: 'locale'
   }),

--- a/test/unit/paged-sync-test.js
+++ b/test/unit/paged-sync-test.js
@@ -1,7 +1,7 @@
 import test from 'blue-tape'
+import cloneDeep from 'clone'
 import sinon from 'sinon'
-import Promise from 'es6-promise'
-import cloneDeep from 'lodash/cloneDeep'
+
 import {entryMock, assetMock} from './mocks'
 import pagedSync from '../../lib/paged-sync'
 

--- a/version.js
+++ b/version.js
@@ -1,1 +1,1 @@
-module.exports = '4.1.0'
+module.exports = '4.5.1'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,22 +2,10 @@ const path = require('path')
 
 const webpack = require('webpack')
 const BabiliPlugin = require('babili-webpack-plugin')
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
 
 const PROD = process.env.NODE_ENV === 'production'
 
 const plugins = [
-  new LodashModuleReplacementPlugin({
-    'shorthands': true,
-    'cloning': true,
-    'currying': true,
-    'caching': true,
-    'collections': true,
-    'paths': true,
-    'guards': true,
-    'unicode': true,
-    'placeholders': true
-  }),
   new webpack.optimize.OccurrenceOrderPlugin(),
   new webpack.IgnorePlugin(/vertx/),
   new webpack.DefinePlugin({
@@ -37,6 +25,12 @@ if (PROD) {
   )
 }
 
+const jsLoaderIncludes = [
+  path.resolve(__dirname, 'lib'),
+  path.resolve(__dirname, 'node_modules', 'mem'),
+  path.resolve(__dirname, 'node_modules', 'mimic-fn')
+]
+
 module.exports = [
   {
     // Browser
@@ -52,7 +46,7 @@ module.exports = [
       loaders: [
         {
           test: /\.js?$/,
-          exclude: /(node_modules|bower_components|dist)/,
+          include: jsLoaderIncludes,
           loader: 'babel-loader',
           options: {
             env: 'browser'
@@ -78,7 +72,7 @@ module.exports = [
       loaders: [
         {
           test: /\.js?$/,
-          exclude: /(node_modules|bower_components|dist)/,
+          include: jsLoaderIncludes,
           loader: 'babel-loader',
           options: {
             env: 'node'


### PR DESCRIPTION
Based on https://github.com/contentful/contentful-sdk-core/pull/35

* Introduces object rest spread for a readable syntax of complex object assignments
* [mem](https://github.com/sindresorhus/mem) replaces `lodash.memoize`
* [clone](https://github.com/pvorb/clone) replaces `lodash.cloneDeep`
* [deep-get-set](https://github.com/acstll/deep-get-set) replaces `lodash.get`
* ES5 & ES6 replace the rest