### PR TITLE
Fix: Remove browser field as contentful-sdk-core has been fixed now

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@contentful/axios": "^0.18.0",
     "contentful-resolve-response": "^1.1.4",
-    "contentful-sdk-core": "^6.0.0-beta0",
+    "contentful-sdk-core": "^6.0.1",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.5"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
   "main": "./dist/contentful.node.js",
   "module": "./dist/es-modules/contentful.js",
-  "browser": "./dist/contentful.browser.js",
   "jsnext:main": "./dist/es-modules/contentful.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
We can safely remove the browser field now thus fixing the webpack tree shaking. See relevant issue:
https://github.com/contentful/contentful.js/issues/260

