### PR TITLE
feat(docs): create documentation with better-docs

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -2,7 +2,11 @@
     "tags": {
         "allowUnknownTags": true
     },
+    "plugins": [
+        "node_modules/better-docs/typescript"
+    ],
     "source": {
+        "includePattern": "\\.(js|ts)$",
         "include": [
             "lib/",
             "./README.md"
@@ -10,7 +14,7 @@
     },
     "opts": {
         "encoding": "utf8",
-        "template": "node_modules/contentful-sdk-jsdoc/jsdoc-template",
+        "template": "node_modules/better-docs",
         "destination": "out/",
         "recurse": true,
         "verbose": true

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-inline-replace-variables": "^1.3.1",
+    "better-docs": "^2.3.2",
     "bundlesize": "^0.18.0",
     "codecov": "^3.0.0",
     "contentful-sdk-jsdoc": "^2.2.0",


### PR DESCRIPTION
## Summary

Make use of [better-docs](https://github.com/SoftwareBrothers/better-docs/) to generate our documentation 

## Docs Preview

![Screenshot 2020-12-15 at 14 34 47](https://user-images.githubusercontent.com/8948313/102221927-107c1e00-3ee3-11eb-93aa-75aab7d78f67.png)
![Screenshot 2020-12-15 at 14 35 15](https://user-images.githubusercontent.com/8948313/102221940-14a83b80-3ee3-11eb-8b6a-eded570ae9d4.png)

## To Do

Once we are done with the TS migration, we should document `common-types`.

E.g

```
/**
 * AssetDetails'
 * @category Types
 * @alias AssetDetails'
 * @typedef {object} AssetDetails'
 * @property {number} size '
 * @property {object} image'
 * @property {number}  image.width'
 * @property {string} image.height '
 */

export interface AssetDetails {
  size: number
  image?: {
    width: number
    height: number
  }
}
```

