### PR TITLE
feat(chore): drop IE 11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@
 - Chrome
 - Firefox
 - Edge
-- IE11 (with [legacy version](#legacy-browsers) of the library)
 - Safari
 - node.js (LTS)
 
@@ -142,9 +141,9 @@ Check the [releases](https://github.com/contentful/contentful.js/releases) page 
 
 #### Legacy browsers:
 
-This library also comes with a legacy version to support Internet Explorer 11 and other older browsers. It already contains a polyfill for Promises.
+~~This library also comes with a legacy version to support Internet Explorer 11 and other older browsers. It already contains a polyfill for Promises.~~
 
-To support legacy browsers in your application, use `contentful.legacy.min.js` instead of `contentful.browser.min.js`
+> With version `9.0.4` we dropped the support for IE 11. The legacy bundle will only be available for older versions. The full list of supported browsers can be found here [@contentful/browserslist-config](https://github.com/contentful/browserslist-config/blob/master/index.js)
 
 ### Your first request
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "build:modules": "BABEL_ENV=modules babel lib -d dist/es-modules/",
     "build:standalone": "NODE_ENV=development webpack && NODE_ENV=production webpack",
     "build:standalone:log": "NODE_ENV=production WEBPACK_MODE=log webpack --json --profile --progress > webpack-build-log.json && webpack-bundle-analyzer webpack-build-log.json",
-    "postbuild": "npm run check:browser && npm run check:legacy && npm run check:modules && npm run check:node",
-    "check:legacy": "es-check es5 ./dist/contentful.legacy.js ./dist/contentful.legacy.min.js",
+    "postbuild": "npm run check:browser && npm run check:modules && npm run check:node",
     "check:browser": "es-check es2017 ./dist/contentful.browser.js ./dist/contentful.browser.min.js",
     "check:node": "es-check es2017 ./dist/contentful.node.js ./dist/contentful.node.min.js",
     "check:modules": "es-check es6 --module ./dist/es-modules/**/*.js",
@@ -136,14 +135,6 @@
     {
       "path": "./dist/contentful.browser.min.js",
       "maxSize": "16Kb"
-    },
-    {
-      "path": "./dist/contentful.legacy.js",
-      "maxSize": "90Kb"
-    },
-    {
-      "path": "./dist/contentful.legacy.min.js",
-      "maxSize": "35Kb"
     },
     {
       "path": "./dist/contentful.node.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,18 +63,6 @@ browserBundle.module.rules = [
 ]
 browserBundle.output.filename = `${baseFileName}.browser${PROD ? '.min' : ''}.js`
 
-// Legacy browsers like IE11, with bundled regenerator-runtime
-const legacyBundle = copy(baseBundleConfig)
-legacyBundle.module.rules = [
-  Object.assign({}, defaultBabelLoader, {
-    options: Object.assign({}, defaultBabelLoader.options, {
-      envName: 'legacy'
-    })
-  })
-]
-
-legacyBundle.output.filename = `${baseFileName}.legacy${PROD ? '.min' : ''}.js`
-
 // Node - bundled umd file
 const nodeBundle = copy(baseBundleConfig)
 nodeBundle.module.rules = [
@@ -91,6 +79,5 @@ delete nodeBundle.node
 
 module.exports = [
   browserBundle,
-  legacyBundle,
   nodeBundle
 ]


### PR DESCRIPTION
according to the official [supported list of browsers](https://github.com/contentful/browserslist-config/blob/master/index.js), we don't support IE 11 anymore.

<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
