### PR TITLE
fix(version): make sure latest v6 is on latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentful",
   "description": "Client for Contentful's Content Delivery API",
-  "version": "6.0.0-beta0",
+  "version": "0.0.0-determined-by-semantic-release",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
   "main": "./dist/contentful.node.js",
   "module": "./dist/es-modules/contentful.js",


### PR DESCRIPTION
Had to rerelease v4 of the sdk. This ensures that v6 is installed on fresh projects. Should have added a tag to the release. Sorry.