### PR TITLE
bump deps of axios to patch CVE-2022-0155

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dist"
   ],
   "dependencies": {
-    "axios": "^0.24.0",
+    "axios": "^0.25.0",
     "contentful-resolve-response": "^1.3.0",
     "contentful-sdk-core": "^6.10.4",
     "fast-copy": "^2.1.0",


### PR DESCRIPTION
## Summary

patch CVE-2022-0155
high severity

## Description

Vulnerable versions: < 1.14.7
Patched version: 1.14.7
follow-redirects is vulnerable to Exposure of Private Personal Information to an Unauthorized Actor