### PR TITLE
fix(docs): fixed the title and the color of prettyprint source class.

### DIFF
--- a/contentful/7.14.4/styles/jsdoc.css
+++ b/contentful/7.14.4/styles/jsdoc.css
@@ -59,6 +59,7 @@ h1 {
   font-weight: 300;
   font-size: 48px;
   margin: 1em 0 .5em;
+  line-height: 1;
 }
 
 h1.page-title {
@@ -385,7 +386,7 @@ footer {
   line-height: 18px;
   display: block;
   background-color: #0d152a;
-  color: ##536171;
+  color: #536171;
 }
 
 .prettyprint code {


### PR DESCRIPTION
## Summary
Fixes an overlapping title and a typo in jsdoc css file 7.14.4 (fixes and closes #406).

## Description
Added a line-height of 1 and remove an extra '#' from the color property of the .prettyprint.source.