### PR TITLE
Stringify error threw by not found method

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -66,7 +66,7 @@ export default function createContentfulApi ({http, getGlobalOptions}) {
   const {wrapAsset, wrapAssetCollection} = entities.asset
   const {wrapLocaleCollection} = entities.locale
   const notFoundError = (id) => {
-    return new Error({
+    return new Error(JSON.stringify({
       'sys': {
         'type': 'Error',
         'id': 'NotFound'
@@ -78,7 +78,7 @@ export default function createContentfulApi ({http, getGlobalOptions}) {
         'environment': getGlobalOptions().environment,
         'space': getGlobalOptions().space
       }
-    })
+    }))
   }
 
   function errorHandler (error) {


### PR DESCRIPTION
## Summary
Stringify error to have a better error handling


## Description

When a 404 is throw on the getEntry method the response doesn't contain the correct object structure, instead has a [object, Object], so this change only stringify that error throw

## Motivation and Context

The change is required by helping to handling better the throw errors instead of an generic error object

## Todos

-   [x] Implemented feature
