### PR TITLE
Add getLocales and Locales interface to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export interface ContentfulClientApi {
     getEntries<T>(query?: any): Promise<EntryCollection<T>>;
     getEntry<T>(id: string, query?: any): Promise<Entry<T>>;
     getSpace(): Promise<Space>;
-    getLocales(): Promise<Locales>;
+    getLocales(): Promise<LocaleCollection>;
     sync(query: any): Promise<SyncCollection>;
 }
 
@@ -99,15 +99,6 @@ export interface Space {
     toPlainObject(): Space;
 }
 
-export interface Locales {
-    sys: Sys;
-    total: number;
-    skip: number;
-    limit: number;
-    items: ContentfulCollection<Locale>;
-    toPlainObject(): Space;
-}
-
 export interface Locale {
   code: string
   name: string
@@ -119,6 +110,8 @@ export interface Locale {
     version: number
   }
 }
+
+export type LocaleCollection = ContentfulCollection<Locale>;
 
 export interface SyncCollection {
     entries: Array<Entry<any>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,8 +104,20 @@ export interface Locales {
     total: number;
     skip: number;
     limit: number;
-    items: Array<string>;
+    items: ContentfulCollection<Locale>;
     toPlainObject(): Space;
+}
+
+export interface Locale {
+  code: string
+  name: string
+  default: boolean
+  fallbackCode: string | null
+  sys: {
+    id: string
+    type: 'Locale'
+    version: number
+  }
 }
 
 export interface SyncCollection {

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ export interface ContentfulClientApi {
     getEntries<T>(query?: any): Promise<EntryCollection<T>>;
     getEntry<T>(id: string, query?: any): Promise<Entry<T>>;
     getSpace(): Promise<Space>;
+    getLocales(): Promise<Locales>;
     sync(query: any): Promise<SyncCollection>;
 }
 
@@ -95,6 +96,15 @@ export interface Space {
     sys: Sys;
     name: string;
     locales: Array<string>;
+    toPlainObject(): Space;
+}
+
+export interface Locales {
+    sys: Sys;
+    total: number;
+    skip: number;
+    limit: number;
+    items: Array<string>;
     toPlainObject(): Space;
 }
 


### PR DESCRIPTION
## Summary

Adding the missing method `getLocales()` to the Contentful client interface

## Description

Added:
- `getLocales()` method (documented and implemented https://contentful.github.io/contentful.js/contentful/7.0.0/ContentfulClientAPI.html#.getLocales) but not declared in the `index.d.ts`
- `Locales` interface

## Motivation and Context
If the Contentful library will be used with a Typescript compiler it will throw errors because the declaration of the type is missing from the `index.d.ts` file.
