### PR TITLE
fix(types) add revision and space to Sys interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,9 +139,19 @@ export interface Sys {
     createdAt: string;
     updatedAt: string;
     locale: string;
-    contentType: {
+    revision?: number;
+    space: {
+        sys: SpaceLink;
+    };
+    contentType?: {
         sys: ContentTypeLink;
     };
+}
+
+export interface SpaceLink {
+    type: 'Link';
+    linkType: 'Space';
+    id: string;
 }
 
 export interface ContentTypeLink {


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Changes the `Sys` definition in types to include `revision` and `space` fields.

## Description

Changes the `Sys` definition in types to include `revision` and `space` fields. They're included optionally -- `revision` is actually optional, since it's `undefined` for unpublished content. I left `space` as optional in order to avoid a breaking change. The type for `space` is defined similarly to the existing definition for `contentType`.

`contentType` should also probably be optional (since it's not set on the `sys` field for content types), but I wasn't entirely sure on that.

## Motivation and Context

Fixes #351 
