### PR TITLE
feat(sync): sync can now be used without pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ function customPaginatedSync (query) {
     }
 
     // Otherwise, just continue to next page of the current sync run
-    return customSync({nextPageToken: response.nextPageToken})
+    return customPaginatedSync({nextPageToken: response.nextPageToken})
   })
 }
 

--- a/README.md
+++ b/README.md
@@ -206,13 +206,45 @@ const client = contentful.createClient({
   accessToken:'<you-access-token>',
   space: '<your-space-id>',
 })
-// first time you are syncing make sure to spcify `initial: true`
+// first time you are syncing make sure to specify `initial: true`
 client.sync({initial: true}).then((response) => {
   // You should save the `nextSyncToken` to use in the following sync
   console.log(response.nextSyncToken)
 })
 ```
 The SDK will go through all the pages for you and gives you back a response object with the full data so you don't need to handle pagination.
+
+#### Sync without pagination
+
+You may use syncing without pagination if you want to handle it on your own. To do this, you have to pass `pagination: false` as option when calling sync. You manually have to take care to pass `nextPageToken` or `nextSyncToken` to your subsequent calls. The logic follows our [sync API docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/synchronization/pagination-and-subsequent-syncs) while you pass tokens instead of full urls.
+
+```js
+const contentful = require('contentful')
+const client = contentful.createClient({
+  accessToken:'<you-access-token>',
+  space: '<your-space-id>',
+})
+
+function customPaginatedSync (query) {
+  // Call sync, make sure you set pagination to false for every call
+  return client.sync(query, {pagination: false}).then((response) => {
+    // Do something with the respond. For example save result to disk.
+    console.log('Result of current sync page:', response.items)
+
+    // Sync finished when `nextSyncToken` is available
+    if (response.nextSyncToken) {
+      console.log('Syncing done. Start a new sync via ' + response.nextSyncToken)
+      return
+    }
+
+    // Otherwise, just continue to next page of the current sync run
+    return customSync({nextPageToken: response.nextPageToken})
+  })
+}
+
+customPaginatedSync({initial: true})
+  .then(() => console.log('Sync done'))
+```
 
 ### Querying & Search parameters
 

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -244,6 +244,8 @@ export default function createContentfulApi ({http, getGlobalOptions}) {
    * @param  {string=} query.type - Filter by this type (all (default), Entry, Asset, Deletion, DeletedAsset or DeletedEntry)
    * @param  {string=} query.content_type - Filter by this content type id
    * @param  {boolean=} query.resolveLinks - When true, links to other Entries or Assets are resolved. Default: true.
+   * @param  {Object} options
+   * @param  {boolean=} [options.paginate = true] - Set to false to disable pagination
    * @return {Promise<Sync.SyncCollection>} Promise for the collection resulting of a sync operation
    * @example
    * const contentful = require('contentful')
@@ -263,9 +265,9 @@ export default function createContentfulApi ({http, getGlobalOptions}) {
    * }))
    * .catch(console.error)
    */
-  function sync (query = {}) {
+  function sync (query = {}, options = { paginate: true }) {
     const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
-    return pagedSync(http, query, { resolveLinks, removeUnresolved })
+    return pagedSync(http, query, { resolveLinks, removeUnresolved, ...options })
   }
 
   /**

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -37,12 +37,15 @@ import mixinStringifySafe from './mixins/stringify-safe'
  * @private
  * @param {Object} http - HTTP client
  * @param {Object} query - Query object
- * @param {boolean} resolveLinks - If links should be resolved
+ * @param {Object} options - If links should be resolved
+ * @param {boolean} [options.resolveLinks = true] - If links should be resolved
+ * @param {boolean} [options.removeUnresolved = false] - If unresolvable links should get removed
+ * @param {boolean} [options.paginate = true] - If links should be resolved
  * @return {Promise<SyncCollection>}
  */
-export default function pagedSync (http, query, { resolveLinks, removeUnresolved }) {
-  if (!query || (!query.initial && !query.nextSyncToken)) {
-    throw new Error('Please provide one of `initial` or `nextSyncToken` parameters for syncing')
+export default function pagedSync (http, query, { resolveLinks = true, removeUnresolved = false, paginate = true } = { resolveLinks: true, removeUnresolved: false, paginate: true }) {
+  if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
+    throw new Error('Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing')
   }
 
   if (query && query.content_type && !query.type) {
@@ -51,7 +54,11 @@ export default function pagedSync (http, query, { resolveLinks, removeUnresolved
     throw new Error('When using the `content_type` filter your `type` parameter cannot be different from `Entry`.')
   }
 
-  return getSyncPage(http, [], query)
+  const options = {
+    paginate
+  }
+
+  return getSyncPage(http, [], query, options)
     .then((response) => {
       // clones response.items used in includes because we don't want these to be mutated
       if (resolveLinks) {
@@ -59,7 +66,15 @@ export default function pagedSync (http, query, { resolveLinks, removeUnresolved
       }
       // maps response items again after getters are attached
       const mappedResponseItems = mapResponseItems(response.items)
-      mappedResponseItems.nextSyncToken = response.nextSyncToken
+
+      if (response.nextSyncToken) {
+        mappedResponseItems.nextSyncToken = response.nextSyncToken
+      }
+
+      if (response.nextPageToken) {
+        mappedResponseItems.nextPageToken = response.nextPageToken
+      }
+
       return freezeSys(mixinStringifySafe(toPlainObject(mappedResponseItems)))
     }, (error) => {
       throw error
@@ -93,10 +108,15 @@ function mapResponseItems (items) {
  * @param {Object} query
  * @return {Promise<{items: Array, nextSyncToken: string}>}
  */
-function getSyncPage (http, items, query) {
+function getSyncPage (http, items, query, { paginate }) {
   if (query.nextSyncToken) {
     query.sync_token = query.nextSyncToken
     delete query.nextSyncToken
+  }
+
+  if (query.nextPageToken) {
+    query.sync_token = query.nextPageToken
+    delete query.nextPageToken
   }
 
   if (query.sync_token) {
@@ -110,9 +130,15 @@ function getSyncPage (http, items, query) {
       const data = response.data
       items = items.concat(data.items)
       if (data.nextPageUrl) {
-        delete query.initial
-        query.sync_token = getToken(data.nextPageUrl)
-        return getSyncPage(http, items, query)
+        if (paginate) {
+          delete query.initial
+          query.sync_token = getToken(data.nextPageUrl)
+          return getSyncPage(http, items, query, { paginate })
+        }
+        return {
+          items: items,
+          nextPageToken: getToken(data.nextPageUrl)
+        }
       } else if (data.nextSyncUrl) {
         return {
           items: items,

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -37,13 +37,13 @@ import mixinStringifySafe from './mixins/stringify-safe'
  * @private
  * @param {Object} http - HTTP client
  * @param {Object} query - Query object
- * @param {Object} options - If links should be resolved
+ * @param {Object} options - Sync options object
  * @param {boolean} [options.resolveLinks = true] - If links should be resolved
  * @param {boolean} [options.removeUnresolved = false] - If unresolvable links should get removed
- * @param {boolean} [options.paginate = true] - If links should be resolved
+ * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<SyncCollection>}
  */
-export default function pagedSync (http, query, { resolveLinks = true, removeUnresolved = false, paginate = true } = { resolveLinks: true, removeUnresolved: false, paginate: true }) {
+export default function pagedSync (http, query, options = {}) {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error('Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing')
   }
@@ -54,11 +54,17 @@ export default function pagedSync (http, query, { resolveLinks = true, removeUnr
     throw new Error('When using the `content_type` filter your `type` parameter cannot be different from `Entry`.')
   }
 
-  const options = {
+  const defaultOptions = { resolveLinks: true, removeUnresolved: false, paginate: true }
+  const { resolveLinks, removeUnresolved, paginate } = {
+    ...defaultOptions,
+    ...options
+  }
+
+  const syncOptions = {
     paginate
   }
 
-  return getSyncPage(http, [], query, options)
+  return getSyncPage(http, [], query, syncOptions)
     .then((response) => {
       // clones response.items used in includes because we don't want these to be mutated
       if (resolveLinks) {
@@ -106,6 +112,8 @@ function mapResponseItems (items) {
  * @param {Object} http
  * @param {Array<Entities.Entry|Entities.Array|Sync.DeletedEntry|Sync.DeletedAsset>} items
  * @param {Object} query
+ * @param {Object} options - Sync page options object
+ * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<{items: Array, nextSyncToken: string}>}
  */
 function getSyncPage (http, items, query, { paginate }) {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "bundlesize": [
     {
       "path": "./dist/contentful.browser.js",
-      "maxSize": "38Kb"
+      "maxSize": "50Kb"
     },
     {
       "path": "./dist/contentful.browser.min.js",
@@ -131,7 +131,7 @@
     },
     {
       "path": "./dist/contentful.legacy.js",
-      "maxSize": "55Kb"
+      "maxSize": "60Kb"
     },
     {
       "path": "./dist/contentful.legacy.min.js",
@@ -139,7 +139,7 @@
     },
     {
       "path": "./dist/contentful.node.js",
-      "maxSize": "47Kb"
+      "maxSize": "60Kb"
     },
     {
       "path": "./dist/contentful.node.min.js",


### PR DESCRIPTION
Huge spaces might be problematic with the current sync implementation since it stores all results in the memory till it is done syncing. This allows the SDK user to disable this automatic pagination.

Fixes #220 
