### PR TITLE
build(deps): bump contentful-sdk-core from 6.4.0 to 6.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "axios": "^0.19.1",
     "contentful-resolve-response": "^1.1.4",
-    "contentful-sdk-core": "^6.4.0",
+    "contentful-sdk-core": "^6.4.5",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.11"
   },


### PR DESCRIPTION
Bump [contentful-sdk-core version](https://github.com/contentful/contentful-sdk-core/releases/tag/v6.4.5)
