### PR TITLE
Make arguments Optional for Stringify safe method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -78,7 +78,7 @@ export interface Entry<T> {
 export interface EntryCollection<T> extends ContentfulCollection<Entry<T>> {
     errors?: Array<any>;
     includes?: any;
-    stringifySafe(replacer: any, space: any): string;
+    stringifySafe(replacer?: any, space?: any): string;
 }
 
 export interface ContentType {
@@ -120,7 +120,7 @@ export interface SyncCollection {
     deletedAssets: Array<Asset>;
     nextSyncToken: string;
     toPlainObject(): SyncCollection;
-    stringifySafe(replacer: any, space: any): string;
+    stringifySafe(replacer?: any, space?: any): string;
 }
 
 export interface Sys {


### PR DESCRIPTION
TS linter complains when you try to call stringifySafe without args as suggested here:

https://www.contentful.com/developers/docs/javascript/tutorials/using-the-sync-api-with-js/

<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
