### PR TITLE
fix: fix EntryFields.RichText types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -210,7 +210,7 @@ export namespace EntryFields {
     export type Object<T = any> = T;
     export interface RichText {
         data:{};
-        content: RichTextContent;
+        content: RichTextContent[];
         nodeType: 'document';
     }
 }


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary
<!-- Give a short summary what your PR is introducing/fixing. -->

🤔Looks like the type is wrong.

[![Image from Gyazo](https://i.gyazo.com/ccdb8f7d68f5f9b9ae25871bc420fe9b.png)](https://gyazo.com/ccdb8f7d68f5f9b9ae25871bc420fe9b)

Its `content` is really array but type is object.

## Description

<!-- Describe your changes in detail -->

I changed it into array.