### PR TITLE
Add type definition for axios adapter in CreateClientParams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,7 @@ export interface CreateClientParams {
     httpsAgent?: any;
     proxy?: AxiosProxyConfig;
     headers?: any;
+    adapter?: any;
     application?: string;
     integration?: string;
     resolveLinks?: boolean;


### PR DESCRIPTION
## Summary

Add missing type definitions for recently added axios adapter.

-   [x] Implemented feature
-   [ ] Feature with pending implementation

