### PR TITLE
fix(chore): SYS type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -143,7 +143,7 @@ export interface Sys {
     space: {
         sys: SpaceLink;
     };
-    contentType?: {
+    contentType: {
         sys: ContentTypeLink;
     };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ export interface Sys {
     updatedAt: string;
     locale: string;
     revision?: number;
-    space: {
+    space?: {
         sys: SpaceLink;
     };
     contentType: {


### PR DESCRIPTION
## Description
It turned out changes made earlier to `SYS.contentType` are too strict.
Even though, there are rare cases where `contentType` can be missing, we will keep it required for now.

This problem has been reported in context of another [PR](https://github.com/contentful/contentful.js/pull/368) 

**Update:**
We also identified `space` as an optional field and added the changes to this PR.