### PR TITLE
Ignore spaces around commas in select parameter

### DIFF
--- a/lib/utils/normalize-select.js
+++ b/lib/utils/normalize-select.js
@@ -11,7 +11,7 @@ export default function normalizeSelect (query) {
 
   // The selection of fields for the query is limited
   // Get the different parts that are listed for selection
-  const allSelects = Array.isArray(query.select) ? query.select : query.select.split(',')
+  const allSelects = Array.isArray(query.select) ? query.select : query.select.split(',').map(q => q.trim())
   // Move the parts into a set for easy access and deduplication
   const selectedSet = new Set(allSelects)
 


### PR DESCRIPTION
## Summary
Few people including myself have run into issues when trying to use the `select` parameter in queries with spaces around fields separated by commas.  This simple PR fixes that by trimming the spaces around.


## Motivation and Context
People have run into same issue as I did:
https://github.com/contentful/contentful.js/issues/135#issuecomment-490431849

