### PR TITLE
Added missing type 'italic' on RichTextContent interface. Webstorm wa…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -237,7 +237,7 @@ type RichTextNodeType = 'text' | 'heading-1' | 'heading-2' | 'heading-3' | 'head
 interface RichTextContent {
     data: RichTextData;
     content?: RichTextContent[]
-    marks: {type: ('bold' | 'underline' | 'code')}[];
+    marks: {type: ('bold' | 'underline' | 'code' | 'italic')}[];
     value?: string;
     nodeType: RichTextNodeType;
 }


### PR DESCRIPTION
…s complaining about it...

<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
--> 
There's a missing type on RichTextContent interface ('italic'), and my IDE complaints on a switch-case I'm using. I preferred to fix it instead of contacting support. 

## Todos

(TODO by Contentful team): I added the missing 'italic' value on the enum type for the interface. But I think the proper way would be to reference to the type in https://github.com/contentful/rich-text/blob/master/packages/rich-text-types/src/marks.ts

Cheers 

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
