### PR TITLE
fix: ensure minimum select

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -48,6 +48,7 @@
 import { createRequestConfig } from 'contentful-sdk-core'
 import entities from './entities'
 import pagedSync from './paged-sync'
+import normalizeSelect from './utils/normalize-select'
 
 /**
  * Creates API object with methods to access functionality from Contentful's
@@ -361,15 +362,6 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
   function parseEntries (data) {
     const { resolveLinks, removeUnresolved } = getGlobalOptions({})
     return wrapEntryCollection(data, { resolveLinks, removeUnresolved })
-  }
-  /*
-   * sdk relies heavily on sys metadata
-   * so we cannot omit the sys property on sdk level
-   * */
-  function normalizeSelect (query) {
-    if (query.select && !/sys/i.test(query.select)) {
-      query.select += ',sys'
-    }
   }
 
   /*

--- a/lib/utils/normalize-select.js
+++ b/lib/utils/normalize-select.js
@@ -1,0 +1,10 @@
+/*
+* sdk relies heavily on sys metadata
+* so we cannot omit the sys property on sdk level
+* */
+
+export default function normalizeSelect (query) {
+  if (query.select && !/sys/i.test(query.select)) {
+    query.select += ',sys'
+  }
+}

--- a/lib/utils/normalize-select.js
+++ b/lib/utils/normalize-select.js
@@ -1,10 +1,30 @@
 /*
 * sdk relies heavily on sys metadata
-* so we cannot omit the sys property on sdk level
+* so we cannot omit the sys property on sdk level entirely
+* and we have to ensure that at least `id` and `type` are present
 * */
 
 export default function normalizeSelect (query) {
-  if (query.select && !/sys/i.test(query.select)) {
-    query.select += ',sys'
+  if (!query.select) {
+    return
   }
+
+  // The selection of fields for the query is limited
+  // Get the different parts that are listed for selection
+  const allSelects = query.select.split(',')
+  // Move the parts into a set for easy access and deduplication
+  const selectedSet = new Set(allSelects)
+
+  // If we already select all of `sys` we can just return
+  // since we're anyway fetching everything that is needed
+  if (selectedSet.has('sys')) {
+    return
+  }
+
+  // We don't select `sys` so we need to ensure the minimum set
+  selectedSet.add('sys.id')
+  selectedSet.add('sys.type')
+
+  // Reassign the normalized sys properties
+  query.select = [...selectedSet].join(',')
 }

--- a/test/unit/utils/normalize-select-test.js
+++ b/test/unit/utils/normalize-select-test.js
@@ -1,0 +1,46 @@
+import test from 'blue-tape'
+import normalizeSelect from '../../../lib/utils/normalize-select'
+
+test('normalizeSelect does nothing if sys is selected', (t) => {
+  const query = {
+    select: 'fields.foo,sys'
+  }
+
+  normalizeSelect(query)
+
+  t.equal(query.select, 'fields.foo,sys')
+  t.end()
+})
+
+test('normalizeSelect adds required properties if sys is not selected', (t) => {
+  const query = {
+    select: 'fields.foo'
+  }
+
+  normalizeSelect(query)
+
+  t.equal(query.select, 'fields.foo,sys.id,sys.type')
+  t.end()
+})
+
+test('normalizeSelect adds required properties if different sys properties are selected', (t) => {
+  const query = {
+    select: 'fields.foo,sys.createdAt'
+  }
+
+  normalizeSelect(query)
+
+  t.equal(query.select, 'fields.foo,sys.createdAt,sys.id,sys.type')
+  t.end()
+})
+
+test('normalizeSelect adds required properties if only some required sys properties are selected', (t) => {
+  const query = {
+    select: 'fields.foo,sys.type'
+  }
+
+  normalizeSelect(query)
+
+  t.equal(query.select, 'fields.foo,sys.type,sys.id')
+  t.end()
+})


### PR DESCRIPTION
Fixes https://github.com/contentful/contentful.js/issues/296 and sort of fixes https://github.com/contentful/contentful.js/issues/430
Might be the cause for https://github.com/contentful/contentful.js/issues/444 too.

Basically the SDK always needs `sys.id` and `sys.type` to perform link resolution.  
Other `sys` fields are optional from what I can tell.

Previously the SDK would simply check if the string `sys` appears in the `select` section of the query and continue with that if it did, and add `sys` if it did not.

This led to the problem where selecting for example just `sys.id` would fail link resolution because `sys.type` was not included. It also led to the problem where not selecting `sys` as an optimization would always force the entire sys object back into the query. 

Now we ensure that the minimum set of sys properties is always included, but not more than that.
This does not fully fix the issue of not wanting `sys` at all, but it gives the best compromise for still keeping things working.