### PR TITLE
fix(stringify): Replace json-stringify-safe package

### DIFF
--- a/lib/mixins/stringify-safe.js
+++ b/lib/mixins/stringify-safe.js
@@ -23,17 +23,13 @@ const decycleObject = (object, replacer = (oldPath, value) => ({ $ref: oldPath }
   // the object or array. [NUMBER] or [STRING] indicates a child element or
   // property.
 
-  let objects = new WeakMap() // object to path mappings
+  const objects = new WeakMap() // object to path mappings
 
   return (function derez (value, path) {
     // The derez function recurses through the object, producing the deep copy.
 
-    let oldPath // The path of an earlier occurance of value
-    let nu // The new object or array
-
     // typeof null === "object", so go on if this value is really an object but not
     // one of the weird builtin objects.
-
     if (
       typeof value === 'object' &&
       value !== null &&
@@ -47,31 +43,26 @@ const decycleObject = (object, replacer = (oldPath, value) => ({ $ref: oldPath }
       // encountered it. If so, return a {"$ref":PATH} object. This uses an
       // ES6 WeakMap.
 
-      oldPath = objects.get(value)
+      const oldPath = objects.get(value) // The path of an earlier occurance of value
       if (oldPath !== undefined) {
         return replacer(oldPath, value)
       }
 
       // Otherwise, accumulate the unique value and its path.
-
       objects.set(value, path)
 
       // If it is an array, replicate the array.
-
       if (Array.isArray(value)) {
-        nu = []
-        value.forEach(function (element, i) {
-          nu[i] = derez(element, path + '[' + i + ']')
-        })
-      } else {
-        // If it is an object, replicate the object.
-
-        nu = {}
-        Object.keys(value).forEach(function (name) {
-          nu[name] = derez(value[name], path + '[' + JSON.stringify(name) + ']')
-        })
+        return value.map((element, i) => derez(element, `${path}[${i}]`))
       }
-      return nu
+      // If it is an object, replicate the object.
+      return Object.entries(value).reduce(
+        (red, [key, val]) =>
+          Object.assign({}, red, {
+            [key]: derez(val, `${path}[${JSON.stringify(key)}]`)
+          }),
+        {}
+      )
     }
     return value
   })(object, '$')

--- a/lib/mixins/stringify-safe.js
+++ b/lib/mixins/stringify-safe.js
@@ -1,32 +1,24 @@
+// This is a modified version of the algorithm by Douglas Crockford: https://github.com/douglascrockford/JSON-js/blob/master/cycle.js
+
 const decycleObject = (object, replacer = (oldPath, value) => ({ $ref: oldPath })) => {
   // Make a deep copy of an object or array, assuring that there is at most
   // one instance of each object or array in the resulting structure. The
   // duplicate references (which might be forming cycles) are replaced with
   // an object of the form
 
-  //      {"$ref": PATH}
-
-  // where the PATH is a JSONPath string that locates the first occurance.
-
-  // So,
-
-  //      var a = [];
-  //      a[0] = a;
-  //      return JSON.stringify(JSON.decycle(a));
-
-  // produces the string '[{"$ref":"$"}]'.
-
-  // If a replacer function is provided, then it will be called for each value.
-  // A replacer function receives a value and returns a replacement value.
-
-  // JSONPath is used to locate the unique object. $ indicates the top level of
-  // the object or array. [NUMBER] or [STRING] indicates a child element or
-  // property.
+  // {
+  //   sys: {
+  //     type: 'Link',
+  //     linkType: 'Entry',
+  //     id: value.sys.id,
+  //     circular: true
+  //   }
+  // }
 
   const objects = new WeakMap() // object to path mappings
 
-  return (function derez (value, path) {
-    // The derez function recurses through the object, producing the deep copy.
+  return (function createDeepCopy (value, path) {
+    // The createDeepCopy function recurses through the object, producing the deep copy.
 
     // typeof null === "object", so go on if this value is really an object but not
     // one of the weird builtin objects.
@@ -53,13 +45,13 @@ const decycleObject = (object, replacer = (oldPath, value) => ({ $ref: oldPath }
 
       // If it is an array, replicate the array.
       if (Array.isArray(value)) {
-        return value.map((element, i) => derez(element, `${path}[${i}]`))
+        return value.map((element, i) => createDeepCopy(element, `${path}[${i}]`))
       }
       // If it is an object, replicate the object.
       return Object.entries(value).reduce(
         (red, [key, val]) =>
           Object.assign({}, red, {
-            [key]: derez(val, `${path}[${JSON.stringify(key)}]`)
+            [key]: createDeepCopy(val, `${path}[${JSON.stringify(key)}]`)
           }),
         {}
       )

--- a/lib/mixins/stringify-safe.js
+++ b/lib/mixins/stringify-safe.js
@@ -1,4 +1,81 @@
-import jsonStringifySafe from 'json-stringify-safe'
+const decycleObject = (object, replacer = (oldPath, value) => ({ $ref: oldPath })) => {
+  // Make a deep copy of an object or array, assuring that there is at most
+  // one instance of each object or array in the resulting structure. The
+  // duplicate references (which might be forming cycles) are replaced with
+  // an object of the form
+
+  //      {"$ref": PATH}
+
+  // where the PATH is a JSONPath string that locates the first occurance.
+
+  // So,
+
+  //      var a = [];
+  //      a[0] = a;
+  //      return JSON.stringify(JSON.decycle(a));
+
+  // produces the string '[{"$ref":"$"}]'.
+
+  // If a replacer function is provided, then it will be called for each value.
+  // A replacer function receives a value and returns a replacement value.
+
+  // JSONPath is used to locate the unique object. $ indicates the top level of
+  // the object or array. [NUMBER] or [STRING] indicates a child element or
+  // property.
+
+  let objects = new WeakMap() // object to path mappings
+
+  return (function derez (value, path) {
+    // The derez function recurses through the object, producing the deep copy.
+
+    let oldPath // The path of an earlier occurance of value
+    let nu // The new object or array
+
+    // typeof null === "object", so go on if this value is really an object but not
+    // one of the weird builtin objects.
+
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !(value instanceof Boolean) &&
+      !(value instanceof Date) &&
+      !(value instanceof Number) &&
+      !(value instanceof RegExp) &&
+      !(value instanceof String)
+    ) {
+      // If the value is an object or array, look to see if we have already
+      // encountered it. If so, return a {"$ref":PATH} object. This uses an
+      // ES6 WeakMap.
+
+      oldPath = objects.get(value)
+      if (oldPath !== undefined) {
+        return replacer(oldPath, value)
+      }
+
+      // Otherwise, accumulate the unique value and its path.
+
+      objects.set(value, path)
+
+      // If it is an array, replicate the array.
+
+      if (Array.isArray(value)) {
+        nu = []
+        value.forEach(function (element, i) {
+          nu[i] = derez(element, path + '[' + i + ']')
+        })
+      } else {
+        // If it is an object, replicate the object.
+
+        nu = {}
+        Object.keys(value).forEach(function (name) {
+          nu[name] = derez(value[name], path + '[' + JSON.stringify(name) + ']')
+        })
+      }
+      return nu
+    }
+    return value
+  })(object, '$')
+}
 
 export default function mixinStringifySafe (data) {
   return Object.defineProperty(data, 'stringifySafe', {
@@ -6,7 +83,7 @@ export default function mixinStringifySafe (data) {
     configurable: false,
     writable: false,
     value: function (serializer = null, indent = '') {
-      return jsonStringifySafe(this, serializer, indent, (key, value) => {
+      const decycledObject = decycleObject(this, (oldPath, value) => {
         return {
           sys: {
             type: 'Link',
@@ -16,6 +93,7 @@ export default function mixinStringifySafe (data) {
           }
         }
       })
+      return JSON.stringify(decycledObject, serializer, indent)
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "axios": "^0.19.0",
     "contentful-resolve-response": "^1.1.4",
     "contentful-sdk-core": "^6.4.0",
-    "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.11"
   },
   "devDependencies": {

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -101,3 +101,78 @@ test('Entry collection links are resolved', (t) => {
   t.ok(wrappedCollection.stringifySafe(), 'stringifies safely')
   t.end()
 })
+
+test('Entry collection with circular references are decycled and stringified safely', (t) => {
+  const entry1 = cloneDeep(entryMock)
+  const entry2 = cloneDeep(entryMock)
+  const entry3 = cloneDeep(entryMock)
+
+  entry1.sys.id = 'entry1'
+  entry2.sys.id = 'entry2'
+  entry3.sys.id = 'entry3'
+
+  // set up circular structure:
+  // entry1 -> entry2, entry 3
+  // entry2 -> entry1
+  // entry3 -> entry1
+
+  entry1.fields.entry2link = {
+    sys: {
+      id: 'entry2',
+      type: 'Link',
+      linkType: 'Entry'
+    }
+  }
+  entry1.fields.entry3link = {
+    sys: {
+      id: 'entry3',
+      type: 'Link',
+      linkType: 'Entry'
+    }
+  }
+  entry2.fields.linked = {
+    sys: {
+      id: 'entry1',
+      type: 'Link',
+      linkType: 'Entry'
+    }
+  }
+  entry3.fields.linked = {
+    sys: {
+      id: 'entry1',
+      type: 'Link',
+      linkType: 'Entry'
+    }
+  }
+
+  // define entry collection
+  const entryCollection = {
+    total: 1,
+    skip: 0,
+    limit: 100,
+    items: [
+      entry1,
+      entry2
+    ],
+    includes: {
+      Entry: [ entry3 ]
+    }
+  }
+
+  // circular entries will be replaced in decycle procedure
+  const replacedEntry1 = { sys: { type: 'Link', linkType: 'Entry', id: 'entry1', circular: true } }
+  const replacedEntry2 = { sys: { type: 'Link', linkType: 'Entry', id: 'entry2', circular: true } }
+  const replacedEntry3 = { sys: { type: 'Link', linkType: 'Entry', id: 'entry3', circular: true } }
+
+  const wrappedCollection = wrapEntryCollection(entryCollection, {resolveLinks: true})
+  const safelystringed = wrappedCollection.stringifySafe()
+
+  t.ok(safelystringed, 'safely stringify completes')
+  const parsed = JSON.parse(safelystringed)
+
+  t.deepEquals(parsed.items[0].fields.entry2link.fields.linked, replacedEntry1, 'first circular link replaced correctly in nested fields')
+  t.deepEquals(parsed.items[0].fields.entry3link.fields.linked, replacedEntry1, 'second circular link replaced correctly in nested fields')
+  t.deepEquals(parsed.items[1], replacedEntry2, 'circular link replaced correctly in items list')
+  t.deepEquals(parsed.includes.Entry[0], replacedEntry3, 'circular link replaced correctly in includes')
+  t.end()
+})

--- a/test/unit/mixins/stringify-safe-test.js
+++ b/test/unit/mixins/stringify-safe-test.js
@@ -1,0 +1,46 @@
+import test from 'blue-tape'
+import mixinStringifySafe from '../../../lib/mixins/stringify-safe'
+
+test('Stringifies circular object', t => {
+  const obj = { sys: { id: 'foo' } }
+  obj.self = obj
+  mixinStringifySafe(obj)
+  t.looseEqual(
+    obj.stringifySafe(),
+    JSON.stringify({
+      sys: { id: 'foo' },
+      self: {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: 'foo',
+          circular: true
+        }
+      }
+    })
+  )
+  t.end()
+})
+
+test('Stringifies nested circular object', t => {
+  const obj = { sys: { id: 'foo' } }
+  obj.identity = { self: obj }
+  mixinStringifySafe(obj)
+  t.looseEqual(
+    obj.stringifySafe(),
+    JSON.stringify({
+      sys: { id: 'foo' },
+      identity: {
+        self: {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: 'foo',
+            circular: true
+          }
+        }
+      }
+    })
+  )
+  t.end()
+})

--- a/test/unit/mixins/stringify-safe-test.js
+++ b/test/unit/mixins/stringify-safe-test.js
@@ -1,4 +1,5 @@
 import test from 'blue-tape'
+import cloneDeep from 'lodash/cloneDeep'
 import mixinStringifySafe from '../../../lib/mixins/stringify-safe'
 
 test('Stringifies circular object', t => {
@@ -42,5 +43,33 @@ test('Stringifies nested circular object', t => {
       }
     })
   )
+  t.end()
+})
+
+test('must stringify circular objects in an array', t => {
+  const obj = {sys: {id: 'Alice'}}
+  obj.self = [obj, obj]
+
+  const expected = cloneDeep(obj)
+  const objReplacer = {sys: {type: 'Link', linkType: 'Entry', id: 'Alice', circular: true}}
+  expected.self = [objReplacer, objReplacer]
+  mixinStringifySafe(obj, null, 2)
+  t.deepEqual(obj.stringifySafe(), JSON.stringify(expected))
+  t.end()
+})
+
+test('must stringify repeated objects in objects', t => {
+  const alice = {sys: {id: 'Alice'}}
+  const obj = {}
+  obj.alice1 = alice
+  obj.alice2 = alice
+
+  const aliceReplacer = {sys: {type: 'Link', linkType: 'Entry', id: 'Alice', circular: true}}
+  const expected = {
+    alice1: alice,
+    alice2: aliceReplacer
+  }
+  mixinStringifySafe(obj, null, 2)
+  t.deepEqual(obj.stringifySafe(), JSON.stringify(expected))
   t.end()
 })


### PR DESCRIPTION
Json-stringify-safe https://www.npmjs.com/package/json-stringify-safe is slow and unreliable, or perhaps broken. This PR uses a decycling algorithm by Douglas Crockford https://github.com/douglascrockford/JSON-js/blob/master/cycle.js.

