### PR TITLE
fix(sync): remove type and content_type filter at second paged sync

### DIFF
--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -53,12 +53,6 @@ export default function pagedSync (http, query, resolveLinks) {
     throw new Error('When using the `content_type` filter your `type` parameter cannot be different from `Entry`.')
   }
 
-  if (query.nextSyncToken) {
-    query.sync_token = query.nextSyncToken
-    delete query.initial
-    delete query.nextSyncToken
-  }
-
   return getSyncPage(http, [], query)
   .then((response) => {
     // clones response.items used in includes because we don't want these to be mutated
@@ -70,7 +64,7 @@ export default function pagedSync (http, query, resolveLinks) {
     mappedResponseItems.nextSyncToken = response.nextSyncToken
     return freezeSys(mixinStringifySafe(toPlainObject(mappedResponseItems)))
   }, (error) => {
-    throw error.data
+    throw error
   })
 }
 
@@ -116,12 +110,22 @@ function mapIncludeItems (items) {
  * @return {Promise<{items: Array, nextSyncToken: string}>}
  */
 function getSyncPage (http, items, query) {
+  if (query.nextSyncToken) {
+    query.sync_token = query.nextSyncToken
+    delete query.nextSyncToken
+  }
+
+  if (query.sync_token) {
+    delete query.initial
+    delete query.type
+    delete query.content_type
+  }
+
   return http.get('sync', createRequestConfig({query: query}))
   .then((response) => {
     const data = response.data
     items = items.concat(data.items)
     if (data.nextPageUrl) {
-      delete query.initial
       query.sync_token = getToken(data.nextPageUrl)
       return getSyncPage(http, items, query)
     } else if (data.nextSyncUrl) {

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -356,7 +356,7 @@ test('CDA call sync fails', (t) => {
   return api.sync({initial: true})
     .then(() => {
     }, (r) => {
-      t.equal(r, 'error')
+      t.equal(r.data, 'error')
       teardown()
     })
 })

--- a/test/unit/paged-sync-test.js
+++ b/test/unit/paged-sync-test.js
@@ -112,9 +112,9 @@ test('Initial sync with one page and filter', (t) => {
 })
 
 test('Initial sync with multiple pages', (t) => {
-  t.plan(9)
+  t.plan(12)
   const http = {get: sinon.stub()}
-  http.get.withArgs('sync', {params: {initial: true}}).returns(Promise.resolve({
+  http.get.withArgs('sync', {params: {initial: true, type: 'Entries'}}).returns(Promise.resolve({
     data: {
       items: [
         createEntry('1'),
@@ -147,10 +147,13 @@ test('Initial sync with multiple pages', (t) => {
     }
   }))
 
-  return pagedSync(http, {initial: true}, true)
+  return pagedSync(http, {initial: true, type: 'Entries'}, true)
   .then((response) => {
     const objResponse = response.toPlainObject()
     t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+    t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
+    t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
+    t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
     t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
     t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
     t.equal(objResponse.entries.length, 3, 'entries length')


### PR DESCRIPTION
Also fixes error to be thrown properly since `error.data` was undefined.