### PR TITLE
feat: Allow limit in sync API

### DIFF
--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -140,6 +140,7 @@ function getSyncPage (http, items, query, { paginate }) {
     delete query.initial
     delete query.type
     delete query.content_type
+    delete query.limit
   }
 
   return http.get('sync', createRequestConfig({ query: query }))


### PR DESCRIPTION
## Summary

Handles deleting the `limit` from subsequent sync calls if present on the initial call

## Description

A change has been introduced to the Sync API endpoint that allows a limit to be provided on the initial call that must not be provided on subsequent calls. This PR deletes that query parameter from subsequent calls if present.
