### PR TITLE
docs: add environment setup to `createClient` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ contentful.createClient({
       </td>
     </tr>
     <tr>
+      <td><code>environment</code></td>
+      <td><code>'master'</code></td>
+      <td>
+        Set the environment that the API key has access to.
+      </td>
+    </tr>
+    <tr>
       <td><code>host</code></td>
       <td><code>'cdn.contentful.com'</code></td>
       <td>


### PR DESCRIPTION
## Summary

This pull request is to add documentation on how to configure which environment the user wants to communicate with. By default, `master` is set the environment.

## Description

Added a row in the `Configuration` table to show that `environment` can be set, and that the default environment is `master`.

## Motivation and Context

I have API keys that talk to specific environments, but I didn't know how to set which environment within my client. I had to go into the source code to see if this was possible. Since it is, I just wanted to add documentation to let others know that this is easily possible.