### PR TITLE
220117/fix user agent header issue

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -63,8 +63,7 @@ export function createClient(params: CreateClientParams): ContentfulClientApi {
   }
 
   const userAgentHeader = getUserAgentHeader(
-    //`contentful.js/${__VERSION__}`,
-    `contentful.js/test-0.0.0`,
+    `contentful.js/${__VERSION__}`,
     config.application,
     config.integration
   )

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -630,8 +630,7 @@ export default function createContentfulApi({
   }
 
   return <ContentfulClientApi>{
-    // version: __VERSION__,
-    version: 'test-0.0.0',
+    version: __VERSION__,
 
     getSpace,
 

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -1,4 +1,8 @@
-import { expectAssignable, expectType } from 'tsd'
+// As tsd does not pick up the global.d.ts located in /lib we
+// explicitly reference it here once.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../lib/global.d.ts" />
+import { expectAssignable } from 'tsd'
 import {
   Entry,
   EntryFields,

--- a/test/unit/contentful.test.ts
+++ b/test/unit/contentful.test.ts
@@ -46,7 +46,7 @@ describe('contentful', () => {
   })
 
   // version currently not set correctly
-  test.skip('Generate the correct User Agent Header', () => {
+  test('Generate the correct User Agent Header', () => {
     createClient({
       accessToken: 'accessToken',
       space: 'spaceId',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const copy = require('fast-copy')
 const webpack = require('webpack')
+const __VERSION__ = require('./package.json').version
 
 const PROD = process.env.NODE_ENV === 'production'
 const baseFileName = 'contentful'
@@ -8,6 +9,7 @@ const baseFileName = 'contentful'
 const plugins = [
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    __VERSION__: JSON.stringify(__VERSION__),
   }),
 ]
 


### PR DESCRIPTION
### DONE
- Header generator picks up the `__VERSION__` var, both type tests as well as header tests pass.
- Manually test that version numbers are actually picked up.
- Investigate how to avoid the `global.d.ts` duplication.
--> In order to avoid uplication, we use ts triple slash reference.