### PR TITLE
feat(errors): improve error data thrown

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -87,27 +87,8 @@ export function createClient (params) {
   // Append environment to baseURL
   http.defaults.baseURL = getGlobalOptions().environmentBaseUrl
 
-  // Intercepts response and obscure the token
-  obscureAuthTokenInResponse(http)
-
   return createContentfulApi({
     http,
     getGlobalOptions
-  })
-}
-
-function obscureAuthTokenInResponse (http) {
-  http.interceptors.response.use(response => { return response }, error => {
-    if (error.response && error.response.config.headers.Authorization) {
-      const token = error.response.config.headers.Authorization
-
-      error.response.config.headers.Authorization = error.response.config.headers.Authorization.replace(token, `Bearer...${token.substr(-5)}`)
-
-      if (error.response.request._header) {
-        error.response.request._header = error.response.request._header.replace(token, `Bearer...${token.substr(-5)}`)
-      }
-    }
-
-    return Promise.reject(error)
   })
 }

--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -48,7 +48,7 @@
  * @prop {function} sync
  */
 
-import { createRequestConfig } from 'contentful-sdk-core'
+import { createRequestConfig, errorHandler } from 'contentful-sdk-core'
 import entities from './entities'
 import pagedSync from './paged-sync'
 import normalizeSelect from './utils/normalize-select'
@@ -87,18 +87,6 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
       space: getGlobalOptions().space
     }
     return error
-  }
-
-  function errorHandler (error) {
-    if (error.data) {
-      throw error.data
-    }
-
-    if (error.response && error.response.data) {
-      throw error.response.data
-    }
-
-    throw error
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^0.21.1",
         "contentful-resolve-response": "^1.3.0",
-        "contentful-sdk-core": "^6.8.5",
+        "contentful-sdk-core": "^6.9.0",
         "fast-copy": "^2.1.0",
         "json-stringify-safe": "^5.0.1"
       },
@@ -18245,11 +18245,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "contentful-resolve-response": "^1.3.0",
-    "contentful-sdk-core": "^6.8.5",
+    "contentful-sdk-core": "^6.9.0",
     "fast-copy": "^2.1.0",
     "json-stringify-safe": "^5.0.1"
   },

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -109,7 +109,7 @@ test('API call getSpace fails', async (t) => {
   try {
     await api.getSpace('spaceid')
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -147,7 +147,7 @@ test('API call getContentType fails', async (t) => {
   try {
     await api.getContentType('ctid')
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -191,7 +191,7 @@ test('API call getContentTypes fails', async (t) => {
   try {
     await api.getContentTypes()
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -231,7 +231,7 @@ test('API call getEntry fails', async (t) => {
   try {
     await api.getEntry('eid')
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -317,7 +317,7 @@ test('API call getEntries fails', async (t) => {
   try {
     await api.getEntries()
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -355,7 +355,7 @@ test('API call getAsset fails', async (t) => {
   try {
     await api.getAsset('aid')
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -399,7 +399,7 @@ test('API call getAssets fails', async (t) => {
   try {
     await api.getAssets()
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -437,7 +437,7 @@ test('API call createAssetKey fails', async (t) => {
   try {
     await api.createAssetKey(now() + 60)
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }
@@ -481,7 +481,7 @@ test('API call getLocaless fails', async (t) => {
   try {
     await api.getLocales()
   } catch (r) {
-    t.looseEqual(r, data)
+    t.looseEqual(r.data, data)
   } finally {
     teardown()
   }


### PR DESCRIPTION
BREAKING CHANGE: stop sending Axios error object

## Summary
Introduce a new error handling function and parse Axios' error object.

## Description
Use the error handling function from the contentful-sdk-core library that handles and returns better-parsed errors.

## Motivation and Context
We want to obscure tokens returned in the error response object. With this change, we're implementing a better way to obfuscate and parse the error response we get from Axios.

## Todos

-   [x] Implemented feature