### PR TITLE
refactor: replace promises with async/await

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -105,14 +105,17 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    * // returns the space object with the above <space-id>
-   * client.getSpace()
-   * .then((space) => console.log(space))
-   * .catch(console.error)
+   * const space = await client.getSpace()
+   * console.log(space)
    */
-  function getSpace () {
+  async function getSpace () {
     switchToSpace(http)
-    return http.get('')
-      .then((response) => wrapSpace(response.data), errorHandler)
+    try {
+      const response = await http.get('')
+      return wrapSpace(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -128,14 +131,18 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getContentType('<content_type_id>')
-   * .then((contentType) => console.log(contentType))
-   * .catch(console.error)
+   * const contentType = await client.getContentType('<content_type_id>')
+   * console.log(contentType)
    */
-  function getContentType (id) {
+  async function getContentType (id) {
     switchToEnvironment(http)
-    return http.get('content_types/' + id)
-      .then((response) => wrapContentType(response.data), errorHandler)
+
+    try {
+      const response = await http.get(`content_types/${id}`)
+      return wrapContentType(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -151,14 +158,17 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getContentTypes()
-   * .then((response) => console.log(response.items))
-   * .catch(console.error)
+   * const response = await client.getContentTypes()
+   * console.log(response.items)
    */
-  function getContentTypes (query = {}) {
+  async function getContentTypes (query = {}) {
     switchToEnvironment(http)
-    return http.get('content_types', createRequestConfig({ query: query }))
-      .then((response) => wrapContentTypeCollection(response.data), errorHandler)
+    try {
+      const response = await http.get('content_types', createRequestConfig({ query: query }))
+      return wrapContentTypeCollection(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -175,22 +185,24 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getEntry('<entry_id>')
-   * .then((entry) => console.log(entry))
-   * .catch(console.error)
+   * const entry = await client.getEntry('<entry_id>')
+   * console.log(entry)
    */
-  function getEntry (id, query = {}) {
+  async function getEntry (id, query = {}) {
     if (!id) {
-      return Promise.reject(notFoundError(id))
+      throw notFoundError(id)
     }
 
-    return this.getEntries({ 'sys.id': id, ...query })
-      .then((response) => {
-        if (response.items.length > 0) {
-          return wrapEntry(response.items[0])
-        }
+    try {
+      const response = await this.getEntries({ 'sys.id': id, ...query })
+      if (response.items.length > 0) {
+        return wrapEntry(response.items[0])
+      } else {
         throw notFoundError(id)
-      }, errorHandler)
+      }
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -206,16 +218,20 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getEntries()
-   * .then((response) => console.log(response.items))
-   * .catch(console.error)
+   * const response = await client.getEntries()
+   * .console.log(response.items)
    */
-  function getEntries (query = {}) {
+  async function getEntries (query = {}) {
     switchToEnvironment(http)
     const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
     normalizeSelect(query)
-    return http.get('entries', createRequestConfig({ query: query }))
-      .then((response) => wrapEntryCollection(response.data, { resolveLinks, removeUnresolved }), errorHandler)
+
+    try {
+      const response = await http.get('entries', createRequestConfig({ query: query }))
+      return wrapEntryCollection(response.data, { resolveLinks, removeUnresolved })
+    } catch (error) {
+      errorHandler(error)
+    }
   }
   /**
    * Gets an Asset
@@ -231,15 +247,19 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getAsset('<asset_id>')
-   * .then((asset) => console.log(asset))
-   * .catch(console.error)
+   * const asset = await client.getAsset('<asset_id>')
+   * console.log(asset)
    */
-  function getAsset (id, query = {}) {
+  async function getAsset (id, query = {}) {
     switchToEnvironment(http)
     normalizeSelect(query)
-    return http.get('assets/' + id, createRequestConfig({ query: query }))
-      .then((response) => wrapAsset(response.data), errorHandler)
+
+    try {
+      const response = await http.get(`assets/${id}`, createRequestConfig({ query: query }))
+      return wrapAsset(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -255,15 +275,19 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getAssets()
-   * .then((response) => console.log(response.items))
-   * .catch(console.error)
+   * const response = await client.getAssets()
+   * console.log(response.items)
    */
-  function getAssets (query = {}) {
+  async function getAssets (query = {}) {
     switchToEnvironment(http)
     normalizeSelect(query)
-    return http.get('assets', createRequestConfig({ query: query }))
-      .then((response) => wrapAssetCollection(response.data), errorHandler)
+
+    try {
+      const response = await http.get('assets', createRequestConfig({ query: query }))
+      return wrapAssetCollection(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -279,14 +303,18 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.getLocales()
-   * .then((response) => console.log(response.items))
-   * .catch(console.error)
+   * const response = await client.getLocales()
+   * console.log(response.items)
    */
-  function getLocales (query = {}) {
+  async function getLocales (query = {}) {
     switchToEnvironment(http)
-    return http.get('locales', createRequestConfig({ query: query }))
-      .then((response) => wrapLocaleCollection(response.data), errorHandler)
+
+    try {
+      const response = await http.get('locales', createRequestConfig({ query: query }))
+      return wrapLocaleCollection(response.data)
+    } catch (error) {
+      errorHandler(error)
+    }
   }
 
   /**
@@ -313,17 +341,16 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    *   accessToken: '<content_delivery_api_key>'
    * })
    *
-   * client.sync({
+   * const response = await client.sync({
    *   initial: true
    * })
-   * .then((response) => console.log({
+   * console.log({
    *   entries: response.entries,
    *   assets: response.assets,
    *   nextSyncToken: response.nextSyncToken
-   * }))
-   * .catch(console.error)
+   * })
    */
-  function sync (query = {}, options = { paginate: true }) {
+  async function sync (query = {}, options = { paginate: true }) {
     const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
     switchToEnvironment(http)
     return pagedSync(http, query, { resolveLinks, removeUnresolved, ...options })

--- a/lib/paged-sync.js
+++ b/lib/paged-sync.js
@@ -43,7 +43,7 @@ import mixinStringifySafe from './mixins/stringify-safe'
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<SyncCollection>}
  */
-export default function pagedSync (http, query, options = {}) {
+export default async function pagedSync (http, query, options = {}) {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error('Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing')
   }
@@ -64,27 +64,23 @@ export default function pagedSync (http, query, options = {}) {
     paginate
   }
 
-  return getSyncPage(http, [], query, syncOptions)
-    .then((response) => {
-      // clones response.items used in includes because we don't want these to be mutated
-      if (resolveLinks) {
-        response.items = resolveResponse(response, { removeUnresolved, itemEntryPoints: ['fields'] })
-      }
-      // maps response items again after getters are attached
-      const mappedResponseItems = mapResponseItems(response.items)
+  const response = await getSyncPage(http, [], query, syncOptions)
+  // clones response.items used in includes because we don't want these to be mutated
+  if (resolveLinks) {
+    response.items = resolveResponse(response, { removeUnresolved, itemEntryPoints: ['fields'] })
+  }
+  // maps response items again after getters are attached
+  const mappedResponseItems = mapResponseItems(response.items)
 
-      if (response.nextSyncToken) {
-        mappedResponseItems.nextSyncToken = response.nextSyncToken
-      }
+  if (response.nextSyncToken) {
+    mappedResponseItems.nextSyncToken = response.nextSyncToken
+  }
 
-      if (response.nextPageToken) {
-        mappedResponseItems.nextPageToken = response.nextPageToken
-      }
+  if (response.nextPageToken) {
+    mappedResponseItems.nextPageToken = response.nextPageToken
+  }
 
-      return freezeSys(mixinStringifySafe(toPlainObject(mappedResponseItems)))
-    }, (error) => {
-      throw error
-    })
+  return freezeSys(mixinStringifySafe(toPlainObject(mappedResponseItems)))
 }
 
 /**
@@ -125,7 +121,7 @@ function mapResponseItems (items) {
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<{items: Array, nextSyncToken: string}>}
  */
-function getSyncPage (http, items, query, { paginate }) {
+async function getSyncPage (http, items, query, { paginate }) {
   if (query.nextSyncToken) {
     query.sync_token = query.nextSyncToken
     delete query.nextSyncToken
@@ -143,29 +139,27 @@ function getSyncPage (http, items, query, { paginate }) {
     delete query.limit
   }
 
-  return http.get('sync', createRequestConfig({ query: query }))
-    .then((response) => {
-      const data = response.data || {}
-      items = items.concat(data.items || [])
-      if (data.nextPageUrl) {
-        if (paginate) {
-          delete query.initial
-          query.sync_token = getToken(data.nextPageUrl)
-          return getSyncPage(http, items, query, { paginate })
-        }
-        return {
-          items: items,
-          nextPageToken: getToken(data.nextPageUrl)
-        }
-      } else if (data.nextSyncUrl) {
-        return {
-          items: items,
-          nextSyncToken: getToken(data.nextSyncUrl)
-        }
-      } else {
-        return { items: [] }
-      }
-    })
+  const response = await http.get('sync', createRequestConfig({ query: query }))
+  const data = response.data || {}
+  items = items.concat(data.items || [])
+  if (data.nextPageUrl) {
+    if (paginate) {
+      delete query.initial
+      query.sync_token = getToken(data.nextPageUrl)
+      return getSyncPage(http, items, query, { paginate })
+    }
+    return {
+      items: items,
+      nextPageToken: getToken(data.nextPageUrl)
+    }
+  } else if (data.nextSyncUrl) {
+    return {
+      items: items,
+      nextSyncToken: getToken(data.nextSyncUrl)
+    }
+  } else {
+    return { items: [] }
+  }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "karma-webpack": "^4.0.2",
     "mkdirp": "^1.0.3",
     "nodemon": "^2.0.2",
+    "regenerator-runtime": "^0.13.7",
     "require-all": "^3.0.0",
     "rimraf": "^3.0.0",
     "selenium-webdriver": "^4.0.0-alpha.5",

--- a/test/e2e/index.js
+++ b/test/e2e/index.js
@@ -24,14 +24,12 @@ const driver = new Builder()
   .usingServer(`http://${process.env.SAUCE_USERNAME}:${process.env.SAUCE_ACCESS_KEY}@ondemand.saucelabs.com/wd/hub`)
   .build()
 
-initServer((server) => {
+initServer(async (server) => {
   driver.get('http://localhost:3000')
 
   const h1 = driver.findElement(By.tagName('h1'))
 
   driver.wait(until.elementTextIs(h1, 'Success'), 30000)
-  driver.quit()
-    .then(() => {
-      server.close()
-    })
+  await driver.quit()
+  server.close()
 })

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -35,342 +35,307 @@ const clientWithLoggers = contentful.createClient({
   requestLogger: requestLoggerStub
 })
 
-test('Gets space', (t) => {
+test('Gets space', async (t) => {
   t.plan(3)
-  return client.getSpace()
-    .then((response) => {
-      t.ok(response.sys, 'sys')
-      t.ok(response.name, 'name')
-      t.ok(response.locales, 'locales')
-    })
+  const response = await client.getSpace()
+  t.ok(response.sys, 'sys')
+  t.ok(response.name, 'name')
+  t.ok(response.locales, 'locales')
 })
 
-test('Gets content type', (t) => {
+test('Gets content type', async (t) => {
   t.plan(3)
-  return client.getContentType('1t9IbcfdCk6m04uISSsaIK')
-    .then((response) => {
-      t.ok(response.sys, 'sys')
-      t.ok(response.name, 'name')
-      t.ok(response.fields, 'fields')
-    })
+  const response = await client.getContentType('1t9IbcfdCk6m04uISSsaIK')
+  t.ok(response.sys, 'sys')
+  t.ok(response.name, 'name')
+  t.ok(response.fields, 'fields')
 })
 
-test('Gets content types', (t) => {
+test('Gets content types', async (t) => {
   t.plan(1)
-  return client.getContentTypes()
-    .then((response) => {
-      t.ok(response.items, 'items')
-    })
+  const response = await client.getContentTypes()
+  t.ok(response.items, 'items')
 })
 
-test('Gets entry', (t) => {
+test('Gets entry', async (t) => {
   t.plan(2)
-  return client.getEntry('5ETMRzkl9KM4omyMwKAOki')
-    .then((response) => {
-      t.ok(response.sys, 'sys')
-      t.ok(response.fields, 'fields')
-    })
+  const response = await client.getEntry('5ETMRzkl9KM4omyMwKAOki')
+  t.ok(response.sys, 'sys')
+  t.ok(response.fields, 'fields')
 })
 
-test('Gets an entry with a specific locale', (t) => {
+test('Gets an entry with a specific locale', async (t) => {
   t.plan(1)
-  return client.getEntry('nyancat', {
+  const entry = await client.getEntry('nyancat', {
     locale: 'tlh'
   })
-    .then((entry) => {
-      t.equal(entry.sys.locale, 'tlh')
-    })
+  t.equal(entry.sys.locale, 'tlh')
 })
 
-test('Get entry fails if entryId does not exist', (t) => {
+test('Get entry fails if entryId does not exist', async (t) => {
   t.plan(1)
-  return t.shouldFail(client.getEntry('nyancatblah'))
+  await t.shouldFail(client.getEntry('nyancatblah'))
 })
 
-test('Get entry fails if an entryId is not passed', (t) => {
+test('Get entry fails if an entryId is not passed', async (t) => {
   t.plan(1)
-  return t.shouldFail(client.getEntry())
+  await t.shouldFail(client.getEntry())
 })
 
-test('Get entry with fallback locale', (t) => {
+test('Get entry with fallback locale', async (t) => {
   t.plan(5)
-  Promise.all([
+  const entries = await Promise.all([
     localeClient.getEntry('no-af-and-no-zu-za', { locale: 'af' }),
     localeClient.getEntry('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
     localeClient.getEntry('no-zu-ZA', { locale: 'zu-ZA' }),
     localeClient.getEntry('no-ne-NP', { locale: 'ne-NP' }),
     localeClient.getEntry('no-af', { locale: 'af' })
-  ]).then((entries) => {
-    t.notEqual(entries[0].fields.title, '')
-    t.notEqual(entries[1].fields.title, '')
-    t.notEqual(entries[2].fields.title, '')
-    t.notEqual(entries[3].fields.title, '')
-    t.notEqual(entries[4].fields.title, '')
-  })
+  ])
+
+  t.notEqual(entries[0].fields.title, '')
+  t.notEqual(entries[1].fields.title, '')
+  t.notEqual(entries[2].fields.title, '')
+  t.notEqual(entries[3].fields.title, '')
+  t.notEqual(entries[4].fields.title, '')
 })
 
-test('Gets entries', (t) => {
+test('Gets entries', async (t) => {
   t.plan(1)
-  return client.getEntries()
-    .then((response) => {
-      t.ok(response.items, 'items')
-    })
+  const response = await client.getEntries()
+
+  t.ok(response.items, 'items')
 })
-test('Gets entries with select', (t) => {
+test('Gets entries with select', async (t) => {
   t.plan(4)
-  return client.getEntries({ select: 'fields.name,fields.likes', content_type: 'cat' })
-    .then((response) => {
-      t.ok(response.items, 'items')
-      t.ok(response.items[0].fields.name, 'fields.name')
-      t.ok(response.items[0].fields.likes, 'fields.likes')
-      t.notOk(response.items[0].fields.color, 'no fields.color')
-    })
+  const response = await client.getEntries({ select: 'fields.name,fields.likes', content_type: 'cat' })
+
+  t.ok(response.items, 'items')
+  t.ok(response.items[0].fields.name, 'fields.name')
+  t.ok(response.items[0].fields.likes, 'fields.likes')
+  t.notOk(response.items[0].fields.color, 'no fields.color')
 })
 
-test('Gets entries with a specific locale', (t) => {
+test('Gets entries with a specific locale', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     locale: 'tlh'
   })
-    .then((response) => {
-      t.equal(response.items[0].sys.locale, 'tlh')
-      t.ok(response.items, 'items')
-    })
+
+  t.equal(response.items[0].sys.locale, 'tlh')
+  t.ok(response.items, 'items')
 })
 
-test('Gets entries with a limit parameter', (t) => {
+test('Gets entries with a limit parameter', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     limit: 2
   })
-    .then((response) => {
-      t.ok(response.items, 'items')
-      t.equal(response.items.length, 2)
-    })
+
+  t.ok(response.items, 'items')
+  t.equal(response.items.length, 2)
 })
 
-test('Gets entries with a skip parameter', (t) => {
+test('Gets entries with a skip parameter', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     skip: 2
   })
-    .then((response) => {
-      t.ok(response.items, 'items')
-      t.equal(response.skip, 2)
-    })
+
+  t.ok(response.items, 'items')
+  t.equal(response.skip, 2)
 })
 
-test('Gets entries with linked includes', (t) => {
+test('Gets entries with linked includes', async (t) => {
   t.plan(5)
-  return client.getEntries({ include: 2, 'sys.id': 'nyancat' })
-    .then((response) => {
-      t.ok(response.includes, 'includes')
-      t.ok(response.includes.Asset, 'includes for Assets')
-      t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items')
-      t.equal(response.items[0].fields.bestFriend.sys.type, 'Entry', 'entry gets resolved from other entries in collection')
-      t.ok(response.items[0].fields.bestFriend.fields, 'resolved entry has fields')
-    })
+  const response = await client.getEntries({ include: 2, 'sys.id': 'nyancat' })
+
+  t.ok(response.includes, 'includes')
+  t.ok(response.includes.Asset, 'includes for Assets')
+  t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items')
+  t.equal(response.items[0].fields.bestFriend.sys.type, 'Entry', 'entry gets resolved from other entries in collection')
+  t.ok(response.items[0].fields.bestFriend.fields, 'resolved entry has fields')
 })
 
-test('Gets entry with link resolution', (t) => {
+test('Gets entry with link resolution', async (t) => {
   t.plan(2)
-  return client.getEntry('nyancat', { include: 2 })
-    .then((response) => {
-      t.equal(response.fields.bestFriend.sys.type, 'Entry', 'entry gets resolved from other entries in collection')
-      t.ok(response.fields.bestFriend.fields, 'resolved entry has fields')
-    })
+  const response = await client.getEntry('nyancat', { include: 2 })
+
+  t.equal(response.fields.bestFriend.sys.type, 'Entry', 'entry gets resolved from other entries in collection')
+  t.ok(response.fields.bestFriend.fields, 'resolved entry has fields')
 })
 
-test('Gets entries with content type query param', (t) => {
+test('Gets entries with content type query param', async (t) => {
   t.plan(2)
-  return client.getEntries({ content_type: 'cat' })
-    .then((response) => {
-      t.equal(response.total, 3)
-      t.looseEqual(response.items.map((item) => item.sys.contentType.sys.id), ['cat', 'cat', 'cat'])
-    })
+  const response = await client.getEntries({ content_type: 'cat' })
+
+  t.equal(response.total, 3)
+  t.looseEqual(response.items.map((item) => item.sys.contentType.sys.id), ['cat', 'cat', 'cat'])
 })
 
-test('Gets entries with equality query', (t) => {
+test('Gets entries with equality query', async (t) => {
   t.plan(2)
-  return client.getEntries({ 'sys.id': 'nyancat' })
-    .then((response) => {
-      t.equal(response.total, 1)
-      t.equal(response.items[0].sys.id, 'nyancat')
-    })
+  const response = await client.getEntries({ 'sys.id': 'nyancat' })
+
+  t.equal(response.total, 1)
+  t.equal(response.items[0].sys.id, 'nyancat')
 })
 
-test('Gets entries with inequality query', (t) => {
+test('Gets entries with inequality query', async (t) => {
   t.plan(2)
-  return client.getEntries({ 'sys.id[ne]': 'nyancat' })
-    .then((response) => {
-      t.ok(response.total > 0)
-      t.equal(response.items.filter((item) => item.sys.id === 'nyancat').length, 0)
-    })
+  const response = await client.getEntries({ 'sys.id[ne]': 'nyancat' })
+
+  t.ok(response.total > 0)
+  t.equal(response.items.filter((item) => item.sys.id === 'nyancat').length, 0)
 })
 
-test('Gets entries with array equality query', (t) => {
+test('Gets entries with array equality query', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.likes': 'lasagna'
   })
-    .then((response) => {
-      t.equal(response.total, 1)
-      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 1)
-    })
+
+  t.equal(response.total, 1)
+  t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 1)
 })
 
-test('Gets entries with array inequality query', (t) => {
+test('Gets entries with array inequality query', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.likes[ne]': 'lasagna'
   })
-    .then((response) => {
-      t.ok(response.total > 0)
-      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
-    })
+
+  t.ok(response.total > 0)
+  t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
 })
 
-test('Gets entries with inclusion query', (t) => {
+test('Gets entries with inclusion query', async (t) => {
   t.plan(3)
-  return client.getEntries({ 'sys.id[in]': 'finn,jake' })
-    .then((response) => {
-      t.equal(response.total, 2)
-      t.equal(response.items.filter((item) => item.sys.id === 'finn').length, 1)
-      t.equal(response.items.filter((item) => item.sys.id === 'jake').length, 1)
-    })
+  const response = await client.getEntries({ 'sys.id[in]': 'finn,jake' })
+
+  t.equal(response.total, 2)
+  t.equal(response.items.filter((item) => item.sys.id === 'finn').length, 1)
+  t.equal(response.items.filter((item) => item.sys.id === 'jake').length, 1)
 })
 
-test('Gets entries with exclusion query', (t) => {
+test('Gets entries with exclusion query', async (t) => {
   t.plan(3)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.likes[nin]': 'rainbows,lasagna'
   })
-    .then((response) => {
-      t.ok(response.total > 0)
-      t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
-      t.equal(response.items[0].fields.likes.filter((i) => i === 'rainbows').length, 0)
-    })
+
+  t.ok(response.total > 0)
+  t.equal(response.items[0].fields.likes.filter((i) => i === 'lasagna').length, 0)
+  t.equal(response.items[0].fields.likes.filter((i) => i === 'rainbows').length, 0)
 })
 
-test('Gets entries with exists query', (t) => {
+test('Gets entries with exists query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.likes[exists]': 'true'
   })
-    .then((response) => {
-      t.equal(response.items.map((item) => item.fields.likes).length, response.total)
-    })
+
+  t.equal(response.items.map((item) => item.fields.likes).length, response.total)
 })
 
-test('Gets entries with inverse exists query', (t) => {
+test('Gets entries with inverse exists query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.likes[exists]': 'false'
   })
-    .then((response) => {
-      t.equal(response.items.map((item) => item.fields.likes).length, 0)
-    })
+
+  t.equal(response.items.map((item) => item.fields.likes).length, 0)
 })
 
-test('Gets entries with field link query', (t) => {
+test('Gets entries with field link query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'cat',
     'fields.bestFriend.sys.id': 'happycat'
   })
-    .then((response) => {
-      t.equal(response.items[0].sys.id, 'nyancat', 'returned entry has link to specified linked entry')
-    })
+
+  t.equal(response.items[0].sys.id, 'nyancat', 'returned entry has link to specified linked entry')
 })
 
-test('Gets entries with gte range query', (t) => {
+test('Gets entries with gte range query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     'sys.updatedAt[gte]': '2013-01-01T00:00:00Z'
   })
-    .then((response) => {
-      t.ok(response.total > 0)
-    })
+
+  t.ok(response.total > 0)
 })
 
-test('Gets entries with lte range query', (t) => {
+test('Gets entries with lte range query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     'sys.updatedAt[lte]': '2013-01-01T00:00:00Z'
   })
-    .then((response) => {
-      t.equal(response.total, 0)
-    })
+
+  t.equal(response.total, 0)
 })
 
-test('Gets entries with full text search query', (t) => {
+test('Gets entries with full text search query', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     query: 'bacon'
   })
-    .then((response) => {
-      t.ok(response.items[0].fields.description.match(/bacon/))
-    })
+
+  t.ok(response.items[0].fields.description.match(/bacon/))
 })
 
-test('Gets entries with full text search query on field', (t) => {
+test('Gets entries with full text search query on field', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: 'dog',
     'fields.description[match]': 'bacon pancakes'
   })
-    .then((response) => {
-      t.ok(response.items[0].fields.description.match(/bacon/))
-    })
+
+  t.ok(response.items[0].fields.description.match(/bacon/))
 })
 
-test('Gets entries with location proximity search', (t) => {
+test('Gets entries with location proximity search', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: '1t9IbcfdCk6m04uISSsaIK',
     'fields.center[near]': '38,-122'
   })
-    .then((response) => {
-      t.ok(response.items[0].fields.center.lat, 'has latitude')
-      t.ok(response.items[0].fields.center.lon, 'has longitude')
-    })
+
+  t.ok(response.items[0].fields.center.lat, 'has latitude')
+  t.ok(response.items[0].fields.center.lon, 'has longitude')
 })
 
-test('Gets entries with location in bounding object', (t) => {
+test('Gets entries with location in bounding object', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     content_type: '1t9IbcfdCk6m04uISSsaIK',
     'fields.center[within]': '40,-124,36,-120'
   })
-    .then((response) => {
-      t.ok(response.items[0].fields.center.lat, 'has latitude')
-      t.ok(response.items[0].fields.center.lon, 'has longitude')
-    })
+
+  t.ok(response.items[0].fields.center.lat, 'has latitude')
+  t.ok(response.items[0].fields.center.lon, 'has longitude')
 })
 
-test('Gets entries by creation order', (t) => {
+test('Gets entries by creation order', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     order: 'sys.createdAt'
   })
-    .then((response) => {
-      t.ok(response.items[0].sys.createdAt < response.items[1].sys.createdAt)
-    })
+
+  t.ok(response.items[0].sys.createdAt < response.items[1].sys.createdAt)
 })
 
-test('Gets entries by inverse creation order', (t) => {
+test('Gets entries by inverse creation order', async (t) => {
   t.plan(1)
-  return client.getEntries({
+  const response = await client.getEntries({
     order: '-sys.createdAt'
   })
-    .then((response) => {
-      t.ok(response.items[0].sys.createdAt > response.items[1].sys.createdAt)
-    })
+
+  t.ok(response.items[0].sys.createdAt > response.items[1].sys.createdAt)
 })
 
 /**
@@ -382,143 +347,119 @@ test('Gets entries by inverse creation order', (t) => {
  * It's a slightly fragile test as it can break if entries are added or deleted
  * from the space.
  */
-test('Gets entries by creation order and id order', (t) => {
+test('Gets entries by creation order and id order', async (t) => {
   t.plan(2)
-  return client.getEntries({
+  const response = await client.getEntries({
     order: 'sys.contentType.sys.id,sys.id'
   })
-    .then((response) => {
-      const contentTypeOrder = response.items
-        .map((item) => item.sys.contentType.sys.id)
-        .filter((value, index, self) => self.indexOf(value) === index)
-      t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'dog', 'human'], 'orders')
-      t.ok(response.items[0].sys.id < response.items[1].sys.id, 'id of entry with index 1 is higher than the one of index 0 since they share content type')
-    })
+
+  const contentTypeOrder = response.items
+    .map((item) => item.sys.contentType.sys.id)
+    .filter((value, index, self) => self.indexOf(value) === index)
+
+  t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'dog', 'human'], 'orders')
+  t.ok(response.items[0].sys.id < response.items[1].sys.id, 'id of entry with index 1 is higher than the one of index 0 since they share content type')
 })
 
-test('Gets assets with only images', (t) => {
+test('Gets assets with only images', async (t) => {
   t.plan(1)
-  return client.getAssets({
+  const response = await client.getAssets({
     mimetype_group: 'image'
   })
-    .then((response) => {
-      t.ok(response.items[0].fields.file.contentType.match(/image/))
-    })
+  t.ok(response.items[0].fields.file.contentType.match(/image/))
 })
 
-test('Gets asset', (t) => {
+test('Gets asset', async (t) => {
   t.plan(2)
-  return client.getAsset('1x0xpXu4pSGS4OukSyWGUK')
-    .then((response) => {
-      t.ok(response.sys, 'sys')
-      t.ok(response.fields, 'fields')
-    })
+  const response = await client.getAsset('1x0xpXu4pSGS4OukSyWGUK')
+  t.ok(response.sys, 'sys')
+  t.ok(response.fields, 'fields')
 })
 
-test('Gets an asset with a specific locale', (t) => {
+test('Gets an entry with a specific locale', async (t) => {
   t.plan(1)
-  return client.getEntry('jake', {
+  const entry = await client.getEntry('jake', {
     locale: 'tlh'
   })
-    .then((asset) => {
-      t.equal(asset.sys.locale, 'tlh')
-    })
+  t.equal(entry.sys.locale, 'tlh')
 })
 
-test('Gets assets', (t) => {
+test('Gets assets', async (t) => {
   t.plan(1)
-  return client.getAssets()
-    .then((response) => {
-      t.ok(response.items, 'items')
-    })
+  const response = await client.getAssets()
+  t.ok(response.items, 'items')
 })
-test('Gets Locales', (t) => {
+test('Gets Locales', async (t) => {
   t.plan(2)
-  return client.getLocales()
-    .then((response) => {
-      t.ok(response.items, 'items')
-      t.equals(response.items[0].code, 'en-US', 'first locale is en-US')
-    })
+  const response = await client.getLocales()
+  t.ok(response.items, 'items')
+  t.equals(response.items[0].code, 'en-US', 'first locale is en-US')
 })
-test('Sync space', (t) => {
+test('Sync space', async (t) => {
   t.plan(6)
-  return client.sync({ initial: true })
-    .then((response) => {
-      t.ok(response.entries, 'entries')
-      t.ok(response.assets, 'assets')
-      t.ok(response.deletedEntries, 'deleted entries')
-      t.ok(response.deletedAssets, 'deleted assets')
-      t.ok(response.nextSyncToken, 'next sync token')
-      t.equal(response.entries[0].fields.image['en-US'].sys.type, 'Asset', 'links are resolved')
-    })
+  const response = await client.sync({ initial: true })
+  t.ok(response.entries, 'entries')
+  t.ok(response.assets, 'assets')
+  t.ok(response.deletedEntries, 'deleted entries')
+  t.ok(response.deletedAssets, 'deleted assets')
+  t.ok(response.nextSyncToken, 'next sync token')
+  t.equal(response.entries[0].fields.image['en-US'].sys.type, 'Asset', 'links are resolved')
 })
 
-test('Sync space with token', (t) => {
+test('Sync space with token', async (t) => {
   t.plan(5)
-  return client.sync({ nextSyncToken: 'w5ZGw6JFwqZmVcKsE8Kow4grw45QdybDsm4DWMK6OVYsSsOJwqPDksOVFXUFw54Hw65Tw6MAwqlWw5QkdcKjwqrDlsOiw4zDolvDq8KRRwUVBn3CusK6wpB3w690w6vDtMKkwrHDmsKSwobCuMKww57Cl8OGwp_Dq1QZCA' })
-    .then((response) => {
-      t.ok(response.entries, 'entries')
-      t.ok(response.assets, 'assets')
-      t.ok(response.deletedEntries, 'deleted entries')
-      t.ok(response.deletedAssets, 'deleted assets')
-      t.ok(response.nextSyncToken, 'next sync token')
-    })
+  const response = await client.sync({ nextSyncToken: 'w5ZGw6JFwqZmVcKsE8Kow4grw45QdybDsm4DWMK6OVYsSsOJwqPDksOVFXUFw54Hw65Tw6MAwqlWw5QkdcKjwqrDlsOiw4zDolvDq8KRRwUVBn3CusK6wpB3w690w6vDtMKkwrHDmsKSwobCuMKww57Cl8OGwp_Dq1QZCA' })
+  t.ok(response.entries, 'entries')
+  t.ok(response.assets, 'assets')
+  t.ok(response.deletedEntries, 'deleted entries')
+  t.ok(response.deletedAssets, 'deleted assets')
+  t.ok(response.nextSyncToken, 'next sync token')
 })
 
-test('Sync spaces assets', (t) => {
+test('Sync spaces assets', async (t) => {
   t.plan(4)
-  return client.sync({ initial: true, type: 'Asset' })
-    .then((response) => {
-      t.ok(response.assets, 'assets')
-      t.ok(response.assets[0].toPlainObject, 'toPlainObject exists on asset')
-      t.ok(response.deletedAssets, 'deleted assets')
-      t.ok(response.nextSyncToken, 'next sync token')
-    })
+  const response = await client.sync({ initial: true, type: 'Asset' })
+  t.ok(response.assets, 'assets')
+  t.ok(response.assets[0].toPlainObject, 'toPlainObject exists on asset')
+  t.ok(response.deletedAssets, 'deleted assets')
+  t.ok(response.nextSyncToken, 'next sync token')
 })
 
-test('Sync space entries by content type', (t) => {
+test('Sync space entries by content type', async (t) => {
   t.plan(4)
-  return client.sync({ initial: true, type: 'Entry', content_type: 'dog' })
-    .then((response) => {
-      t.ok(response.entries, 'entries')
-      t.ok(response.entries[0].toPlainObject, 'toPlainObject exists on entry')
-      t.ok(response.deletedEntries, 'deleted entries')
-      t.ok(response.nextSyncToken, 'next sync token')
-    })
+  const response = await client.sync({ initial: true, type: 'Entry', content_type: 'dog' })
+  t.ok(response.entries, 'entries')
+  t.ok(response.entries[0].toPlainObject, 'toPlainObject exists on entry')
+  t.ok(response.deletedEntries, 'deleted entries')
+  t.ok(response.nextSyncToken, 'next sync token')
 })
 
-test('Gets entries with linked includes with locale:*', (t) => {
+test('Gets entries with linked includes with locale:*', async (t) => {
   t.plan(5)
-  return client.getEntries({ locale: '*', include: 5, 'sys.id': 'nyancat' })
-    .then((response) => {
-      t.ok(response.includes, 'includes')
-      t.ok(response.includes.Asset, 'includes for Assets from preview endpoint')
-      t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items from preview endpoint')
-      t.ok(response.items[0].fields.bestFriend['en-US'].fields, 'resolved entry has fields from preview endpoint')
-      t.equal(response.items[0].fields.bestFriend['en-US'].sys.type, 'Entry', 'entry gets resolved from other entries in collection from preview endpoint')
-    })
+  const response = await client.getEntries({ locale: '*', include: 5, 'sys.id': 'nyancat' })
+  t.ok(response.includes, 'includes')
+  t.ok(response.includes.Asset, 'includes for Assets from preview endpoint')
+  t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items from preview endpoint')
+  t.ok(response.items[0].fields.bestFriend['en-US'].fields, 'resolved entry has fields from preview endpoint')
+  t.equal(response.items[0].fields.bestFriend['en-US'].sys.type, 'Entry', 'entry gets resolved from other entries in collection from preview endpoint')
 })
 
-test('Gets entries with linked includes with local:* in preview', (t) => {
+test('Gets entries with linked includes with local:* in preview', async (t) => {
   t.plan(5)
-  return previewClient.getEntries({ locale: '*', include: 5, 'sys.id': 'nyancat' })
-    .then((response) => {
-      t.ok(response.includes, 'includes')
-      t.ok(response.includes.Asset, 'includes for Assets from preview endpoint')
-      t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items from preview endpoint')
-      t.ok(response.items[0].fields.bestFriend['en-US'].fields, 'resolved entry has fields from preview endpoint')
-      t.equal(response.items[0].fields.bestFriend['en-US'].sys.type, 'Entry', 'entry gets resolved from other entries in collection from preview endpoint')
-    })
+  const response = await previewClient.getEntries({ locale: '*', include: 5, 'sys.id': 'nyancat' })
+  t.ok(response.includes, 'includes')
+  t.ok(response.includes.Asset, 'includes for Assets from preview endpoint')
+  t.ok(Object.keys(response.includes.Asset).length > 0, 'list of includes has asset items from preview endpoint')
+  t.ok(response.items[0].fields.bestFriend['en-US'].fields, 'resolved entry has fields from preview endpoint')
+  t.equal(response.items[0].fields.bestFriend['en-US'].sys.type, 'Entry', 'entry gets resolved from other entries in collection from preview endpoint')
 })
 
-test('Logs request and response with custom loggers', (t) => {
+test('Logs request and response with custom loggers', async (t) => {
   t.plan(4)
 
-  return clientWithLoggers.getEntries()
-    .then(() => {
-      t.equal(responseLoggerStub.callCount, 1, 'responseLogger is called')
-      t.equal(requestLoggerStub.callCount, 1, 'requestLogger is called')
-      t.equal(requestLoggerStub.args[0][0].baseURL, 'https://cdn.contentful.com:443/spaces/ezs1swce23xe/environments/master', 'requestLogger is called with correct base url')
-      t.equal(requestLoggerStub.args[0][0].url, 'entries', 'requestLogger is called with correct url')
-    })
+  await clientWithLoggers.getEntries()
+  t.equal(responseLoggerStub.callCount, 1, 'responseLogger is called')
+  t.equal(requestLoggerStub.callCount, 1, 'requestLogger is called')
+  t.equal(requestLoggerStub.args[0][0].baseURL, 'https://cdn.contentful.com:443/spaces/ezs1swce23xe/environments/master', 'requestLogger is called with correct base url')
+  t.equal(requestLoggerStub.args[0][0].url, 'entries', 'requestLogger is called with correct url')
 })

--- a/test/runner
+++ b/test/runner
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+require('regenerator-runtime/runtime')
 require('@babel/register')({
   ignore: [/node_modules(?!\/contentful-resolve-response)/]
 })

--- a/test/runner-browser.js
+++ b/test/runner-browser.js
@@ -4,6 +4,9 @@ require('core-js/es/object/assign')
 require('core-js/es/array/from')
 require('core-js/es/array/find')
 require('core-js/es/set')
+require('core-js/stable')
+
+require('regenerator-runtime/runtime')
 
 // This file is required due to an issue with karma-tap
 // https://github.com/tmcw-up-for-adoption/karma-tap/issues/10

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -54,7 +54,7 @@ function teardown () {
   createContentfulApiRewireApi.__ResetDependency__('entities')
 }
 
-test('API call getSpace', (t) => {
+test('API call getSpace', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -69,14 +69,15 @@ test('API call getSpace', (t) => {
   })
   entitiesMock.space.wrapSpace.returns(data)
 
-  return api.getSpace('spaceid')
-    .then((r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    const r = await api.getSpace('spaceid')
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getSpace fails', (t) => {
+test('API call getSpace fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -90,29 +91,31 @@ test('API call getSpace fails', (t) => {
   })
   entitiesMock.space.wrapSpace.returns(data)
 
-  return api.getSpace('spaceid')
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getSpace('spaceid')
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getContentType', (t) => {
+test('API call getContentType', async (t) => {
   t.plan(1)
   const { api } = setupWithData({
     promise: Promise.resolve({ data: contentTypeMock })
   })
   entitiesMock.contentType.wrapContentType.returns(contentTypeMock)
 
-  return api.getContentType('ctid')
-    .then((r) => {
-      t.looseEqual(r, contentTypeMock)
-      teardown()
-    })
+  try {
+    const r = await api.getContentType('ctid')
+    t.looseEqual(r, contentTypeMock)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getContentType fails', (t) => {
+test('API call getContentType fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -126,15 +129,16 @@ test('API call getContentType fails', (t) => {
   })
   entitiesMock.contentType.wrapContentType.returns(data)
 
-  return api.getContentType('ctid')
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getContentType('ctid')
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getContentTypes', (t) => {
+test('API call getContentTypes', async (t) => {
   t.plan(1)
   const data = {
     total: 100,
@@ -147,14 +151,15 @@ test('API call getContentTypes', (t) => {
   })
   entitiesMock.contentType.wrapContentTypeCollection.returns(data)
 
-  return api.getContentTypes()
-    .then((r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    const r = await api.getContentTypes()
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getContentTypes fails', (t) => {
+test('API call getContentTypes fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -168,15 +173,16 @@ test('API call getContentTypes fails', (t) => {
   })
   entitiesMock.contentType.wrapContentTypeCollection.returns(data)
 
-  return api.getContentTypes()
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getContentTypes()
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntry', (t) => {
+test('API call getEntry', async (t) => {
   t.plan(2)
   const { api } = setupWithData({
     promise: Promise.resolve({ data: entryMock })
@@ -184,15 +190,16 @@ test('API call getEntry', (t) => {
   api.getEntries = sinon.stub().resolves({ items: [entryMock] })
   entitiesMock.entry.wrapEntry.returns(entryMock)
 
-  return api.getEntry('eid')
-    .then((r) => {
-      t.looseEqual(r, entryMock)
-      t.true(api.getEntries.calledOnce)
-      teardown()
-    })
+  try {
+    const r = await api.getEntry('eid')
+    t.looseEqual(r, entryMock)
+    t.true(api.getEntries.calledOnce)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntry fails', (t) => {
+test('API call getEntry fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -206,15 +213,16 @@ test('API call getEntry fails', (t) => {
   })
   entitiesMock.entry.wrapEntry.returns(data)
 
-  return api.getEntry('eid')
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getEntry('eid')
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntries', (t) => {
+test('API call getEntries', async (t) => {
   t.plan(2)
 
   const data = {
@@ -229,15 +237,16 @@ test('API call getEntries', (t) => {
   })
   entitiesMock.entry.wrapEntryCollection.returns(data)
 
-  return api.getEntries()
-    .then((r) => {
-      t.ok(entitiesMock.entry.wrapEntryCollection.args[0][1], 'resolveLinks turned on by default')
-      t.looseEqual(r, data, 'returns expected data')
-      teardown()
-    })
+  try {
+    const r = await api.getEntries()
+    t.ok(entitiesMock.entry.wrapEntryCollection.args[0][1], 'resolveLinks turned on by default')
+    t.looseEqual(r, data, 'returns expected data')
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntries with global resolve links overriden by query', (t) => {
+test('API call getEntries with global resolve links overriden by query', async (t) => {
   t.plan(1)
 
   const data = { sys: { id: 'id' } }
@@ -248,14 +257,15 @@ test('API call getEntries with global resolve links overriden by query', (t) => 
   })
   entitiesMock.entry.wrapEntryCollection.returns(data)
 
-  return api.getEntries({ resolveLinks: true })
-    .then((r) => {
-      t.ok(entitiesMock.entry.wrapEntryCollection.args[0][1].resolveLinks, 'resolveLinks turned off globally')
-      teardown()
-    })
+  try {
+    await api.getEntries({ resolveLinks: true })
+    t.ok(entitiesMock.entry.wrapEntryCollection.args[0][1].resolveLinks, 'resolveLinks turned off globally')
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntries with global resolve links turned off', (t) => {
+test('API call getEntries with global resolve links turned off', async (t) => {
   t.plan(2)
 
   const data = { sys: { id: 'id' } }
@@ -266,15 +276,16 @@ test('API call getEntries with global resolve links turned off', (t) => {
   })
   entitiesMock.entry.wrapEntryCollection.returns(data)
 
-  return api.getEntries()
-    .then((r) => {
-      t.notOk(entitiesMock.entry.wrapEntryCollection.args[0][1].resolveLinks, 'resolveLinks turned off globally')
-      t.looseEqual(r, data, 'returns expected data')
-      teardown()
-    })
+  try {
+    const r = await api.getEntries()
+    t.notOk(entitiesMock.entry.wrapEntryCollection.args[0][1].resolveLinks, 'resolveLinks turned off globally')
+    t.looseEqual(r, data, 'returns expected data')
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getEntries fails', (t) => {
+test('API call getEntries fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -288,29 +299,31 @@ test('API call getEntries fails', (t) => {
   })
   entitiesMock.entry.wrapEntryCollection.returns(data)
 
-  return api.getEntries()
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getEntries()
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getAsset', (t) => {
+test('API call getAsset', async (t) => {
   t.plan(1)
   const { api } = setupWithData({
     promise: Promise.resolve({ data: assetMock })
   })
   entitiesMock.asset.wrapAsset.returns(assetMock)
 
-  return api.getAsset('aid')
-    .then((r) => {
-      t.looseEqual(r, assetMock)
-      teardown()
-    })
+  try {
+    const r = await api.getAsset('aid')
+    t.looseEqual(r, assetMock)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getAsset fails', (t) => {
+test('API call getAsset fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -324,15 +337,16 @@ test('API call getAsset fails', (t) => {
   })
   entitiesMock.asset.wrapAsset.returns(data)
 
-  return api.getAsset('aid')
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getAsset('aid')
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getAssets', (t) => {
+test('API call getAssets', async (t) => {
   t.plan(1)
   const data = {
     total: 100,
@@ -345,14 +359,15 @@ test('API call getAssets', (t) => {
   })
   entitiesMock.asset.wrapAssetCollection.returns(data)
 
-  return api.getAssets()
-    .then((r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    const r = await api.getAssets()
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getAssets fails', (t) => {
+test('API call getAssets fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -366,15 +381,16 @@ test('API call getAssets fails', (t) => {
   })
   entitiesMock.asset.wrapAssetCollection.returns(data)
 
-  return api.getAssets()
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getAssets()
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getLocales', (t) => {
+test('API call getLocales', async (t) => {
   t.plan(1)
   const data = {
     total: 100,
@@ -387,14 +403,15 @@ test('API call getLocales', (t) => {
   })
   entitiesMock.locale.wrapLocaleCollection.returns(data)
 
-  return api.getLocales()
-    .then((r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    const r = await api.getLocales()
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('API call getLocaless fails', (t) => {
+test('API call getLocaless fails', async (t) => {
   t.plan(1)
   const data = {
     sys: {
@@ -408,15 +425,16 @@ test('API call getLocaless fails', (t) => {
   })
   entitiesMock.locale.wrapLocaleCollection.returns(data)
 
-  return api.getLocales()
-    .then(() => {
-    }, (r) => {
-      t.looseEqual(r, data)
-      teardown()
-    })
+  try {
+    await api.getLocales()
+  } catch (r) {
+    t.looseEqual(r, data)
+  } finally {
+    teardown()
+  }
 })
 
-test('CDA call sync', (t) => {
+test('CDA call sync', async (t) => {
   t.plan(5)
   const { api } = setupWithData({
     promise: Promise.resolve({
@@ -427,30 +445,32 @@ test('CDA call sync', (t) => {
     })
   })
 
-  return api.sync({ initial: true })
-    .then((r) => {
-      t.ok(r.entries, 'entries')
-      t.ok(r.assets, 'assets')
-      t.ok(r.deletedEntries, 'deletedEntries')
-      t.ok(r.deletedAssets, 'deletedAssets')
-      t.equal(r.nextSyncToken, 'thisisthesynctoken', 'sync token')
-      teardown()
-    })
+  try {
+    const r = await api.sync({ initial: true })
+    t.ok(r.entries, 'entries')
+    t.ok(r.assets, 'assets')
+    t.ok(r.deletedEntries, 'deletedEntries')
+    t.ok(r.deletedAssets, 'deletedAssets')
+    t.equal(r.nextSyncToken, 'thisisthesynctoken', 'sync token')
+  } finally {
+    teardown()
+  }
 })
 
-test('CDA call sync fails', (t) => {
+test('CDA call sync fails', async (t) => {
   t.plan(1)
   const rejectError = new Error()
   rejectError.data = 'error'
   const { api } = setupWithData({
     promise: Promise.reject(rejectError)
   })
-  return api.sync({ initial: true })
-    .then(() => {
-    }, (r) => {
-      t.equal(r.data, 'error')
-      teardown()
-    })
+  try {
+    await api.sync({ initial: true })
+  } catch (r) {
+    t.equal(r.data, 'error')
+  } finally {
+    teardown()
+  }
 })
 
 test('Given json should be parsed correctly as a collection of entries', (t) => {

--- a/test/unit/paged-sync-test.js
+++ b/test/unit/paged-sync-test.js
@@ -23,27 +23,26 @@ function createAsset (id, deleted) {
   return asset
 }
 
-test('Throws with no parameters', (t) => {
+test('Rejects with no parameters', (t) => {
   t.plan(1)
   const http = { get: sinon.stub() }
-  t.throws(() => {
+  t.shouldFail(
     pagedSync(http, {}, { resolveLinks: true })
-  }, /initial.*nextSyncToken/)
+    , /initial.*nextSyncToken/)
 })
 
-test('Throws with incompatible content_type and type parameter', (t) => {
+test('Rejects with incompatible content_type and type parameter', (t) => {
   t.plan(1)
   const http = { get: sinon.stub() }
-  t.throws(() => {
-    pagedSync(http, {
-      initial: true,
-      content_type: 'id',
-      type: 'ContentType'
-    }, { resolveLinks: true })
-  }, /content_type.*type.*Entry/)
+  t.shouldFail(pagedSync(http, {
+    initial: true,
+    content_type: 'id',
+    type: 'ContentType'
+  }, { resolveLinks: true })
+  , /content_type.*type.*Entry/)
 })
 
-test('Returns empty response if response has no items', (t) => {
+test('Returns empty response if response has no items', async (t) => {
   t.plan(4)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', {
@@ -56,16 +55,14 @@ test('Returns empty response if response has no items', (t) => {
     } // no items returned
   }))
 
-  return pagedSync(http, { initial: true }, { resolveLinks: true })
-    .then(response => {
-      t.deepEqual(response.entries, [])
-      t.deepEqual(response.assets, [])
-      t.deepEqual(response.deletedEntries, [])
-      t.deepEqual(response.deletedAssets, [])
-    })
+  const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
+  t.deepEqual(response.entries, [])
+  t.deepEqual(response.assets, [])
+  t.deepEqual(response.deletedEntries, [])
+  t.deepEqual(response.deletedAssets, [])
 })
 
-test('Returns empty response if response is empty', (t) => {
+test('Returns empty response if response is empty', async (t) => {
   t.plan(4)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', {
@@ -74,16 +71,14 @@ test('Returns empty response if response is empty', (t) => {
     }
   }).returns(Promise.resolve({}))
 
-  return pagedSync(http, { initial: true }, { resolveLinks: true })
-    .then(response => {
-      t.deepEqual(response.entries, [])
-      t.deepEqual(response.assets, [])
-      t.deepEqual(response.deletedEntries, [])
-      t.deepEqual(response.deletedAssets, [])
-    })
+  const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
+  t.deepEqual(response.entries, [])
+  t.deepEqual(response.assets, [])
+  t.deepEqual(response.deletedEntries, [])
+  t.deepEqual(response.deletedAssets, [])
 })
 
-test('Initial sync with one page', (t) => {
+test('Initial sync with one page', async (t) => {
   t.plan(11)
   const http = { get: sinon.stub() }
   const entryWithLink = createEntry('1')
@@ -111,23 +106,21 @@ test('Initial sync with one page', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true }, { resolveLinks: true })
-    .then((response) => {
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(response.entries.length, 3, 'entries length')
-      t.ok(response.entries[0].toPlainObject, 'toPlainObject on entry')
-      t.equal(response.deletedEntries.length, 2, 'deleted entries length')
-      t.ok(response.deletedEntries[0].toPlainObject, 'toPlainObject on deletedEntry')
-      t.equal(response.assets.length, 3, 'entries length')
-      t.ok(response.assets[0].toPlainObject, 'toPlainObject on asset')
-      t.equal(response.deletedAssets.length, 1, 'deleted assets length')
-      t.ok(response.deletedAssets[0].toPlainObject, 'toPlainObject on deletedAsset')
-      t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-      t.equal(response.entries[0].fields.linked.sys.type, 'Entry', 'linked entry is resolved')
-    })
+  const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(response.entries.length, 3, 'entries length')
+  t.ok(response.entries[0].toPlainObject, 'toPlainObject on entry')
+  t.equal(response.deletedEntries.length, 2, 'deleted entries length')
+  t.ok(response.deletedEntries[0].toPlainObject, 'toPlainObject on deletedEntry')
+  t.equal(response.assets.length, 3, 'entries length')
+  t.ok(response.assets[0].toPlainObject, 'toPlainObject on asset')
+  t.equal(response.deletedAssets.length, 1, 'deleted assets length')
+  t.ok(response.deletedAssets[0].toPlainObject, 'toPlainObject on deletedAsset')
+  t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
+  t.equal(response.entries[0].fields.linked.sys.type, 'Entry', 'linked entry is resolved')
 })
 
-test('Initial sync with one page and filter', (t) => {
+test('Initial sync with one page and filter', async (t) => {
   t.plan(5)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', {
@@ -147,17 +140,15 @@ test('Initial sync with one page and filter', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true, content_type: 'cat' }, { resolveLinks: true })
-    .then((response) => {
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(http.get.args[0][1].params.content_type, 'cat', 'http request has content type filter param')
-      t.equal(http.get.args[0][1].params.type, 'Entry', 'http request has entity type filter param')
-      t.equal(response.entries.length, 3, 'entries length')
-      t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-    })
+  const response = await pagedSync(http, { initial: true, content_type: 'cat' }, { resolveLinks: true })
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(http.get.args[0][1].params.content_type, 'cat', 'http request has content type filter param')
+  t.equal(http.get.args[0][1].params.type, 'Entry', 'http request has entity type filter param')
+  t.equal(response.entries.length, 3, 'entries length')
+  t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
 })
 
-test('Initial sync with one page and limit', (t) => {
+test('Initial sync with one page and limit', async (t) => {
   t.plan(4)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', {
@@ -176,16 +167,14 @@ test('Initial sync with one page and limit', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true, limit: 10 }, { resolveLinks: true })
-    .then((response) => {
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
-      t.equal(response.entries.length, 3, 'entries length')
-      t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-    })
+  const response = await pagedSync(http, { initial: true, limit: 10 }, { resolveLinks: true })
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
+  t.equal(response.entries.length, 3, 'entries length')
+  t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
 })
 
-test('Initial sync with multiple pages', (t) => {
+test('Initial sync with multiple pages', async (t) => {
   t.plan(12)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', { params: { initial: true, type: 'Entries' } }).returns(Promise.resolve({
@@ -221,25 +210,23 @@ test('Initial sync with multiple pages', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true, type: 'Entries' }, { resolveLinks: true })
-    .then((response) => {
-      const objResponse = response.toPlainObject()
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-      t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
-      t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
-      t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
-      t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
-      t.equal(objResponse.entries.length, 3, 'entries length')
-      t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
-      t.equal(objResponse.assets.length, 3, 'entries length')
-      t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
-      t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
-      t.ok(response.stringifySafe(), 'stringifies response')
-    })
+  const response = await pagedSync(http, { initial: true, type: 'Entries' }, { resolveLinks: true })
+  const objResponse = response.toPlainObject()
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
+  t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
+  t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
+  t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
+  t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
+  t.equal(objResponse.entries.length, 3, 'entries length')
+  t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
+  t.equal(objResponse.assets.length, 3, 'entries length')
+  t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
+  t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
+  t.ok(response.stringifySafe(), 'stringifies response')
 })
 
-test('Initial sync with limit and multiple pages', (t) => {
+test('Initial sync with limit and multiple pages', async (t) => {
   t.plan(14)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', { params: { initial: true, limit: 10, type: 'Entries' } }).returns(Promise.resolve({
@@ -275,27 +262,25 @@ test('Initial sync with limit and multiple pages', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true, limit: 10, type: 'Entries' }, { resolveLinks: true })
-    .then((response) => {
-      const objResponse = response.toPlainObject()
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
-      t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-      t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
-      t.notOk(http.get.args[1][1].params.limit, 'second http request does not have limit param')
-      t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
-      t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
-      t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
-      t.equal(objResponse.entries.length, 3, 'entries length')
-      t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
-      t.equal(objResponse.assets.length, 3, 'entries length')
-      t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
-      t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
-      t.ok(response.stringifySafe(), 'stringifies response')
-    })
+  const response = await pagedSync(http, { initial: true, limit: 10, type: 'Entries' }, { resolveLinks: true })
+  const objResponse = response.toPlainObject()
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
+  t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
+  t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
+  t.notOk(http.get.args[1][1].params.limit, 'second http request does not have limit param')
+  t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
+  t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
+  t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
+  t.equal(objResponse.entries.length, 3, 'entries length')
+  t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
+  t.equal(objResponse.assets.length, 3, 'entries length')
+  t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
+  t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
+  t.ok(response.stringifySafe(), 'stringifies response')
 })
 
-test('Sync with existing token', (t) => {
+test('Sync with existing token', async (t) => {
   t.plan(6)
   const http = { get: sinon.stub() }
   http.get.withArgs('sync', { params: { sync_token: 'nextsynctoken' } }).returns(Promise.resolve({
@@ -310,18 +295,16 @@ test('Sync with existing token', (t) => {
     }
   }))
 
-  return pagedSync(http, { nextSyncToken: 'nextsynctoken' }, { resolveLinks: true })
-    .then((response) => {
-      t.equal(http.get.args[0][1].params.sync_token, 'nextsynctoken', 'http request param for sync')
-      t.equal(response.entries.length, 1, 'entries length')
-      t.equal(response.deletedEntries.length, 1, 'deleted entries length')
-      t.equal(response.assets.length, 1, 'entries length')
-      t.equal(response.deletedAssets.length, 1, 'deleted assets length')
-      t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-    })
+  const response = await pagedSync(http, { nextSyncToken: 'nextsynctoken' }, { resolveLinks: true })
+  t.equal(http.get.args[0][1].params.sync_token, 'nextsynctoken', 'http request param for sync')
+  t.equal(response.entries.length, 1, 'entries length')
+  t.equal(response.deletedEntries.length, 1, 'deleted entries length')
+  t.equal(response.assets.length, 1, 'entries length')
+  t.equal(response.deletedAssets.length, 1, 'deleted assets length')
+  t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
 })
 
-test('Initial sync with multiple pages but pagination disabled', (t) => {
+test('Initial sync with multiple pages but pagination disabled', async (t) => {
   t.plan(18)
 
   const http = { get: sinon.stub() }
@@ -358,38 +341,32 @@ test('Initial sync with multiple pages but pagination disabled', (t) => {
     }
   }))
 
-  return pagedSync(http, { initial: true, type: 'Entries' }, { paginate: false })
-    .then((response) => {
-      const objResponse = response.toPlainObject()
-      t.equal(http.get.callCount, 1, 'only one request was sent')
-      t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-      t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-      t.equal(objResponse.entries.length, 2, 'entries length')
-      t.equal(objResponse.deletedEntries.length, 0, 'deleted entries length')
-      t.equal(objResponse.assets.length, 0, 'entries length')
-      t.equal(objResponse.deletedAssets.length, 0, 'deleted assets length')
-      t.equal(objResponse.nextPageToken, 'nextpage1', 'next page token')
-      t.notOk(objResponse.nextSyncToken, 'next sync token should not exist')
-      t.ok(response.stringifySafe(), 'stringifies response')
+  const response = await pagedSync(http, { initial: true, type: 'Entries' }, { paginate: false })
+  const objResponse = response.toPlainObject()
+  t.equal(http.get.callCount, 1, 'only one request was sent')
+  t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
+  t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
+  t.equal(objResponse.entries.length, 2, 'entries length')
+  t.equal(objResponse.deletedEntries.length, 0, 'deleted entries length')
+  t.equal(objResponse.assets.length, 0, 'entries length')
+  t.equal(objResponse.deletedAssets.length, 0, 'deleted assets length')
+  t.equal(objResponse.nextPageToken, 'nextpage1', 'next page token')
+  t.notOk(objResponse.nextSyncToken, 'next sync token should not exist')
+  t.ok(response.stringifySafe(), 'stringifies response')
 
-      // Manually sync next page
-      return pagedSync(http, { nextPageToken: objResponse.nextPageToken }, { paginate: false })
-    })
-    .then((response) => {
-      const objResponse = response.toPlainObject()
-      t.equal(http.get.callCount, 2, 'second request was sent and no pagination happened')
-      t.notOk(http.get.args[1][1].params.initial, 'http request does not have initial param')
-      t.equal(objResponse.nextPageToken, 'nextpage2', 'next page token')
-      t.notOk(objResponse.nextSyncToken, 'next sync token should not exist')
+  // Manually sync next page
+  const response2 = await pagedSync(http, { nextPageToken: objResponse.nextPageToken }, { paginate: false })
+  const objResponse2 = response2.toPlainObject()
+  t.equal(http.get.callCount, 2, 'second request was sent and no pagination happened')
+  t.notOk(http.get.args[1][1].params.initial, 'http request does not have initial param')
+  t.equal(objResponse2.nextPageToken, 'nextpage2', 'next page token')
+  t.notOk(objResponse2.nextSyncToken, 'next sync token should not exist')
 
-      // Manually sync next (last) page
-      return pagedSync(http, { nextPageToken: objResponse.nextPageToken }, { paginate: false })
-    })
-    .then((response) => {
-      const objResponse = response.toPlainObject()
-      t.equal(http.get.callCount, 3, 'third request was sent and no pagination happened')
-      t.notOk(http.get.args[2][1].params.initial, 'http request does not have initial param')
-      t.notOk(objResponse.nextPageToken, 'next page token should not exist')
-      t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
-    })
+  // Manually sync next (last) page
+  const response3 = await pagedSync(http, { nextPageToken: objResponse2.nextPageToken }, { paginate: false })
+  const objResponse3 = response3.toPlainObject()
+  t.equal(http.get.callCount, 3, 'third request was sent and no pagination happened')
+  t.notOk(http.get.args[2][1].params.initial, 'http request does not have initial param')
+  t.notOk(objResponse3.nextPageToken, 'next page token should not exist')
+  t.equal(objResponse3.nextSyncToken, 'nextsynctoken', 'next sync token')
 })


### PR DESCRIPTION
BREAKING CHANGE: Some functions that used to throw synchronously for things like bad parameters now reject the promise.
In many cases users may not have to do anything assuming the calls already happened within a promise chain, but in rare cases this may need some refactoring of error handling cases.
