### PR TITLE
fix(chore): bundle building

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,57 +1,38 @@
 const mainSupportedBrowsers = require('@contentful/browserslist-config')
 
-var defaultBabelPresetEnvConfig = {
-  // No module transformation, webpack will take care of this if necessary.
-  modules: false,
-  useBuiltIns: 'entry',
-  corejs: 3,
+// Latest browsers
+var browserBabelPresetEnvConfig = {
+  targets: {
+    browsers: mainSupportedBrowsers
+  }
 }
 
-// Latest browsers
-var browserBabelPresetEnvConfig = Object.assign(
-  {},
-  defaultBabelPresetEnvConfig,
-  {
-    targets: {
-      browsers: mainSupportedBrowsers
-    }
-  }
-)
-
 // Legacy browsers
-var legacyBabelPresetEnvConfig = Object.assign(
-  {},
-  defaultBabelPresetEnvConfig,
-  {
-    targets: {
-      browsers: ['last 5 versions', 'not ie < 10']
-    }
+var legacyBabelPresetEnvConfig = {
+  targets: {
+    browsers: ['last 5 versions', 'not ie < 10']
   }
-)
+}
 
 // Node
-var nodeBabelPresetEnvConfig = Object.assign({}, defaultBabelPresetEnvConfig, {
+var nodeBabelPresetEnvConfig = {
   targets: {
     node: '12'
   }
-})
+}
 
 // Combined node and browser environment for es6 modules version and tests
-var modulesBabelPresetEnvConfig = Object.assign(
-  {},
-  defaultBabelPresetEnvConfig,
-  {
-    targets: Object.assign({},
-      legacyBabelPresetEnvConfig.targets,
-      nodeBabelPresetEnvConfig.targets
-    )
+var modulesBabelPresetEnvConfig = {
+  targets: {
+    browsers: mainSupportedBrowsers,
+    node: '12'
   }
-)
+}
 
-var testBabelPresetEnvConfig = Object.assign({}, modulesBabelPresetEnvConfig, {
+var testBabelPresetEnvConfig = {
   // Tests need to transform modules
   modules: 'commonjs'
-})
+}
 
 var plugins = [
   '@babel/plugin-proposal-object-rest-spread',
@@ -68,7 +49,8 @@ var babelConfig = {
   plugins
 }
 
-module.exports = function (api) {
+module
+  .exports = function(api) {
 
   var env = api.env()
 
@@ -80,6 +62,15 @@ module.exports = function (api) {
 
   if (env === 'legacy') {
     babelConfig = Object.assign({}, babelConfig, {
+      plugins: [
+        [
+          '@babel/plugin-transform-runtime',
+          {
+            'regenerator': true,
+            'corejs': 3
+          }
+        ]
+      ].concat(plugins),
       presets: [['@babel/preset-env', legacyBabelPresetEnvConfig]]
     })
   }
@@ -103,8 +94,8 @@ module.exports = function (api) {
     })
   }
 
-  console.debug('BABEL ENV: ' + env)
-  console.table(babelConfig.presets.map(p => p[1].targets))
+  console.debug({ babelENV: env, nodeENV: process.env.NODE_ENV })
+  // console.table(babelConfig.presets.map(p => p[1].targets))
 
   return babelConfig
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,101 +1,65 @@
 const mainSupportedBrowsers = require('@contentful/browserslist-config')
 
-// Latest browsers
-var browserBabelPresetEnvConfig = {
-  targets: {
-    browsers: mainSupportedBrowsers
-  }
-}
+module.exports = function(api) {
+  api.cache(false)
 
-// Legacy browsers
-var legacyBabelPresetEnvConfig = {
-  targets: {
-    browsers: ['last 5 versions', 'not ie < 10']
-  }
-}
-
-// Node
-var nodeBabelPresetEnvConfig = {
-  targets: {
-    node: '12'
-  }
-}
-
-// Combined node and browser environment for es6 modules version and tests
-var modulesBabelPresetEnvConfig = {
-  targets: {
-    browsers: mainSupportedBrowsers,
-    node: '12'
-  }
-}
-
-var testBabelPresetEnvConfig = {
-  // Tests need to transform modules
-  modules: 'commonjs'
-}
-
-var plugins = [
-  '@babel/plugin-proposal-object-rest-spread',
-  [
-    'inline-replace-variables',
-    {
-      // Inject version number into code
-      __VERSION__: require('./package.json').version
-    }
-  ]
-]
-
-var babelConfig = {
-  plugins
-}
-
-module
-  .exports = function(api) {
-
-  var env = api.env()
-
-  if (env === 'browser') {
-    babelConfig = Object.assign({}, babelConfig, {
-      presets: [['@babel/preset-env', browserBabelPresetEnvConfig]]
-    })
-  }
-
-  if (env === 'legacy') {
-    babelConfig = Object.assign({}, babelConfig, {
-      plugins: [
-        [
-          '@babel/plugin-transform-runtime',
-          {
-            'regenerator': true,
-            'corejs': 3
+  return {
+    env: {
+      browser: {
+        presets: [['@babel/preset-env', {
+          targets: {
+            browsers: mainSupportedBrowsers
           }
-        ]
-      ].concat(plugins),
-      presets: [['@babel/preset-env', legacyBabelPresetEnvConfig]]
-    })
+        }]]
+      },
+      legacy: {
+        plugins: [
+          [
+            '@babel/plugin-transform-runtime',
+            {
+              'regenerator': true,
+              'corejs': 3
+            }
+          ]
+        ],
+        presets: [['@babel/preset-env', {
+          targets: {
+            browsers: ['last 5 versions', 'not ie < 10']
+          }
+        }]]
+      },
+      node: {
+        presets: [['@babel/preset-env', {
+          targets: {
+            node: '12'
+          }
+        }]]
+      },
+      test: {
+        presets: [['@babel/preset-env', {
+          // Tests need to transform modules
+          modules: 'commonjs'
+        }]],
+        plugins: ['rewire']
+      },
+      modules: {
+        presets: [['@babel/preset-env', {
+          targets: {
+            browsers: mainSupportedBrowsers,
+            node: '12'
+          }
+        }]]
+      }
+    },
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+      [
+        'inline-replace-variables',
+        {
+          // Inject version number into code
+          __VERSION__: require('./package.json').version
+        }
+      ]
+    ]
   }
-
-  if (env === 'modules') {
-    babelConfig = Object.assign({}, babelConfig, {
-      presets: [['@babel/preset-env', modulesBabelPresetEnvConfig]]
-    })
-  }
-
-  if (env === 'node') {
-    babelConfig = Object.assign({}, babelConfig, {
-      presets: [['@babel/preset-env', nodeBabelPresetEnvConfig]]
-    })
-  }
-
-  if (env === 'test') {
-    babelConfig = Object.assign({}, babelConfig, {
-      presets: [['@babel/preset-env', testBabelPresetEnvConfig]],
-      plugins: babelConfig.plugins.concat(['rewire'])
-    })
-  }
-
-  console.debug({ babelENV: env, nodeENV: process.env.NODE_ENV })
-  // console.table(babelConfig.presets.map(p => p[1].targets))
-
-  return babelConfig
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2464,6 +2464,222 @@
         }
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.13.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.5.tgz",
+      "integrity": "sha512-prZzwuR0C4pCHAkWzBAPSqm7A1kOyE+Fd7IaNqZPfEtWvt6xWmOtgbfmQ1lAZqbvU+4e9DSvf7ldkjClmNbZSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "babel-plugin-polyfill-corejs2": "^0.1.4",
+        "babel-plugin-polyfill-corejs3": "^0.1.3",
+        "babel-plugin-polyfill-regenerator": "^0.1.2",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
+          "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-define-polyfill-provider": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.1.2.tgz",
+          "integrity": "sha512-hWeolZJivTNGHXHzJjQz/NwDaG4mGXf22ZroOP8bQYgvHNzaQ5tylsVbAcAS2oDjXBwpu8qH2I/654QFS2rDpw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-compilation-targets": "^7.13.0",
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/traverse": "^7.13.0",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.12.13",
+            "@babel/template": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.13.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
+          "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+          "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.13.0",
+            "@babel/helper-function-name": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/parser": "^7.13.0",
+            "@babel/types": "^7.13.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "babel-plugin-polyfill-corejs2": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.5.tgz",
+          "integrity": "sha512-5IzdFIjYWqlOFVr/hMYUpc+5fbfuvJTAISwIY58jhH++ZtawtNlcJnxAixlk8ahVwHCz1ipW/kpXYliEBp66wg==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.13.0",
+            "@babel/helper-define-polyfill-provider": "^0.1.2",
+            "semver": "^6.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.1.4.tgz",
+          "integrity": "sha512-ysSzFn/qM8bvcDAn4mC7pKk85Y5dVaoa9h4u0mHxOEpDzabsseONhUpR7kHxpUinfj1bjU7mUZqD23rMZBoeSg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.1.2",
+            "core-js-compat": "^3.8.1"
+          }
+        },
+        "babel-plugin-polyfill-regenerator": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.1.3.tgz",
+          "integrity": "sha512-hRjTJQiOYt/wBKEc+8V8p9OJ9799blAJcuKzn1JXh3pApHoWl1Emxh2BHc6MC7Qt6bbr3uDpNxaYQnATLIudEg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.1.2"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
@@ -2737,6 +2953,16 @@
       "integrity": "sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==",
       "dev": true,
       "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.13.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.4.tgz",
+      "integrity": "sha512-W8GBjqrF1/zMrdus/epxngkjn5TGePhgAu1EJq8llEC2NmPsVipm6Emd39z/iPzyqwG2QUJXpy6qajHC5m6PGA==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -6918,6 +7144,12 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
+      "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:modules": "BABEL_ENV=modules babel lib -d dist/es-modules/",
     "build:standalone": "NODE_ENV=development webpack && NODE_ENV=production webpack",
     "build:standalone:log": "NODE_ENV=production WEBPACK_MODE=log webpack --json --profile --progress > webpack-build-log.json && webpack-bundle-analyzer webpack-build-log.json",
-    "postbuild": "npm run check:browser && npm run check:legacy && npm run check:modules",
+    "postbuild": "npm run check:browser && npm run check:legacy && npm run check:modules && npm run check:node",
     "check:legacy": "es-check es5 ./dist/contentful.legacy.js ./dist/contentful.legacy.min.js",
     "check:browser": "es-check es2017 ./dist/contentful.browser.js ./dist/contentful.browser.min.js",
     "check:node": "es-check es2017 ./dist/contentful.node.js ./dist/contentful.node.min.js",
@@ -74,8 +74,10 @@
     "@babel/core": "^7.6.2",
     "@babel/node": "^7.6.2",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/plugin-transform-runtime": "^7.13.5",
     "@babel/preset-env": "^7.6.2",
     "@babel/register": "^7.6.2",
+    "@babel/runtime-corejs3": "^7.13.4",
     "@contentful/browserslist-config": "^1.0.1",
     "@semantic-release/changelog": "^5.0.1",
     "babel-eslint": "^10.0.3",
@@ -140,19 +142,19 @@
     },
     {
       "path": "./dist/contentful.legacy.js",
-      "maxSize": "64Kb"
+      "maxSize": "90Kb"
     },
     {
       "path": "./dist/contentful.legacy.min.js",
-      "maxSize": "25Kb"
+      "maxSize": "40Kb"
     },
     {
       "path": "./dist/contentful.node.js",
-      "maxSize": "60Kb"
+      "maxSize": "80Kb"
     },
     {
       "path": "./dist/contentful.node.min.js",
-      "maxSize": "23Kb"
+      "maxSize": "35Kb"
     }
   ],
   "release": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   "bundlesize": [
     {
       "path": "./dist/contentful.browser.js",
-      "maxSize": "50Kb"
+      "maxSize": "40Kb"
     },
     {
       "path": "./dist/contentful.browser.min.js",
@@ -146,15 +146,15 @@
     },
     {
       "path": "./dist/contentful.legacy.min.js",
-      "maxSize": "40Kb"
+      "maxSize": "35Kb"
     },
     {
       "path": "./dist/contentful.node.js",
-      "maxSize": "80Kb"
+      "maxSize": "55Kb"
     },
     {
       "path": "./dist/contentful.node.min.js",
-      "maxSize": "35Kb"
+      "maxSize": "25Kb"
     }
   ],
   "release": {

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -479,7 +479,7 @@ test('Gets entries with attached metadata and metadata field on cpa', async t =>
 
 test('Gets entry with attached metadata and metadata field on cpa', async t => {
   t.plan(4)
-  const entryWithMetadataFieldAndMetadata = '1NnAC4eF9IRMpHtFB1NleW';
+  const entryWithMetadataFieldAndMetadata = '1NnAC4eF9IRMpHtFB1NleW'
   const response = await previewClient.getEntry(entryWithMetadataFieldAndMetadata)
   t.ok(response.sys, 'sys')
   t.ok(response.fields, 'fields')

--- a/test/runner-browser.js
+++ b/test/runner-browser.js
@@ -1,4 +1,4 @@
-// Readd promise polyfills for legacy browsers since karma-webpack removes them
+// Re-add promise polyfills for legacy browsers since karma-webpack removes them
 require('core-js/es/promise')
 require('core-js/es/object/assign')
 require('core-js/es/array/from')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ const defaultBabelLoader = {
   options: {}
 }
 
-// Browsers
+// Browsers with native async await calls
 const browserBundle = copy(baseBundleConfig)
 browserBundle.module.rules = [
   Object.assign({}, defaultBabelLoader, {
@@ -63,7 +63,7 @@ browserBundle.module.rules = [
 ]
 browserBundle.output.filename = `${baseFileName}.browser${PROD ? '.min' : ''}.js`
 
-// Legacy browsers like IE11
+// Legacy browsers like IE11, with bundled regenerator-runtime
 const legacyBundle = copy(baseBundleConfig)
 legacyBundle.module.rules = [
   Object.assign({}, defaultBabelLoader, {
@@ -75,7 +75,7 @@ legacyBundle.module.rules = [
 
 legacyBundle.output.filename = `${baseFileName}.legacy${PROD ? '.min' : ''}.js`
 
-// Node
+// Node - bundled umd file
 const nodeBundle = copy(baseBundleConfig)
 nodeBundle.module.rules = [
   Object.assign({}, defaultBabelLoader, {


### PR DESCRIPTION
## Summary
Fixes the bundling of this library.

## Description

### Observation

When doing a webpack build with a simple setup like [this](https://github.com/rustyy/contentful-issue-545), you get a `ReferenceError`:

```
Uncaught ReferenceError: regeneratorRuntime is not defined
```

I managed to reproduce the problem. As a quick fix for now, I suggest you replace:

```javascript
import {createClient} from 'contentful';
// and same for
import {createClient} from 'contentful/dist/contentful.legacy';
```

with:

```javascript
import {createClient} from 'contentful/dist/contentful.browser';
```
> the browser bundle has native async support

**The reason why this is happening is that some bundles expect the regeneratorRuntime, but we don't bundle them.**

### Currently exported bundles:

- `contentful` points to `dist/es-modules/contentful.js` (expects regeneratorRuntime)
- `contentful.browser` points to `dist/contentful.browser.js` (uses native async, due to the full support of the feature based on our current [browser-list](https://github.com/contentful/browserslist-config/blob/master/index.js))
- `contentful.legacy` points to points to `dist/contentful.legacy.js` (expects regeneratorRuntime, due to the manually defined browser list: `['last 5 versions', 'not ie < 10']`)
- `contentful.node` points to `dist/contentful.node.js` (expects regeneratorRuntime)

## Solution

Things to keep in mind:
> `contentful.browser` and `contentful.legacy` are both used via [jsDeliver](https://www.jsdelivr.com/package/npm/contentful), directly embedded in your HTML file. Without having `regenerator-runtime` bundled, they wont work out of the box as before (< 8). 

### A good set of bundles that I can think of would be:

- default -> es6 modules with native async
- legacy & using bundled regeneratorRuntime
- node & browser -> basically a bundled single file version of es6 modules with native async

## ToDo:

- [x] `node` build as bundled umd file without generators
- [x] `browser` build as bundled umd file without generators
- [x] `legacy` build as bundled umd file without generators
- [x] `es6` with native async