### PR TITLE
fix(dependabot): do not refer to npm registry in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,4 @@
 version: 2
-registries:
-  npm-registry-registry-npmjs-org:
-    type: npm-registry
-    url: https://registry.npmjs.org
-    token: "${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}"
 
 updates:
   - package-ecosystem: npm
@@ -20,5 +15,3 @@ updates:
     commit-message:
       prefix: build
       include: scope
-    registries:
-      - npm-registry-registry-npmjs-org


### PR DESCRIPTION
Remove registry references as we don't rely on private dependencies and the reference broke our setup.