### PR TITLE
fix(axios): Use scoped import in code/tests

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -5,7 +5,7 @@
  * @see ContentfulClientAPI
  */
 
-import axios from 'axios'
+import axios from '@contentful/axios'
 import {createHttpClient, getUserAgentHeader} from 'contentful-sdk-core'
 import createContentfulApi from './create-contentful-api'
 import createLinkResolver from './create-link-resolver'

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   "bundlesize": [
     {
       "path": "./dist/contentful.browser.js",
-      "maxSize": "38Kb"
+      "maxSize": "39Kb"
     },
     {
       "path": "./dist/contentful.browser.min.js",
@@ -133,7 +133,7 @@
     },
     {
       "path": "./dist/contentful.legacy.min.js",
-      "maxSize": "22Kb"
+      "maxSize": "23Kb"
     },
     {
       "path": "./dist/contentful.node.js",

--- a/test/unit/contentful-test.js
+++ b/test/unit/contentful-test.js
@@ -17,7 +17,7 @@ test('Throws if no space is defined', (t) => {
   t.end()
 })
 test('Generate the correct User Agent Header', (t) => {
-  createClientRewireApi.__Rewire__('axios', sinon.stub)
+  createClientRewireApi.__Rewire__('@contentful/axios', sinon.stub)
   const createHttpClientStub = sinon.stub()
   const rateLimitStub = sinon.stub()
   createClientRewireApi.__Rewire__('createHttpClient', createHttpClientStub)
@@ -34,11 +34,11 @@ test('Generate the correct User Agent Header', (t) => {
 
   createClientRewireApi.__ResetDependency__('rateLimit')
   createClientRewireApi.__ResetDependency__('createHttpClient')
-  createClientRewireApi.__ResetDependency__('axios')
+  createClientRewireApi.__ResetDependency__('@contentful/axios')
   t.end()
 })
 test('Passes along HTTP client parameters', (t) => {
-  createClientRewireApi.__Rewire__('axios', sinon.stub)
+  createClientRewireApi.__Rewire__('@contentful/axios', sinon.stub)
   createClientRewireApi.__Rewire__('version', 'version')
   const createHttpClientStub = sinon.stub()
   const rateLimitStub = sinon.stub()
@@ -49,7 +49,7 @@ test('Passes along HTTP client parameters', (t) => {
   t.ok(createHttpClientStub.args[0][1].headers['X-Contentful-User-Agent'])
   createClientRewireApi.__ResetDependency__('rateLimit')
   createClientRewireApi.__ResetDependency__('createHttpClient')
-  createClientRewireApi.__ResetDependency__('axios')
+  createClientRewireApi.__ResetDependency__('@contentful/axios')
   t.end()
 })
 


### PR DESCRIPTION
The scoped package was added in https://github.com/contentful/contentful.js/pull/202.  However, the code was not updated to use the scoped package module.

This was accidentally working (but using the normal axios package) because a devDependecy installs axios to node_modules:

```
$ npm ls axios
contentful@0.0.0-determined-by-semantic-release /home/spainhower/repos/contentful.js
└─┬ bundlesize@0.12.2
  ├── axios@0.16.2 
  └─┬ github-build@1.2.0
    └── axios@0.15.3 
```

Closes #201