### PR TITLE
Replace unpkg with jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,18 +66,16 @@ yarn add contentful
 
 For browsers, we recommend to download the SDK via npm or yarn to ensure 100% availability.
 
-If you'd like to use a standalone built file you can use the following script tag or download it from [unpkg](https://unpkg.com), under the `dist` directory:
+If you'd like to use a standalone built file you can use the following script tag or download it from [jsDelivr](https://www.jsdelivr.com/package/npm/contentful), under the `dist` directory:
 
 ``` html
-<!-- Avoid using the following url for production. You can not rely on its availability. -->
-<script src="https://unpkg.com/contentful@latest/dist/contentful.browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/contentful@latest/dist/contentful.browser.min.js"></script>
 ```
-**It's not recommended to use the above URL for production.**
 
 Using `contentful@latest` will always get you the latest version, but you can also specify a specific version number:
 
 ``` html
-<script src="https://unpkg.com/contentful@5.0.1/dist/contentful.browser.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/contentful@5.0.1/dist/contentful.browser.min.js"></script>
 ```
 
 The Contentful Delivery SDK will be accessible via the `contentful` global variable.


### PR DESCRIPTION
I replaced the unpkg link with a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/contentful) in your readme. jsDelivr works similarly to unpkg but was built specifically for production usage and offers a large network and better reliability.