### PR TITLE
fix(types): add optional environment SpaceLink to Sys interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,6 +159,9 @@ export interface Sys {
     space?: {
         sys: SpaceLink;
     };
+    environment?: {
+        sys: SpaceLink;
+    };
     contentType: {
         sys: ContentTypeLink;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21317,9 +21317,9 @@
       "dev": true
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.0.0-rc-1",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-1.tgz",
-      "integrity": "sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==",
+      "version": "4.0.0-rc-2",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-2.tgz",
+      "integrity": "sha512-HT974l00r7wdZL+SPS0f8lBLVYe/aKGAFONMvVroL7z9mHm3PC30IirsYqrvSkw51Pom3XJiN5gjXBRkxuHAdw==",
       "dev": true,
       "dependencies": {
         "jszip": "^3.6.0",
@@ -42589,9 +42589,9 @@
       }
     },
     "selenium-webdriver": {
-      "version": "4.0.0-rc-1",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-1.tgz",
-      "integrity": "sha512-bcrwFPRax8fifRP60p7xkWDGSJJoMkPAzufMlk5K2NyLPht/YZzR2WcIk1+3gR8VOCLlst1P2PI+MXACaFzpIw==",
+      "version": "4.0.0-rc-2",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-rc-2.tgz",
+      "integrity": "sha512-HT974l00r7wdZL+SPS0f8lBLVYe/aKGAFONMvVroL7z9mHm3PC30IirsYqrvSkw51Pom3XJiN5gjXBRkxuHAdw==",
       "dev": true,
       "requires": {
         "jszip": "^3.6.0",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

<!-- Give a short summary what your PR is introducing/fixing. -->
Raw CDA responses include an `environment` field in each entity's `sys` field, which is not currently reflected in the `Sys` typedef.  This PR introduces `environment` as an optional `SpaceLink` in the `Sys` interface, which should better support typing CDA response entities.
