### PR TITLE
add line height styling to README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   </a>
 </p>
 
-# contentful.js - Contentful JavaScript Delivery SDK
+# <span style="line-height: 1.1">contentful.js - Contentful JavaScript Delivery SDK</span>
 
 > JavaScript SDK for the Contentful [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/) and [Content Preview API](https://www.contentful.com/developers/docs/references/content-preview-api/). It helps you to easily access your Content stored in Contentful with your JavaScript applications.
 


### PR DESCRIPTION
## Summary

- Add a line height of 1.1 to the readme title - see before and after screenshots

**Before:**
Screen capture example -> https://gyazo.com/8fdeeebecd655860c7b371b3b5e804f1
![image](https://user-images.githubusercontent.com/8321838/107801012-8bb84f80-6d2d-11eb-9c11-bdc64dc4b905.png)


**After:**
Screen Capture Example -> https://gyazo.com/7698329405bb6fadb8ff6406d0785fdb
![image](https://user-images.githubusercontent.com/8321838/107800848-501d8580-6d2d-11eb-83c9-56076e800e54.png)


## Description

Adding a line height style to the readme title

## Motivation and Context

For screens smaller than XL the text wraps over self
