### PR TITLE
Use rich text types package

### DIFF
--- a/lib/common-types.ts
+++ b/lib/common-types.ts
@@ -1,4 +1,5 @@
 import { AxiosInstance } from 'contentful-sdk-core'
+import { Document as RichTextDocument } from '@contentful/rich-text-types'
 export type HttpClientInstance = AxiosInstance
 export interface AssetDetails {
   size: number
@@ -151,51 +152,9 @@ export declare namespace EntryFields {
   type Link<T> = Asset | Entry<T>
   type Array<T = any> = symbol[] | Entry<T>[] | Asset[]
   type Object<T = any> = T
-  interface RichText {
-    data: any
-    content: RichTextContent[]
-    nodeType: 'document'
-  }
+  type RichText = RichTextDocument
 }
-interface RichTextDataTarget {
-  sys: {
-    id: string
-    type: 'Link'
-    linkType: 'Entry' | 'Asset'
-  }
-}
-interface RichTextData {
-  uri?: string
-  target?: RichTextDataTarget
-}
-declare type RichTextNodeType =
-  | 'text'
-  | 'heading-1'
-  | 'heading-2'
-  | 'heading-3'
-  | 'heading-4'
-  | 'heading-5'
-  | 'heading-6'
-  | 'paragraph'
-  | 'hyperlink'
-  | 'entry-hyperlink'
-  | 'asset-hyperlink'
-  | 'unordered-list'
-  | 'ordered-list'
-  | 'list-item'
-  | 'blockquote'
-  | 'hr'
-  | 'embedded-entry-block'
-  | 'embedded-entry-inline'
-interface RichTextContent {
-  data: RichTextData
-  content?: RichTextContent[]
-  marks: {
-    type: 'bold' | 'underline' | 'code' | 'italic'
-  }[]
-  value?: string
-  nodeType: RichTextNodeType
-}
+
 export interface Space {
   sys: Sys
   name: string

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -36,9 +36,14 @@ export interface ContentfulClientApi {
 
   getContentTypes(): Promise<ContentTypeCollection>
 
-  getEntries<Fields = Record<string, any>>(query?: FieldsQueries<Fields>): Promise<EntryCollection<Fields>>
+  getEntries<Fields = Record<string, any>>(
+    query?: FieldsQueries<Fields>
+  ): Promise<EntryCollection<Fields>>
 
-  getEntry<Fields = Record<string, any>>(id: string, query?: FieldsQueries<Fields>): Promise<Entry<Fields>>
+  getEntry<Fields = Record<string, any>>(
+    id: string,
+    query?: FieldsQueries<Fields>
+  ): Promise<Entry<Fields>>
 
   getSpace(): Promise<Space>
 
@@ -249,7 +254,9 @@ export default function createContentfulApi({
    * const response = await client.getEntries()
    * .console.log(response.items)
    */
-  async function getEntries<Fields>(query: FieldsQueries<Fields> = {}): Promise<EntryCollection<Fields>> {
+  async function getEntries<Fields>(
+    query: FieldsQueries<Fields> = {}
+  ): Promise<EntryCollection<Fields>> {
     const { resolveLinks, removeUnresolved } = getGlobalOptions({})
     try {
       const entries = await get({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,6 +1367,11 @@
       "integrity": "sha512-0Tf8nMfNoaDtATwVzqbwb1Q1EpLCAI8cZ21ds6P/uB2cu7RuJ/xa+1B/OafrG5huhVH/PxoJk3QWTjlCo6k0sg==",
       "dev": true
     },
+    "@contentful/rich-text-types": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-14.1.2.tgz",
+      "integrity": "sha512-XbgZ7op5uyYYszipgQg/bYobF4b+llXyTwS8hISRniQY9xKESz544eP2OGmRc4J3MHx29M7Vmx7TVA/IK65giQ=="
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "postinstall": "rimraf node_modules/tsdx/node_modules"
   },
   "dependencies": {
+    "@contentful/rich-text-types": "^14.1.2",
     "axios": "^0.21.1",
     "contentful-resolve-response": "^1.3.0",
     "contentful-sdk-core": "^6.6.0",


### PR DESCRIPTION
## Description

The locally defined types for rich text content are inaccurate. 
Instead, we use a dedicated types package for `rich-text- types`.
