### PR TITLE
chore(types): Asset generic type for file details property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,14 +44,14 @@ export interface ContentfulClientApi {
     sync(query: any): Promise<SyncCollection>;
 }
 
-export interface Asset {
+export interface Asset<T = any> {
     sys: Sys;
     fields: {
         title: string;
         description: string;
         file: {
             url: string;
-            details: any;
+            details: T;
             fileName: string;
             contentType: string;
         };


### PR DESCRIPTION
## Summary

Improved typing for `Asset` `fields.file.details` property

## Description

Used type generics with defauld of `any` to represent the property

## Motivation and Context

It will provide more convinient type checking for Asset's details property



-   [x] Implemented feature
