### PR TITLE
fix(package): Change main entry point to node build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Client for Contentful's Content Delivery API",
   "version": "0.0.0-determined-by-semantic-release",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
-  "main": "./dist/contentful.browser.js",
+  "main": "./dist/contentful.node.js",
   "browser": "./dist/contentful.browser.js",
   "modules": "./dist/contentful.browser.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Change main entry point to the node (CJS) build. 

The browser build can still be accessed via the "browser" field and will be respected by bundlers.