### PR TITLE
fix(types): Correct the type for Field['items']

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -151,7 +151,7 @@ export interface Field {
     required: boolean;
     type: FieldType;
     validations: FieldValidation[];
-    items?: FieldItem[];
+    items?: FieldItem;
 }
 
 export type FieldType = 'Symbol' | 'Text' | 'Integer' | 'Number' | 'Date' | 'Boolean' | 'Location' | 'Link' | 'Array' | 'Object' | 'RichText';


### PR DESCRIPTION
The `items` attribute in a Content Type is not an array, it's an object, and it gives a summary of the types that are IN the array. This PR fixes the type. Example response straight from the API for proof:

```json
{
  "id": "logos",
  "name": "Logos",
  "type": "Array",
  "localized": false,
  "required": true,
  "validations": [{ "size": { "min": 5, "max": 15 } }],
  "disabled": false,
  "omitted": false,
  "items": {
    "type": "Link",
    "validations": [{ "linkContentType": ["logo"] }],
    "linkType": "Entry"
  }
}
```