### PR TITLE
fix(perf): improve performance of resolving huge data sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   ],
   "dependencies": {
     "axios": "^0.19.1",
-    "contentful-resolve-response": "^1.1.4",
+    "contentful-resolve-response": "^1.2.2",
     "contentful-sdk-core": "^6.4.5",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.11"


### PR DESCRIPTION
This fixes a performance issue our customers have on really big spaces. The fix itself was implemented already in contentful-resolve-response

Details:

* https://github.com/contentful/contentful-resolve-response/pull/35
* https://github.com/contentful/contentful-resolve-response/issues/30
* Will solve: https://github.com/gatsbyjs/gatsby/issues/25464

Thanks a bunch :)

