### PR TITLE
feat: allow arrays for select

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -224,7 +224,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
   async function getEntries (query = {}) {
     switchToEnvironment(http)
     const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
-    normalizeSelect(query)
+    query = normalizeSelect(query)
 
     try {
       const response = await http.get('entries', createRequestConfig({ query: query }))
@@ -252,7 +252,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    */
   async function getAsset (id, query = {}) {
     switchToEnvironment(http)
-    normalizeSelect(query)
+    query = normalizeSelect(query)
 
     try {
       const response = await http.get(`assets/${id}`, createRequestConfig({ query: query }))
@@ -280,7 +280,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    */
   async function getAssets (query = {}) {
     switchToEnvironment(http)
-    normalizeSelect(query)
+    query = normalizeSelect(query)
 
     try {
       const response = await http.get('assets', createRequestConfig({ query: query }))

--- a/lib/utils/normalize-select.js
+++ b/lib/utils/normalize-select.js
@@ -6,19 +6,19 @@
 
 export default function normalizeSelect (query) {
   if (!query.select) {
-    return
+    return query
   }
 
   // The selection of fields for the query is limited
   // Get the different parts that are listed for selection
-  const allSelects = query.select.split(',')
+  const allSelects = Array.isArray(query.select) ? query.select : query.select.split(',')
   // Move the parts into a set for easy access and deduplication
   const selectedSet = new Set(allSelects)
 
   // If we already select all of `sys` we can just return
   // since we're anyway fetching everything that is needed
   if (selectedSet.has('sys')) {
-    return
+    return query
   }
 
   // We don't select `sys` so we need to ensure the minimum set
@@ -26,5 +26,8 @@ export default function normalizeSelect (query) {
   selectedSet.add('sys.type')
 
   // Reassign the normalized sys properties
-  query.select = [...selectedSet].join(',')
+  return {
+    ...query,
+    select: [...selectedSet].join(',')
+  }
 }

--- a/test/unit/utils/normalize-select-test.js
+++ b/test/unit/utils/normalize-select-test.js
@@ -6,9 +6,9 @@ test('normalizeSelect does nothing if sys is selected', (t) => {
     select: 'fields.foo,sys'
   }
 
-  normalizeSelect(query)
+  const normalized = normalizeSelect(query)
 
-  t.equal(query.select, 'fields.foo,sys')
+  t.equal(normalized.select, 'fields.foo,sys')
   t.end()
 })
 
@@ -17,9 +17,10 @@ test('normalizeSelect adds required properties if sys is not selected', (t) => {
     select: 'fields.foo'
   }
 
-  normalizeSelect(query)
+  const normalized = normalizeSelect(query)
 
-  t.equal(query.select, 'fields.foo,sys.id,sys.type')
+  t.equal(normalized.select, 'fields.foo,sys.id,sys.type')
+  t.notEqual(query, normalized)
   t.end()
 })
 
@@ -28,9 +29,10 @@ test('normalizeSelect adds required properties if different sys properties are s
     select: 'fields.foo,sys.createdAt'
   }
 
-  normalizeSelect(query)
+  const normalized = normalizeSelect(query)
 
-  t.equal(query.select, 'fields.foo,sys.createdAt,sys.id,sys.type')
+  t.equal(normalized.select, 'fields.foo,sys.createdAt,sys.id,sys.type')
+  t.notEqual(query, normalized)
   t.end()
 })
 
@@ -39,8 +41,25 @@ test('normalizeSelect adds required properties if only some required sys propert
     select: 'fields.foo,sys.type'
   }
 
-  normalizeSelect(query)
+  const normalized = normalizeSelect(query)
 
-  t.equal(query.select, 'fields.foo,sys.type,sys.id')
+  t.equal(normalized.select, 'fields.foo,sys.type,sys.id')
+  t.notEqual(query, normalized)
+
+  t.end()
+})
+
+test('normalizeSelect supports arrays but normalizes to strings', (t) => {
+  const query = {
+    select: [
+      'fields.foo',
+      'sys.type'
+    ]
+  }
+
+  const normalized = normalizeSelect(query)
+
+  t.equal(normalized.select, 'fields.foo,sys.type,sys.id')
+  t.notEqual(query, normalized)
   t.end()
 })


### PR DESCRIPTION
Previously we did not officially, support arrays for the select operator, though it would sometimes work nonetheless.
This change ensures that we do support arrays and that they too are normalized properly.
Additionally, we stop mutating the query object in the select normalization and always return a copy.

Fixes https://github.com/contentful/contentful.js/issues/503