### PR TITLE
feat(api): migrate sync

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -5,8 +5,8 @@
  * @see Entities
  */
 
-import { createRequestConfig } from 'contentful-sdk-core'
-import { AxiosInstance } from 'contentful-sdk-core/dist/types/types'
+import {createRequestConfig} from 'contentful-sdk-core'
+import {AxiosInstance} from 'contentful-sdk-core/dist/types/types'
 import {
   Asset,
   AssetCollection,
@@ -16,7 +16,7 @@ import {
   EntryCollection, LocaleCollection,
   Space, SyncCollection
 } from './common-types'
-import { GetGlobalOptions } from './create-global-options'
+import {GetGlobalOptions} from './create-global-options'
 import pagedSync from './paged-sync'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
@@ -80,13 +80,13 @@ class NotFoundError extends Error {
   }
 }
 
-export default function createContentfulApi ({ http, getGlobalOptions }:CreateContentfulApiParams): ContentfulClientApi {
+export default function createContentfulApi({http, getGlobalOptions}: CreateContentfulApiParams): ContentfulClientApi {
   const notFoundError = (id: string = 'unknown') => {
     return new NotFoundError(id, getGlobalOptions().environment, getGlobalOptions().space)
   }
 
   // eslint-disable-next-line no-undef
-  function errorHandler (error): never {
+  function errorHandler(error): never {
     if (error.data) {
       throw error.data
     }
@@ -104,7 +104,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
     config?: any;
   }
 
-  async function get<T> ({ context, path, config }: GetConfig): Promise<T> {
+  async function get<T>({context, path, config}: GetConfig): Promise<T> {
     let baseUrl = context === 'space'
       ? getGlobalOptions().spaceBaseUrl
       : getGlobalOptions().environmentBaseUrl
@@ -140,8 +140,8 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const space = await client.getSpace()
    * console.log(space)
    */
-  async function getSpace (): Promise<Space> {
-    return get<Space>({ context: 'space', path: '' })
+  async function getSpace(): Promise<Space> {
+    return get<Space>({context: 'space', path: ''})
   }
 
   /**
@@ -160,7 +160,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const contentType = await client.getContentType('<content_type_id>')
    * console.log(contentType)
    */
-  async function getContentType (id: string): Promise<ContentType> {
+  async function getContentType(id: string): Promise<ContentType> {
     return get<ContentType>({
       context: 'environment',
       path: `content_types/${id}`
@@ -183,11 +183,11 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const response = await client.getContentTypes()
    * console.log(response.items)
    */
-  async function getContentTypes (query = {}): Promise<ContentTypeCollection> {
+  async function getContentTypes(query = {}): Promise<ContentTypeCollection> {
     return get<ContentTypeCollection>({
       context: 'environment',
       path: 'content_types',
-      config: createRequestConfig({ query: query })
+      config: createRequestConfig({query: query})
     })
   }
 
@@ -208,12 +208,12 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const entry = await client.getEntry('<entry_id>')
    * console.log(entry)
    */
-  async function getEntry<T> (id: string, query = {}): Promise<Entry<T>> {
+  async function getEntry<T>(id: string, query = {}): Promise<Entry<T>> {
     if (!id) {
       throw notFoundError(id)
     }
     try {
-      const response = await this.getEntries({ 'sys.id': id, ...query })
+      const response = await this.getEntries({'sys.id': id, ...query})
       if (response.items.length > 0) {
         return response.items[0]
       } else {
@@ -240,15 +240,15 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const response = await client.getEntries()
    * .console.log(response.items)
    */
-  async function getEntries<T> (query = {}): Promise<EntryCollection<T>> {
-    const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
+  async function getEntries<T>(query = {}): Promise<EntryCollection<T>> {
+    const {resolveLinks, removeUnresolved} = getGlobalOptions(query)
     try {
       const entries = await get({
         context: 'environment',
         path: 'entries',
-        config: createRequestConfig({ query: normalizeSelect(query) })
+        config: createRequestConfig({query: normalizeSelect(query)})
       })
-      return resolveCircular(entries, { resolveLinks, removeUnresolved })
+      return resolveCircular(entries, {resolveLinks, removeUnresolved})
     } catch (error) {
       errorHandler(error)
     }
@@ -271,11 +271,11 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const asset = await client.getAsset('<asset_id>')
    * console.log(asset)
    */
-  async function getAsset (id: string, query = {}): Promise<Asset> {
+  async function getAsset(id: string, query = {}): Promise<Asset> {
     return get<Asset>({
       context: 'environment',
       path: `assets/${id}`,
-      config: createRequestConfig({ query: normalizeSelect(query) })
+      config: createRequestConfig({query: normalizeSelect(query)})
     })
   }
 
@@ -295,11 +295,11 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const response = await client.getAssets()
    * console.log(response.items)
    */
-  async function getAssets (query = {}): Promise<AssetCollection> {
+  async function getAssets(query = {}): Promise<AssetCollection> {
     return get<AssetCollection>({
       context: 'environment',
       path: 'assets',
-      config: createRequestConfig({ query: normalizeSelect(query) })
+      config: createRequestConfig({query: normalizeSelect(query)})
     })
   }
 
@@ -319,11 +319,11 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * const response = await client.getLocales()
    * console.log(response.items)
    */
-  async function getLocales (query = {}): Promise<LocaleCollection> {
+  async function getLocales(query = {}): Promise<LocaleCollection> {
     return get<LocaleCollection>({
       context: 'environment',
       path: 'locales',
-      config: createRequestConfig({ query: normalizeSelect(query) })
+      config: createRequestConfig({query: normalizeSelect(query)})
     })
   }
 
@@ -360,10 +360,10 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    *   nextSyncToken: response.nextSyncToken
    * })
    */
-  async function sync (query = {}, options = { paginate: true }) {
-    const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
-    switchToEnvironment(http)
-    return pagedSync(http, query, { resolveLinks, removeUnresolved, ...options })
+  async function sync(query = {}, options = {paginate: true}) {
+    const {resolveLinks, removeUnresolved} = getGlobalOptions(query)
+    const httpClone = http.cloneWithNewParams({baseURL: getGlobalOptions().environmentBaseUrl});
+    return pagedSync(httpClone, query, {resolveLinks, removeUnresolved, ...options})
   }
 
   /**
@@ -396,16 +396,9 @@ export default function createContentfulApi ({ http, getGlobalOptions }:CreateCo
    * let parsedData = client.parseEntries(data);
    * console.log( parsedData.items[0].fields.foo ); // foo
    */
-  function parseEntries (data) {
-    const { resolveLinks, removeUnresolved } = getGlobalOptions({})
-    return resolveCircular(data, { resolveLinks, removeUnresolved })
-  }
-
-  /*
-   * Switches BaseURL to use /environments path
-   * */
-  function switchToEnvironment (http: AxiosInstance): void {
-    http.defaults.baseURL = getGlobalOptions().environmentBaseUrl
+  function parseEntries(data) {
+    const {resolveLinks, removeUnresolved} = getGlobalOptions({})
+    return resolveCircular(data, {resolveLinks, removeUnresolved})
   }
 
   return {

--- a/lib/paged-sync.ts
+++ b/lib/paged-sync.ts
@@ -4,7 +4,7 @@
  */
 import { createRequestConfig, freezeSys, toPlainObject } from 'contentful-sdk-core'
 import resolveResponse from 'contentful-resolve-response'
-import {AxiosInstance} from "contentful-sdk-core/dist/types/types";
+import {HttpClientInstance} from "./common-types";
 import mixinStringifySafe from './mixins/stringify-safe'
 
 /**
@@ -44,7 +44,7 @@ import mixinStringifySafe from './mixins/stringify-safe'
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<SyncCollection>}
  */
-export default async function pagedSync (http:AxiosInstance, query, options = {}) {
+export default async function pagedSync (http:HttpClientInstance, query, options = {}) {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error('Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing')
   }
@@ -122,7 +122,7 @@ function mapResponseItems (items):any {
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<{items: Array, nextSyncToken: string}>}
  */
-async function getSyncPage (http:AxiosInstance, items, query, { paginate }) {
+async function getSyncPage (http:HttpClientInstance, items, query, { paginate }) {
   if (query.nextSyncToken) {
     query.sync_token = query.nextSyncToken
     delete query.nextSyncToken

--- a/package-lock.json
+++ b/package-lock.json
@@ -4525,6 +4525,18 @@
         }
       }
     },
+    "bunyan": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
+      "integrity": "sha512-LlahJUxXzZLuw/hetUQJmRgZ1LF6+cr5TPpRj6jf327AsiIq2jhYEH4oqUUkVKTor+9w2BT3oxVwhzE5lw9tcg==",
+      "dev": true,
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -5863,6 +5875,16 @@
       "dev": true,
       "requires": {
         "is-obj": "^2.0.0"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "duplexer": {
@@ -10570,6 +10592,173 @@
         }
       }
     },
+    "jest-when": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.0.1.tgz",
+      "integrity": "sha512-JYnqL8dLCztVb4NKBEj+wsPGTLFNgwGlQX2Sq1GNebTQ7j0p23323jcbXGclRLC6T/RoJ+yJdd004WKT+i86VQ==",
+      "dev": true,
+      "requires": {
+        "bunyan": "^1.8.12",
+        "expect": "^24.8.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+          "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.9.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+          "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.1.15",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+          "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.11",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+          "dev": true
+        },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+          "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.9.0"
+          }
+        },
+        "jest-diff": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+          "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+          "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+          "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-regex-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+          "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "jest-worker": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
@@ -11699,6 +11888,13 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true,
+      "optional": true
+    },
     "mri": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
@@ -11716,6 +11912,54 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
     },
     "nan": {
       "version": "2.14.2",
@@ -11753,6 +11997,13 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true,
+      "optional": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -17248,6 +17499,13 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true,
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "husky": "^4.2.3",
     "in-publish": "^2.0.0",
     "istanbul": "^1.0.0-alpha.2",
+    "jest-when": "^3.0.1",
     "jsdoc": "^3.4.0",
     "json": "^10.0.0",
     "mkdirp": "^1.0.3",

--- a/test/unit/create-contentful-api.test.js
+++ b/test/unit/create-contentful-api.test.js
@@ -17,7 +17,11 @@ function setupWithData ({
   const api = createContentfulApi({
     http: {
       defaults: { baseURL: 'baseURL' },
-      get: getStub.mockReturnValue(promise)
+      get: getStub.mockReturnValue(promise),
+      cloneWithNewParams: jest.fn().mockReturnValue({
+        defaults: { baseURL: 'baseURL' },
+        get: getStub.mockReturnValue(promise),
+      })
     },
     getGlobalOptions: getGlobalOptions
   })

--- a/test/unit/paged-sync.test.ts
+++ b/test/unit/paged-sync.test.ts
@@ -1,7 +1,9 @@
+import copy from "fast-copy";
 import pagedSync from '../../lib/paged-sync'
+import {assetMock, entryMock} from "./mocks";
+import {when} from 'jest-when'
 
-/*
-function createEntry (id, deleted) {
+function createEntry(id, deleted = false) {
   const entry = copy(entryMock)
   entry.sys.id = id
   if (deleted) {
@@ -10,7 +12,7 @@ function createEntry (id, deleted) {
   return entry
 }
 
-function createAsset (id, deleted) {
+function createAsset(id, deleted = false): any {
   const asset = copy(assetMock)
   asset.sys.id = id
   if (deleted) {
@@ -18,17 +20,20 @@ function createAsset (id, deleted) {
   }
   return asset
 }
- */
 
 describe('paged-sync', () => {
   let http
 
   beforeEach(() => {
-    http = { get: jest.fn() }
+    http = {get: jest.fn()}
+  })
+
+  afterEach(() => {
+    http.get.mockReset();
   })
 
   test('Rejects with no parameters', async () => {
-    await expect(pagedSync(http, {}, { resolveLinks: true })).rejects
+    await expect(pagedSync(http, {}, {resolveLinks: true})).rejects
       .toEqual(new Error('Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing'))
   })
 
@@ -37,24 +42,36 @@ describe('paged-sync', () => {
       initial: true,
       content_type: 'id',
       type: 'ContentType'
-    }, { resolveLinks: true })).rejects.toEqual(new Error('When using the `content_type` filter your `type` parameter cannot be different from `Entry`.'))
+    }, {resolveLinks: true})).rejects.toEqual(new Error('When using the `content_type` filter your `type` parameter cannot be different from `Entry`.'))
   })
 
-  /*
-  test('Returns empty response if response has no items', async () => {
-    http = { get: jest.fn() }
 
-    http.get.withArgs('sync', {
-      params: {
-        initial: true
-      }
-    }).returns(Promise.resolve({
+  test('Returns empty response if response has no items', async () => {
+
+    http.get.mockResolvedValue({
       data: {
         nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
       }
-    }))
+    })
 
-    const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
+    const response = await pagedSync(http, {initial: true}, {resolveLinks: true})
+    expect(response).toEqual({
+      entries: [],
+      assets: [],
+      deletedEntries: [],
+      deletedAssets: [],
+      nextSyncToken: "nextsynctoken",
+    })
+    expect(http.get).toBeCalledWith('sync', {
+      params: {
+        initial: true
+      }
+    })
+
+  })
+  test('Returns empty response if response is empty', async () => {
+    http.get.mockResolvedValue({});
+    const response = await pagedSync(http, {initial: true}, {resolveLinks: true})
     expect(response).toEqual({
       entries: [],
       assets: [],
@@ -63,26 +80,9 @@ describe('paged-sync', () => {
     })
   })
 
-  test('Returns empty response if response is empty', async (t) => {
-    t.plan(4)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', {
-      params: {
-        initial: true
-      }
-    }).returns(Promise.resolve({}))
-
-    const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
-    t.deepEqual(response.entries, [])
-    t.deepEqual(response.assets, [])
-    t.deepEqual(response.deletedEntries, [])
-    t.deepEqual(response.deletedAssets, [])
-  })
-
-  test('Initial sync with one page', async (t) => {
-    t.plan(11)
-    const http = { get: sinon.stub() }
+  test('Initial sync with one page', async () => {
     const entryWithLink = createEntry('1')
+    // @ts-ignore
     entryWithLink.fields.linked = {
       sys: {
         id: '2',
@@ -90,7 +90,7 @@ describe('paged-sync', () => {
         linkType: 'Entry'
       }
     }
-    http.get.withArgs('sync', { params: { initial: true } }).returns(Promise.resolve({
+    http.get.mockResolvedValue({
       data: {
         items: [
           entryWithLink,
@@ -105,32 +105,49 @@ describe('paged-sync', () => {
         ],
         nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
       }
-    }))
+    })
 
-    const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(response.entries.length, 3, 'entries length')
-    t.ok(response.entries[0].toPlainObject, 'toPlainObject on entry')
-    t.equal(response.deletedEntries.length, 2, 'deleted entries length')
-    t.ok(response.deletedEntries[0].toPlainObject, 'toPlainObject on deletedEntry')
-    t.equal(response.assets.length, 3, 'entries length')
-    t.ok(response.assets[0].toPlainObject, 'toPlainObject on asset')
-    t.equal(response.deletedAssets.length, 1, 'deleted assets length')
-    t.ok(response.deletedAssets[0].toPlainObject, 'toPlainObject on deletedAsset')
-    t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-    t.equal(response.entries[0].fields.linked.sys.type, 'Entry', 'linked entry is resolved')
+    const response = await pagedSync(http, {initial: true}, {resolveLinks: true})
+    expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
+    expect(response.entries).toHaveLength(3);
+    expect(response.deletedEntries).toHaveLength(2)
+    expect(response.assets).toHaveLength(3)
+    expect(response.deletedAssets).toHaveLength(1)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
+    expect(response.entries[0].fields.linked.sys.type).toEqual('Entry')
   })
 
-  test('Initial sync with one page and filter', async (t) => {
-    t.plan(5)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', {
+  test('Initial sync with one page and filter', async () => {
+    http.get.mockResolvedValue({
+      data: {
+        items: [
+          createEntry('1'),
+          createEntry('2'),
+          createEntry('3')
+        ],
+        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+      }
+    })
+
+    const response = await pagedSync(http, {initial: true, content_type: 'cat'}, {resolveLinks: true})
+
+    expect(http.get).toBeCalledWith('sync', {
       params: {
         initial: true,
         content_type: 'cat',
         type: 'Entry'
       }
-    }).returns(Promise.resolve({
+    })
+
+    expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
+    expect(http.get.mock.calls[0][1].params.content_type).toEqual('cat')
+    expect(http.get.mock.calls[0][1].params.type).toEqual('Entry')
+    expect(response.entries).toHaveLength(3)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
+  })
+
+  test('Initial sync with one page and limit', async () => {
+    http.get.mockResolvedValue({
       data: {
         items: [
           createEntry('1'),
@@ -139,237 +156,216 @@ describe('paged-sync', () => {
         ],
         nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
       }
-    }))
+    })
 
-    const response = await pagedSync(http, { initial: true, content_type: 'cat' }, { resolveLinks: true })
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(http.get.args[0][1].params.content_type, 'cat', 'http request has content type filter param')
-    t.equal(http.get.args[0][1].params.type, 'Entry', 'http request has entity type filter param')
-    t.equal(response.entries.length, 3, 'entries length')
-    t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
-  })
+    const response = await pagedSync(http, {initial: true, limit: 10}, {resolveLinks: true})
 
-  test('Initial sync with one page and limit', async (t) => {
-    t.plan(4)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', {
+    expect(http.get).toBeCalledWith('sync', {
       params: {
         initial: true,
         limit: 10
       }
-    }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('1'),
-          createEntry('2'),
-          createEntry('3')
-        ],
-        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
-      }
-    }))
+    })
 
-    const response = await pagedSync(http, { initial: true, limit: 10 }, { resolveLinks: true })
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
-    t.equal(response.entries.length, 3, 'entries length')
-    t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
+    expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
+    expect(http.get.mock.calls[0][1].params.limit).toEqual(10)
+    expect(response.entries).toHaveLength(3)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
   })
 
-  test('Initial sync with multiple pages', async (t) => {
-    t.plan(12)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', { params: { initial: true, type: 'Entries' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('1'),
-          createEntry('2')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
-      }
-    }))
+  test('Initial sync with multiple pages', async () => {
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage1' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('3'),
-          createEntry('3', true),
-          createEntry('3', true),
-          createAsset('1')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
-      }
-    }))
+    when(http.get)
+      .calledWith('sync', {params: {initial: true, type: 'Entries'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('1'),
+            createEntry('2')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
+        }
+      }))
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage2' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createAsset('2'),
-          createAsset('3'),
-          createAsset('3', true)
-        ],
-        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
-      }
-    }))
+      .calledWith('sync', {params: {sync_token: 'nextpage1'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('3'),
+            createEntry('3', true),
+            createEntry('3', true),
+            createAsset('1')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
+        }
+      }))
 
-    const response = await pagedSync(http, { initial: true, type: 'Entries' }, { resolveLinks: true })
-    const objResponse = response.toPlainObject()
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-    t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
-    t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
-    t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
-    t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
-    t.equal(objResponse.entries.length, 3, 'entries length')
-    t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
-    t.equal(objResponse.assets.length, 3, 'entries length')
-    t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
-    t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
-    t.ok(response.stringifySafe(), 'stringifies response')
+      .calledWith('sync', {params: {sync_token: 'nextpage2'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createAsset('2'),
+            createAsset('3'),
+            createAsset('3', true)
+          ],
+          nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+        }
+      }))
+
+    const response = await pagedSync(http, {initial: true, type: 'Entries'}, {resolveLinks: true})
+
+    expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
+    expect(http.get.mock.calls[0][1].params.type).toEqual('Entries')
+    expect(http.get.mock.calls[1][1].params.initial).toBeFalsy()
+    expect(http.get.mock.calls[1][1].params.type).not.toBeDefined()
+    expect(http.get.mock.calls[1][1].params.sync_token).toEqual('nextpage1')
+    expect(http.get.mock.calls[2][1].params.sync_token).toEqual('nextpage2')
+    expect(response.entries).toHaveLength(3)
+    expect(response.deletedEntries).toHaveLength(2)
+    expect(response.assets).toHaveLength(3)
+    expect(response.deletedAssets).toHaveLength(1)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
   })
 
-  test('Initial sync with limit and multiple pages', async (t) => {
-    t.plan(14)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', { params: { initial: true, limit: 10, type: 'Entries' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('1'),
-          createEntry('2')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
-      }
-    }))
+  test('Initial sync with limit and multiple pages', async () => {
+    when(http.get)
+      .calledWith('sync', {params: {initial: true, limit: 10, type: 'Entries'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('1'),
+            createEntry('2')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
+        }
+      }))
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage1' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('3'),
-          createEntry('3', true),
-          createEntry('3', true),
-          createAsset('1')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
-      }
-    }))
+      .calledWith('sync', {params: {sync_token: 'nextpage1'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('3'),
+            createEntry('3', true),
+            createEntry('3', true),
+            createAsset('1')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
+        }
+      }))
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage2' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createAsset('2'),
-          createAsset('3'),
-          createAsset('3', true)
-        ],
-        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
-      }
-    }))
+      .calledWith('sync', {params: {sync_token: 'nextpage2'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createAsset('2'),
+            createAsset('3'),
+            createAsset('3', true)
+          ],
+          nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+        }
+      }))
 
-    const response = await pagedSync(http, { initial: true, limit: 10, type: 'Entries' }, { resolveLinks: true })
-    const objResponse = response.toPlainObject()
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(http.get.args[0][1].params.limit, 10, 'http request has limit param')
-    t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-    t.notOk(http.get.args[1][1].params.initial, 'second http request does not have initial param')
-    t.notOk(http.get.args[1][1].params.limit, 'second http request does not have limit param')
-    t.notOk(http.get.args[1][1].params.type, 'second http request does not have type param')
-    t.equal(http.get.args[1][1].params.sync_token, 'nextpage1', 'http request param for first page')
-    t.equal(http.get.args[2][1].params.sync_token, 'nextpage2', 'http request param for second page')
-    t.equal(objResponse.entries.length, 3, 'entries length')
-    t.equal(objResponse.deletedEntries.length, 2, 'deleted entries length')
-    t.equal(objResponse.assets.length, 3, 'entries length')
-    t.equal(objResponse.deletedAssets.length, 1, 'deleted assets length')
-    t.equal(objResponse.nextSyncToken, 'nextsynctoken', 'next sync token')
-    t.ok(response.stringifySafe(), 'stringifies response')
+    const response = await pagedSync(http, {initial: true, limit: 10, type: 'Entries'}, {resolveLinks: true})
+    expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
+    expect(http.get.mock.calls[0][1].params.limit).toEqual(10)
+    expect(http.get.mock.calls[0][1].params.type).toEqual('Entries')
+    expect(http.get.mock.calls[1][1].params.initial).toBeFalsy()
+    expect(http.get.mock.calls[1][1].params.limit).toBeFalsy()
+    expect(http.get.mock.calls[1][1].params.type).not.toBeDefined()
+    expect(http.get.mock.calls[1][1].params.sync_token).toEqual('nextpage1')
+    expect(http.get.mock.calls[2][1].params.sync_token).toEqual('nextpage2')
+    expect(response.entries).toHaveLength(3)
+    expect(response.deletedEntries).toHaveLength(2)
+    expect(response.assets).toHaveLength(3)
+    expect(response.deletedAssets).toHaveLength(1)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
   })
 
-  test('Sync with existing token', async (t) => {
-    t.plan(6)
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', { params: { sync_token: 'nextsynctoken' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('1'),
-          createEntry('3', true),
-          createAsset('1'),
-          createAsset('3', true)
-        ],
-        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
-      }
-    }))
+  test('Sync with existing token', async () => {
+    when(http.get)
+      .calledWith('sync', {params: {sync_token: 'nextsynctoken'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('1'),
+            createEntry('3', true),
+            createAsset('1'),
+            createAsset('3', true)
+          ],
+          nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+        }
+      }))
 
-    const response = await pagedSync(http, { nextSyncToken: 'nextsynctoken' }, { resolveLinks: true })
-    t.equal(http.get.args[0][1].params.sync_token, 'nextsynctoken', 'http request param for sync')
-    t.equal(response.entries.length, 1, 'entries length')
-    t.equal(response.deletedEntries.length, 1, 'deleted entries length')
-    t.equal(response.assets.length, 1, 'entries length')
-    t.equal(response.deletedAssets.length, 1, 'deleted assets length')
-    t.equal(response.nextSyncToken, 'nextsynctoken', 'next sync token')
+    const response = await pagedSync(http, {nextSyncToken: 'nextsynctoken'}, {resolveLinks: true})
+    expect(http.get.mock.calls[0][1].params.sync_token).toEqual('nextsynctoken')
+    expect(response.entries).toHaveLength(1)
+    expect(response.deletedEntries).toHaveLength(1)
+    expect(response.assets).toHaveLength(1)
+    expect(response.deletedAssets).toHaveLength(1)
+    expect(response.nextSyncToken).toEqual('nextsynctoken')
   })
 
-  test('Initial sync with multiple pages but pagination disabled', async (t) => {
-    t.plan(18)
+  test('Initial sync with multiple pages but pagination disabled', async () => {
+    when(http.get)
+      .calledWith('sync', {params: {initial: true, type: 'Entries'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('1'),
+            createEntry('2')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
+        }
+      }))
 
-    const http = { get: sinon.stub() }
-    http.get.withArgs('sync', { params: { initial: true, type: 'Entries' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('1'),
-          createEntry('2')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage1'
-      }
-    }))
+      .calledWith('sync', {params: {sync_token: 'nextpage1'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createEntry('3'),
+            createEntry('3', true),
+            createEntry('3', true),
+            createAsset('1')
+          ],
+          nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
+        }
+      }))
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage1' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createEntry('3'),
-          createEntry('3', true),
-          createEntry('3', true),
-          createAsset('1')
-        ],
-        nextPageUrl: 'http://nextsyncurl?sync_token=nextpage2'
-      }
-    }))
+      .calledWith('sync', {params: {sync_token: 'nextpage2'}})
+      .mockReturnValue(Promise.resolve({
+        data: {
+          items: [
+            createAsset('2'),
+            createAsset('3'),
+            createAsset('3', true)
+          ],
+          nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
+        }
+      }))
 
-    http.get.withArgs('sync', { params: { sync_token: 'nextpage2' } }).returns(Promise.resolve({
-      data: {
-        items: [
-          createAsset('2'),
-          createAsset('3'),
-          createAsset('3', true)
-        ],
-        nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken'
-      }
-    }))
-
-    const response = await pagedSync(http, { initial: true, type: 'Entries' }, { paginate: false })
-    const objResponse = response.toPlainObject()
-    t.equal(http.get.callCount, 1, 'only one request was sent')
-    t.ok(http.get.args[0][1].params.initial, 'http request has initial param')
-    t.equal(http.get.args[0][1].params.type, 'Entries', 'http request has type param')
-    t.equal(objResponse.entries.length, 2, 'entries length')
-    t.equal(objResponse.deletedEntries.length, 0, 'deleted entries length')
-    t.equal(objResponse.assets.length, 0, 'entries length')
-    t.equal(objResponse.deletedAssets.length, 0, 'deleted assets length')
-    t.equal(objResponse.nextPageToken, 'nextpage1', 'next page token')
-    t.notOk(objResponse.nextSyncToken, 'next sync token should not exist')
-    t.ok(response.stringifySafe(), 'stringifies response')
+    const response = await pagedSync(http, {initial: true, type: 'Entries'}, {paginate: false})
+    expect(http.get).toHaveBeenCalledTimes(1)
+    expect(http.get.mock.calls[0][1].params.initial).toBeDefined()
+    expect(http.get.mock.calls[0][1].params.type).toEqual('Entries')
+    expect(response.entries).toHaveLength(2)
+    expect(response.deletedEntries).toHaveLength(0)
+    expect(response.assets).toHaveLength( 0)
+    expect(response.deletedAssets).toHaveLength( 0)
+    expect(response.nextPageToken).toEqual('nextpage1')
+    expect(response.nextSyncToken).toBeUndefined()
 
     // Manually sync next page
-    const response2 = await pagedSync(http, { nextPageToken: objResponse.nextPageToken }, { paginate: false })
-    const objResponse2 = response2.toPlainObject()
-    t.equal(http.get.callCount, 2, 'second request was sent and no pagination happened')
-    t.notOk(http.get.args[1][1].params.initial, 'http request does not have initial param')
-    t.equal(objResponse2.nextPageToken, 'nextpage2', 'next page token')
-    t.notOk(objResponse2.nextSyncToken, 'next sync token should not exist')
+    const response2 = await pagedSync(http, {nextPageToken: response.nextPageToken}, {paginate: false})
+    expect(http.get).toHaveBeenCalledTimes(2)
+    expect(http.get.mock.calls[1][1].params.initial).toBeUndefined()
+    expect(response2.nextPageToken).toEqual( 'nextpage2')
+    expect(response2.nextSyncToken).toBeUndefined()
 
     // Manually sync next (last) page
-    const response3 = await pagedSync(http, { nextPageToken: objResponse2.nextPageToken }, { paginate: false })
-    const objResponse3 = response3.toPlainObject()
-    t.equal(http.get.callCount, 3, 'third request was sent and no pagination happened')
-    t.notOk(http.get.args[2][1].params.initial, 'http request does not have initial param')
-    t.notOk(objResponse3.nextPageToken, 'next page token should not exist')
-    t.equal(objResponse3.nextSyncToken, 'nextsynctoken', 'next sync token')
+    const response3 = await pagedSync(http, {nextPageToken: response2.nextPageToken}, {paginate: false})
+    expect(http.get).toHaveBeenCalledTimes(3)
+    expect(http.get.mock.calls[2][1].params.initial).toBeUndefined()
+    expect(response3.nextPageToken).toBeUndefined()
+    expect(response3.nextSyncToken).toEqual('nextsynctoken')
   })
-  */
 })


### PR DESCRIPTION
## Summary

Migrate sync api

## Description

Migrate all related tests. 
Use `http.cloneWithParams`  to eliminate global state switching of `http.defaults.baseURL`