### PR TITLE
fix(tests): wrong entity id for integration tests.

### DIFF
--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -64,7 +64,7 @@ test('Gets content types', async (t) => {
 
 test('Gets entry', async (t) => {
   t.plan(2)
-  const response = await client.getEntry('5ETMRzkl9KM4omyMwKAOki')
+  const response = await client.getEntry('nyancat')
   t.ok(response.sys, 'sys')
   t.ok(response.fields, 'fields')
 })


### PR DESCRIPTION
It seems like another project is changing the state of an entry that we use to test the getEntry function from published
to unpublished. With this change, we reference a different entity that's not affected by any changes from other packages.
