### PR TITLE
Remove git dependency for package axios.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "tonic-example.js"
   ],
   "dependencies": {
-    "axios": "contentful/axios#fix/https-via-http-proxy",
+    "axios": "https://github.com/contentful/axios/archive/fix/https-via-http-proxy.tar.gz",
     "contentful-sdk-core": "^5.0.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4"


### PR DESCRIPTION
@axe312ger introduced this https://github.com/contentful/contentful.js/commit/6326f90dea771e7c1e68dfa44e2311a35d5ec4ad

This change broke a bunch of my docker builds that depend on contentful.

This changes it back to simple HTTP interface for fetches packages.

Our docker builder's don't have git and I would prefer not having to add git just for a temporary fix.

The syntax is slightly more verbose but allows dependencies to still be managed by vanilla npm instead of requiring git to be installed and configured. 