### PR TITLE
Address missing values in the error response

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -102,8 +102,14 @@ function obscureAuthTokenInResponse (http) {
       const token = error.response.config.headers.Authorization
 
       error.response.config.headers.Authorization = error.response.config.headers.Authorization.replace(token, `Bearer...${token.substr(-5)}`)
-      error.response.request._headers.authorization = error.response.request._headers.authorization.replace(token, `Bearer...${token.substr(-5)}`)
-      error.response.request._header = error.response.request._header.replace(token, `Bearer...${token.substr(-5)}`)
+
+      if (error.response.request._headers && error.response.request._headers.authorization) {
+        error.response.request._headers.authorization = error.response.request._headers.authorization.replace(token, `Bearer...${token.substr(-5)}`)
+      }
+
+      if (error.response.request._header) {
+        error.response.request._header = error.response.request._header.replace(token, `Bearer...${token.substr(-5)}`)
+      }
     }
 
     return Promise.reject(error)


### PR DESCRIPTION
## Summary
This PR addresses undefined error thrown when obscuring access token.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [x] Feature with pending implementation