### PR TITLE
fix(user-agent): don't detect node when babel-polyfill is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@contentful/axios": "^0.18.0",
     "contentful-resolve-response": "^1.1.4",
-    "contentful-sdk-core": "^5.0.3",
+    "contentful-sdk-core": "^5.0.4",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
fixes #231 
fixes #232 