### PR TITLE
Update name of client chains & fix some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ contentful.createClient({
       <td><code>removeUnresolved</code></td>
       <td><code>false</code></td>
       <td>
-        Remove fields from response for unresolved links.
+        Remove fields from response for unresolvable links.
       </td>
     </tr>
     <tr>

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -16,10 +16,11 @@ import {
   ContentType,
   ContentTypeCollection,
   EntriesQueries,
+  EntryCollection,
   EntryWithoutLinkResolution,
   EntryCollectionWithoutLinkResolution,
   LocaleCollection,
-  LocaleValue,
+  LocaleCode,
   EntryWithAllLocalesAndWithoutLinkResolution,
   EntryCollectionWithAllLocalesAndWithoutLinkResolution,
   EntryWithLinkResolution,
@@ -51,27 +52,23 @@ export type ClientWithoutLinkResolution = {
 }
 
 export type ClientWithAllLocalesAndWithoutLinkResolution = {
-  getEntry<Fields extends FieldsType, Locale extends LocaleValue = any>(
+  getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
     id: string,
-    query?: EntryQueries,
-    locale?: Locale
-  ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locale>>
-  getEntries<Fields extends FieldsType = FieldsType, Locale extends LocaleValue = any>(
-    query?: EntriesQueries<Fields>,
-    locale?: Locale
-  ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locale>>
+    query?: EntryQueries
+  ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+  getEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
+    query?: EntriesQueries<Fields>
+  ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 }
 
 export type ClientWithAllLocalesAndWithLinkResoution = {
-  getEntry<Fields extends FieldsType = FieldsType, Locale extends LocaleValue = any>(
+  getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
     id: string,
-    query?: EntryQueries,
-    locale?: Locale
-  ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, Locale>>
-  getEntries<Fields extends FieldsType = FieldsType, Locale extends LocaleValue = any>(
-    query?: EntriesQueries<Fields>,
-    locale?: Locale
-  ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locale>>
+    query?: EntryQueries
+  ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, Locales>>
+  getEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
+    query?: EntriesQueries<Fields>
+  ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>
 }
 
 export type ContentfulClientApi = {
@@ -259,7 +256,8 @@ export type ContentfulClientApi = {
    * console.log( parsedData.items[0].fields.foo ); // foo
    * ```
    */
-  parseEntries<T>(raw: any): EntryCollectionWithoutLinkResolution<T>
+  // TODO: type properly
+  parseEntries<T>(raw: any): EntryCollection<T>
 
   /**
    * Synchronizes either all the content or only new content since last sync
@@ -455,33 +453,28 @@ export default function createContentfulApi({
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)
   }
 
-  // TODO: third param and second type param are irrelevant,
-  // as the only configuration which returns localized fields is `locale='*'`
-  // so we make this the default and remove the `locale` param
   async function getEntryWithAllLocalesAndWithLinkResolution<
     Fields,
-    Locale extends LocaleValue = any
+    SpaceLocales extends LocaleCode = any
   >(
     id: string,
-    query: EntryQueries = {},
-    locale: LocaleValue = '*'
-  ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, Locale>> {
-    return internalGetEntry<EntryWithAllLocalesAndWithLinkResolution<Fields, Locale>>(
+    query: EntryQueries = {}
+  ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>> {
+    return internalGetEntry<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>>(
       id,
-      { locale, ...query },
+      { ...query, locale: '*' },
       true
     )
   }
 
   async function getEntriesWithAllLocalesAndWithLinkResolution<
     Fields,
-    Locale extends LocaleValue = any
+    Locales extends LocaleCode = any
   >(
-    query: EntriesQueries<Fields> = {},
-    locale: LocaleValue = '*'
-  ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locale>> {
-    return internalGetEntries<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locale>>(
-      { locale, ...query },
+    query: EntriesQueries<Fields> = {}
+  ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>> {
+    return internalGetEntries<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>(
+      { ...query, locale: '*' },
       true
     )
   }
@@ -501,29 +494,27 @@ export default function createContentfulApi({
 
   async function getEntryWithAllLocalesAndWithoutLinkResolution<
     Fields,
-    Locale extends LocaleValue = any
+    Locales extends LocaleCode = any
   >(
     id: string,
-    query: EntryQueries = {},
-    locale: LocaleValue = '*'
-  ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locale>> {
-    return internalGetEntry<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locale>>(
+    query: EntryQueries = {}
+  ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
+    return internalGetEntry<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>(
       id,
-      { locale, ...query },
+      { ...query, locale: '*' },
       false
     )
   }
 
   async function getEntriesWithAllLocalesAndWithoutLinkResolution<
     Fields,
-    Locale extends LocaleValue = any
+    Locales extends LocaleCode = any
   >(
-    query: EntriesQueries<Fields> = {},
-    locale: LocaleValue = '*'
-  ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locale>> {
+    query: EntriesQueries<Fields> = {}
+  ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     return internalGetEntries<
-      EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locale>
-    >({ locale, ...query }, false)
+      EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>
+    >({ ...query, locale: '*' }, false)
   }
 
   async function internalGetEntry<RValue>(

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -44,7 +44,7 @@ export type UnresolvedClient = {
   getEntries<Fields extends FieldsType = FieldsType>(
     query?: EntriesQueries<Fields>
   ): Promise<EntryCollection<Fields>>
-  localized: UnresolvedLocalizedClient
+  withAllLocales: UnresolvedLocalizedClient
 }
 
 export type UnresolvedLocalizedClient = {
@@ -335,9 +335,9 @@ export type ContentfulClientApi = {
    */
   createAssetKey(expiresAt: number): Promise<AssetKey>
 
-  unresolved: UnresolvedClient
+  withoutLinkResolution: UnresolvedClient
 
-  localized: LocalizedClient
+  withAllLocales: LocalizedClient
 }
 
 interface CreateContentfulApiParams {
@@ -452,6 +452,9 @@ export default function createContentfulApi({
     return internalGetEntries<ResolvedEntryCollection<Fields>>(query, true)
   }
 
+  // TODO: third param and second type param are irrelevant,
+  // as the only configuration which returns localized fields is `locale='*'`
+  // so we make this the default and remove the `locale` param
   async function getLocalizedEntry<Fields, Locale extends LocaleValue = any>(
     id: string,
     query: EntryQueries = {},
@@ -634,16 +637,16 @@ export default function createContentfulApi({
 
     createAssetKey,
 
-    localized: {
+    withAllLocales: {
       getEntry: getLocalizedEntry,
       getEntries: getLocalizedEntries,
     },
 
-    unresolved: {
+    withoutLinkResolution: {
       getEntry: getUnresolvedEntry,
       getEntries: getUnresolvedEntries,
 
-      localized: {
+      withAllLocales: {
         getEntry: getUnresolvedLocalizedEntry,
         getEntries: getUnresolvedLocalizedEntries,
       },

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -118,11 +118,11 @@ export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TE
   }
 }
 
+export type EntryCollection<T> = AbstractEntryCollection<Entry<T>>
+
 export type EntryWithoutLinkResolution<T> = Entry<T>
 
-export type EntryCollectionWithoutLinkResolution<T> = AbstractEntryCollection<
-  EntryWithoutLinkResolution<T>
->
+export type EntryCollectionWithoutLinkResolution<T> = EntryCollection<T>
 
 export type EntryCollectionWithLinkResolution<T> = AbstractEntryCollection<
   EntryWithLinkResolution<T>

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -54,6 +54,7 @@ export interface Entry<T> {
 }
 
 // TODO use EntryLink from link.ts instead
+// TODO remove generic
 interface EntryLink<T> {
   sys: {
     type: 'Link'
@@ -62,7 +63,11 @@ interface EntryLink<T> {
   }
 }
 
-export interface LocalizedEntry<Fields extends FieldsType, Locale extends LocaleValue> {
+// TODO remove Locale param
+export interface EntryWithAllLocalesAndWithoutLinkResolution<
+  Fields extends FieldsType,
+  Locale extends LocaleValue
+> {
   sys: EntrySys
   fields: {
     [FieldName in keyof Fields]: {
@@ -72,30 +77,33 @@ export interface LocalizedEntry<Fields extends FieldsType, Locale extends Locale
   metadata: Metadata
 }
 
-export type ResolvedEntry<Fields extends FieldsType> = {
+export type EntryWithLinkResolution<Fields extends FieldsType> = {
   sys: EntrySys
   fields: {
     [FieldName in keyof Fields]: Fields[FieldName] extends
       | EntryLink<infer LinkedEntryFields>
       | undefined
-      ? ResolvedEntry<LinkedEntryFields>
+      ? EntryWithLinkResolution<LinkedEntryFields>
       : Fields[FieldName] extends Array<EntryLink<infer LinkedEntryFields>> | undefined
-      ? Array<ResolvedEntry<LinkedEntryFields>>
+      ? Array<EntryWithLinkResolution<LinkedEntryFields>>
       : Fields[FieldName]
   }
   metadata: Metadata
 }
 
-export type ResolvedLocalizedEntry<Fields extends FieldsType, Locales extends LocaleValue> = {
+export type EntryWithAllLocalesAndWithLinkResolution<
+  Fields extends FieldsType,
+  Locales extends LocaleValue
+> = {
   sys: EntrySys
   fields: {
     [FieldName in keyof Fields]: {
       [LocaleName in Locales]?: Fields[FieldName] extends
         | EntryLink<infer LinkedEntryFields>
         | undefined
-        ? ResolvedLocalizedEntry<LinkedEntryFields, Locales>
+        ? EntryWithAllLocalesAndWithLinkResolution<LinkedEntryFields, Locales>
         : Fields[FieldName] extends Array<EntryLink<infer LinkedEntryFields>> | undefined
-        ? Array<ResolvedLocalizedEntry<LinkedEntryFields, Locales>>
+        ? Array<EntryWithAllLocalesAndWithLinkResolution<LinkedEntryFields, Locales>>
         : Fields[FieldName]
     }
   }
@@ -110,15 +118,22 @@ export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TE
   }
 }
 
-export type EntryCollection<T> = AbstractEntryCollection<Entry<T>>
+export type EntryWithoutLinkResolution<T> = Entry<T>
 
-export type ResolvedEntryCollection<T> = AbstractEntryCollection<ResolvedEntry<T>>
-
-export type LocalizedEntryCollection<Fields, Locales extends LocaleValue> = AbstractEntryCollection<
-  LocalizedEntry<Fields, Locales>
+export type EntryCollectionWithoutLinkResolution<T> = AbstractEntryCollection<
+  EntryWithoutLinkResolution<T>
 >
 
-export type ResolvedLocalizedEntryCollection<
+export type EntryCollectionWithLinkResolution<T> = AbstractEntryCollection<
+  EntryWithLinkResolution<T>
+>
+
+export type EntryCollectionWithAllLocalesAndWithoutLinkResolution<
   Fields,
   Locales extends LocaleValue
-> = AbstractEntryCollection<ResolvedLocalizedEntry<Fields, Locales>>
+> = AbstractEntryCollection<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+
+export type EntryCollectionWithAllLocalesAndWithLinkResolution<
+  Fields,
+  Locales extends LocaleValue
+> = AbstractEntryCollection<EntryWithAllLocalesAndWithLinkResolution<Fields, Locales>>

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -2,7 +2,7 @@ import { Document as RichTextDocument } from '@contentful/rich-text-types'
 import { Asset } from './asset'
 import { ContentfulCollection } from './collection'
 import { ContentTypeLink } from './link'
-import { LocaleValue } from './locale'
+import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { FieldsType } from './query/util'
 import { EntitySys } from './sys'
@@ -63,15 +63,14 @@ interface EntryLink<T> {
   }
 }
 
-// TODO remove Locale param
 export interface EntryWithAllLocalesAndWithoutLinkResolution<
   Fields extends FieldsType,
-  Locale extends LocaleValue
+  Locales extends LocaleCode
 > {
   sys: EntrySys
   fields: {
     [FieldName in keyof Fields]: {
-      [LocaleName in Locale]?: Fields[FieldName]
+      [LocaleName in Locales]?: Fields[FieldName]
     }
   }
   metadata: Metadata
@@ -93,7 +92,7 @@ export type EntryWithLinkResolution<Fields extends FieldsType> = {
 
 export type EntryWithAllLocalesAndWithLinkResolution<
   Fields extends FieldsType,
-  Locales extends LocaleValue
+  Locales extends LocaleCode
 > = {
   sys: EntrySys
   fields: {
@@ -130,10 +129,10 @@ export type EntryCollectionWithLinkResolution<T> = AbstractEntryCollection<
 
 export type EntryCollectionWithAllLocalesAndWithoutLinkResolution<
   Fields,
-  Locales extends LocaleValue
+  Locales extends LocaleCode
 > = AbstractEntryCollection<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 
 export type EntryCollectionWithAllLocalesAndWithLinkResolution<
   Fields,
-  Locales extends LocaleValue
+  Locales extends LocaleCode
 > = AbstractEntryCollection<EntryWithAllLocalesAndWithLinkResolution<Fields, Locales>>

--- a/lib/types/locale.ts
+++ b/lib/types/locale.ts
@@ -1,7 +1,7 @@
 import { ContentfulCollection } from './collection'
 import { BaseSys } from './sys'
 
-export type LocaleValue = keyof any | '*'
+export type LocaleCode = string
 
 export interface LocaleSys extends BaseSys {
   type: 'Locale'

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -1,5 +1,10 @@
 import { expectAssignable, expectType } from 'tsd'
-import { Entry, EntryFields, EntrySys, LocalizedEntry } from '../../lib'
+import {
+  Entry,
+  EntryFields,
+  EntrySys,
+  EntryWithAllLocalesAndWithoutLinkResolution,
+} from '../../lib'
 
 export const stringValue = ''
 export const numberValue = 123
@@ -26,7 +31,9 @@ expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
   metadata: metadataValue,
 })
 
-expectAssignable<LocalizedEntry<{ stringField: EntryFields.Text }, 'US' | 'DE'>>({
+expectAssignable<
+  EntryWithAllLocalesAndWithoutLinkResolution<{ stringField: EntryFields.Text }, 'US' | 'DE'>
+>({
   sys: entrySysValue,
   fields: {
     stringField: {
@@ -39,7 +46,7 @@ expectAssignable<LocalizedEntry<{ stringField: EntryFields.Text }, 'US' | 'DE'>>
 
 // TODO fix test
 /*
-expectAssignable<ResolvedEntry<{ referenceField: EntryLink }>>({
+expectAssignable<EntryWithLinkResolution<{ referenceField: EntryLink }>>({
   sys: entrySysValue,
   fields: {
     referenceField: {

--- a/test/unit/create-contentful-api.test.ts
+++ b/test/unit/create-contentful-api.test.ts
@@ -168,7 +168,7 @@ describe('create-contentful-api', () => {
     await expect(api.getEntries()).resolves.toEqual(data)
   })
 
-  test('API call getEntries with global resolve links overridden by query', async () => {
+  test('API call getEntries with global resolveLinks overridden by chained modifier', async () => {
     const data = { sys: { id: 'id' } }
     const { api } = setupWithData({
       promise: Promise.resolve({ data: data }),
@@ -179,11 +179,11 @@ describe('create-contentful-api', () => {
       }),
     })
 
-    await expect(api.unresolved.getEntries()).resolves.toEqual(data)
+    await expect(api.withoutLinkResolution.getEntries()).resolves.toEqual(data)
     expect(resolveCircularMock.mock.calls[0][1].resolveLinks).toBeFalsy()
   })
 
-  test('API call getEntries with global resolve links turned off', async () => {
+  test('API call getEntries with global resolveLinks turned on', async () => {
     const data = { sys: { id: 'id' } }
 
     const { api } = setupWithData({


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Update name of chained client modifiers

## Description

- update names of client modifiers. `localized` to `withAllLocales` and `unresolved` to `withoutLinkResolution`
- update related type names
- fix/improve tests
- remove locale function param in calls to `withAllLocales` client and query `locale='*'` as default