### PR TITLE
fix(paged-sync): return empty array if sync api returns nothing

### DIFF
--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -146,7 +146,7 @@ function getSyncPage (http, items, query, { paginate }) {
   return http.get('sync', createRequestConfig({ query: query }))
     .then((response) => {
       const data = response.data
-      items = items.concat(data.items)
+      items = items.concat(data.items || [])
       if (data.nextPageUrl) {
         if (paginate) {
           delete query.initial

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -145,7 +145,7 @@ function getSyncPage (http, items, query, { paginate }) {
 
   return http.get('sync', createRequestConfig({ query: query }))
     .then((response) => {
-      const data = response.data
+      const data = response.data || {}
       items = items.concat(data.items || [])
       if (data.nextPageUrl) {
         if (paginate) {
@@ -162,6 +162,8 @@ function getSyncPage (http, items, query, { paginate }) {
           items: items,
           nextSyncToken: getToken(data.nextSyncUrl)
         }
+      } else {
+        return { items: [] }
       }
     })
 }

--- a/test/unit/paged-sync-test.js
+++ b/test/unit/paged-sync-test.js
@@ -43,6 +43,29 @@ test('Throws with incompatible content_type and type parameter', (t) => {
   }, /content_type.*type.*Entry/)
 })
 
+test('Returns empty response if response has no items', (t) => {
+  t.plan(4)
+  const http = { get: sinon.stub() }
+  http.get.withArgs('sync', {
+    params: {
+      initial: true
+    }
+  }).returns(Promise.resolve({
+    data: {
+      nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+    } // no items returned
+  }))
+
+  return pagedSync(http, { initial: true }, { resolveLinks: true })
+    .then(response => {
+      t.deepEqual(response.entries, [])
+      t.deepEqual(response.assets, [])
+      t.deepEqual(response.deletedEntries, [])
+      t.deepEqual(response.deletedAssets, [])
+    })
+
+})
+
 test('Initial sync with one page', (t) => {
   t.plan(11)
   const http = { get: sinon.stub() }

--- a/test/unit/paged-sync-test.js
+++ b/test/unit/paged-sync-test.js
@@ -66,6 +66,24 @@ test('Returns empty response if response has no items', (t) => {
 
 })
 
+test('Returns empty response if response is empty', (t) => {
+  t.plan(4)
+  const http = { get: sinon.stub() }
+  http.get.withArgs('sync', {
+    params: {
+      initial: true
+    }
+  }).returns(Promise.resolve({}))
+
+  return pagedSync(http, { initial: true }, { resolveLinks: true })
+    .then(response => {
+      t.deepEqual(response.entries, [])
+      t.deepEqual(response.assets, [])
+      t.deepEqual(response.deletedEntries, [])
+      t.deepEqual(response.deletedAssets, [])
+    })
+})
+
 test('Initial sync with one page', (t) => {
   t.plan(11)
   const http = { get: sinon.stub() }


### PR DESCRIPTION
We were not handling the case where the request to the sync api returned no items, which caused errors in user applications, failing because items was undefined. This PR gracefully handles this case.

Fixes #432 