### PR TITLE
fix: throw an error when entry id is undefined

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -179,6 +179,10 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    * .catch(console.error)
    */
   function getEntry (id, query = {}) {
+    if (!id) {
+      return Promise.reject(notFoundError(id))
+    }
+
     return this.getEntries({ 'sys.id': id, ...query })
       .then((response) => {
         if (response.items.length > 0) {

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -87,6 +87,11 @@ test('Get entry fails if entryId does not exist', (t) => {
   return t.shouldFail(client.getEntry('nyancatblah'))
 })
 
+test('Get entry fails if an entryId is not passed', (t) => {
+  t.plan(1)
+  return t.shouldFail(client.getEntry())
+})
+
 test('Get entry with fallback locale', (t) => {
   t.plan(5)
   Promise.all([


### PR DESCRIPTION
## Summary
Invoking `getEntry` without passing an ID should fail.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [x] Feature with pending implementation
