### PR TITLE
Delete limit from sync token

### DIFF
--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -137,6 +137,7 @@ function getSyncPage (http, items, query, { paginate }) {
   }
 
   if (query.sync_token) {
+    delete query.limit
     delete query.initial
     delete query.type
     delete query.content_type


### PR DESCRIPTION
The Sync API has brand new 'limit' parameter. It can only be set when initial: true, and should not be sent with syncTokens. This deletes the limit from the sync query if a sync_token is set, otherwise you get the error: When passing a sync token you can not pass any other parameters. If you want to sync with a specific limit, start a new sync with "initial".

## Summary

The error `When passing a sync token you can not pass any other parameters. If you want to sync with a specific limit, start a new sync with "initial".`

## Description

The Sync API has brand new 'limit' parameter. It can only be set when initial: true, and should not be sent with syncTokens. This deletes the limit from the sync query if a sync_token is set, otherwise you get the error: When passing a sync token you can not pass any other parameters. If you want to sync with a specific limit, start a new sync with "initial".

## Motivation and Context

Fixes the above error

## Todos

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
