### PR TITLE
fix: add new content model to tests

### DIFF
--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -369,7 +369,7 @@ test('Gets entries by creation order and id order', async (t) => {
     .map((item) => item.sys.contentType.sys.id)
     .filter((value, index, self) => self.indexOf(value) === index)
 
-  t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'contentTypeWithMetadataField', 'dog', 'human'], 'orders')
+  t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'contentTypeWithMetadataField', 'dog', 'human', 'kangaroo', 'testEntryReferences'], 'orders')
   t.ok(
     response.items[0].sys.id < response.items[1].sys.id,
     'id of entry with index 1 is higher than the one of index 0 since they share content type'


### PR DESCRIPTION
## Summary

We added a new content model to test entry with multiple [references](https://github.com/contentful/contentful-management.js/pull/829), this causes tests to fail in other PRs

## Checklist

- [x] Both unit and integration tests are passing
- [x] There are no breaking changes