### PR TITLE
fix(link-resolution): only resolve links in fields

### DIFF
--- a/lib/entities/entry.js
+++ b/lib/entities/entry.js
@@ -100,7 +100,7 @@ export function wrapEntry (data) {
 export function wrapEntryCollection (data, {resolveLinks, removeUnresolved}) {
   const wrappedData = mixinStringifySafe(toPlainObject(cloneDeep(data)))
   if (resolveLinks) {
-    wrappedData.items = resolveResponse(wrappedData, {removeUnresolved})
+    wrappedData.items = resolveResponse(wrappedData, {removeUnresolved, itemEntryPoints: ['fields']})
   }
   return freezeSys(wrappedData)
 }

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -68,7 +68,7 @@ export default function pagedSync (http, query, options = {}) {
     .then((response) => {
       // clones response.items used in includes because we don't want these to be mutated
       if (resolveLinks) {
-        response.items = resolveResponse(response, {resolveLinks, removeUnresolved})
+        response.items = resolveResponse(response, {removeUnresolved, itemEntryPoints: ['fields']})
       }
       // maps response items again after getters are attached
       const mappedResponseItems = mapResponseItems(response.items)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@contentful/axios": "^0.18.0",
-    "contentful-resolve-response": "^1.0.2",
+    "contentful-resolve-response": "^1.1.3",
     "contentful-sdk-core": "^5.0.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,7 +55,7 @@ const baseBundleConfig = {
 
 const defaultBabelLoader = {
   test: /\.js?$/,
-  exclude: /node_modules(?!\/contentful-resolve-response)/,
+  exclude: /node_modules/,
   loader: 'babel-loader',
   options: {}
 }


### PR DESCRIPTION
Current version of the SDK resolves links within `sys` if `removeUnresolved: true`

This fixes this