### PR TITLE
fix: ensure the node bundle uses native async/await

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -34,7 +34,7 @@ var legacyBabelPresetEnvConfig = Object.assign(
 // Node
 var nodeBabelPresetEnvConfig = Object.assign({}, defaultBabelPresetEnvConfig, {
   targets: {
-    node: '4.7'
+    node: '12'
   }
 })
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,18 +1,23 @@
 # Migration information
 
-- [Migration from contentful.js 5.x](#migration-from-contentfuljs-5x)
-- [Migration from contentful.js 4.x](#migration-from-contentfuljs-4x)
-- [Migration from contentful.js 3.x](#migration-from-contentfuljs-3x)
-- [Migration to contentful.js 3.x from previous versions](#migration-to-contentfuljs-3x-from-previous-versions)
-  - [Method renaming](#method-renaming)
-  - [Format of collection replies](#format-of-collection-replies)
-  - [Callback API removal](#callback-api-removal)
-  - [Class removal](#class-removal)
-  - [Link resolution](#link-resolution)
-- [Migration from contentful.js 2.x and older](#migration-from-contentfuljs-2x-and-older)
+- [Migration information](#migration-information)
+  - [Migration from contentful.js 6.x](#migration-from-contentfuljs-6x)
+  - [Migration from contentful.js 5.x](#migration-from-contentfuljs-5x)
+  - [Migration from contentful.js 4.x](#migration-from-contentfuljs-4x)
+  - [Migration from contentful.js 3.x](#migration-from-contentfuljs-3x)
+  - [Migration to contentful.js 3.x from previous versions](#migration-to-contentfuljs-3x-from-previous-versions)
+    - [Method renaming](#method-renaming)
+    - [Format of collection replies](#format-of-collection-replies)
+    - [Callback API removal](#callback-api-removal)
+    - [Class removal](#class-removal)
+    - [Link resolution](#link-resolution)
+  - [Migration from contentful.js 2.x and older](#migration-from-contentfuljs-2x-and-older)
 
 From version 3.0.0 onwards, you can access documentation for a specific version by visiting `https://contentful.github.io/contentful.js/contentful/<VERSION>`
 
+## Migration from contentful.js 6.x
+
+We dropped support for Node v11 and older. Please ensure you are running Node v12 or newer.
 
 ## Migration from contentful.js 5.x
 

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "webpack-cli": "^4.1.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
We bumped the minimum version of Node to v12
This should have happened in the last release already, but was forgotten about.
While v10 is still on  Maintenance LTS, it will be EOL by the end of Q1 2021.
Thus we're jumping directly to v12 - however most likely the library will work perfectly fine also with v10 since currently we are not using any features unique to v12.

Fixes the problem mentioned in https://github.com/contentful/contentful.js/pull/496#issuecomment-738065819
That is, currently any node project would need to use regenerator so we can stay compatible with an ancient node version.
