### PR TITLE
docs(api-methods): fix example of getEntries

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -215,7 +215,7 @@ export default function createContentfulApi ({ http, getGlobalOptions }) {
    * })
    *
    * const response = await client.getEntries()
-   * .console.log(response.items)
+   * console.log(response.items)
    */
   async function getEntries (query = {}) {
     switchToEnvironment(http)


### PR DESCRIPTION
Fix the example code for getEntries to prevent syntax error


## Summary

Previous example code for the getEntries API method led to syntax error when copied 1:1. 
Fixed the code.


