### PR TITLE
Restrict locale param from clients

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -488,6 +488,9 @@ export default function createContentfulApi<OptionType>(
   async function getEntriesWithLinkResolution<Fields>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolution<Fields>> {
+    if (query.locale === '*') {
+      console.warn('If you want to fetch all the locales, we recommend to use the .withAllLocales')
+    }
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)
   }
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -485,7 +485,7 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
+        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
       )
     }
     return internalGetEntry<EntryWithLinkResolution<Fields>>(id, query, true)
@@ -496,7 +496,7 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryCollectionWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
+        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
       )
     }
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -484,7 +484,7 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
+        'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
       )
     }
     return internalGetEntry<EntryWithLinkResolution<Fields>>(id, query, true)
@@ -495,7 +495,7 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryCollectionWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
+        'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
       )
     }
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)
@@ -509,7 +509,7 @@ export default function createContentfulApi<OptionType>(
     query: EntryQueries = {}
   ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>> {
     if (query.locale) {
-      throw new ValidationError('locale', 'locale parameter is not allowed')
+      throw new ValidationError('locale', 'The `locale` parameter is not allowed')
     }
     return internalGetEntry<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>>(
       id,
@@ -525,7 +525,7 @@ export default function createContentfulApi<OptionType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>> {
     if (query.locale) {
-      throw new ValidationError('locale', 'locale parameter is not allowed')
+      throw new ValidationError('locale', 'The `locale` parameter is not allowed')
     }
     return internalGetEntries<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>(
       { ...query, locale: '*' },
@@ -554,7 +554,7 @@ export default function createContentfulApi<OptionType>(
     query: EntryQueries = {}
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     if (query.locale) {
-      throw new ValidationError('locale', 'locale parameter is not allowed')
+      throw new ValidationError('locale', 'The `locale` parameter is not allowed')
     }
     return internalGetEntry<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>(
       id,
@@ -570,7 +570,7 @@ export default function createContentfulApi<OptionType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     if (query.locale) {
-      throw new ValidationError('locale', 'locale parameter is not allowed')
+      throw new ValidationError('locale', 'The `locale` parameter is not allowed')
     }
     return internalGetEntries<
       EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -71,7 +71,7 @@ export interface ClientWithAllLocalesAndWithLinkResolution
   extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
   getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
     id: string,
-    query?: EntryQueries
+    query?: EntryQueries & { locale?: never }
   ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, Locales>>
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = string>(
     query?: EntriesQueries<Fields> & { locale?: never }
@@ -81,7 +81,7 @@ export interface ClientWithAllLocalesAndWithoutLinkResolution
   extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
   getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
     id: string,
-    query?: EntryQueries
+    query?: EntryQueries & { locale?: never }
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = string>(
     query?: EntriesQueries<Fields> & { locale?: never }
@@ -482,6 +482,11 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithLinkResolution<Fields>> {
+    if (query.locale === '*') {
+      console.warn(
+        'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
+      )
+    }
     return internalGetEntry<EntryWithLinkResolution<Fields>>(id, query, true)
   }
 
@@ -503,6 +508,9 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>> {
+    if (query.locale) {
+      throw new ValidationError('locale', 'locale parameter is not allowed')
+    }
     return internalGetEntry<EntryWithAllLocalesAndWithLinkResolution<Fields, SpaceLocales>>(
       id,
       { ...query, locale: '*' },
@@ -545,6 +553,9 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
+    if (query.locale) {
+      throw new ValidationError('locale', 'locale parameter is not allowed')
+    }
     return internalGetEntry<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>(
       id,
       { ...query, locale: '*' },

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -36,7 +36,8 @@ import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
-import validateTimestamp, { ValidationError } from './utils/validate-timestamp'
+import validateTimestamp from './utils/validate-timestamp'
+import { ValidationError } from './utils/validation-error'
 import {
   ChainOptions,
   isClientWithAllLocalesAndWithLinkResolution,

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -74,7 +74,7 @@ export interface ClientWithAllLocalesAndWithLinkResolution
     query?: EntryQueries
   ): Promise<EntryWithAllLocalesAndWithLinkResolution<Fields, Locales>>
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = string>(
-    query?: EntriesQueries<Fields>
+    query?: EntriesQueries<Fields> & { locale?: never }
   ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>
 }
 export interface ClientWithAllLocalesAndWithoutLinkResolution
@@ -84,7 +84,7 @@ export interface ClientWithAllLocalesAndWithoutLinkResolution
     query?: EntryQueries
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = string>(
-    query?: EntriesQueries<Fields>
+    query?: EntriesQueries<Fields> & { locale?: never }
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 }
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -489,7 +489,9 @@ export default function createContentfulApi<OptionType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolution<Fields>> {
     if (query.locale === '*') {
-      console.warn('If you want to fetch all the locales, we recommend to use the .withAllLocales')
+      console.warn(
+        'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
+      )
     }
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)
   }

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -511,6 +511,9 @@ export default function createContentfulApi<OptionType>(
   >(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>> {
+    if (query.locale) {
+      throw new Error('locale parameter is not allowed')
+    }
     return internalGetEntries<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>(
       { ...query, locale: '*' },
       true
@@ -550,6 +553,9 @@ export default function createContentfulApi<OptionType>(
   >(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
+    if (query.locale) {
+      throw new Error('locale parameter is not allowed')
+    }
     return internalGetEntries<
       EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>
     >({ ...query, locale: '*' }, false)

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -36,7 +36,7 @@ import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
-import validateTimestamp from './utils/validate-timestamp'
+import validateTimestamp, { ValidationError } from './utils/validate-timestamp'
 import {
   ChainOptions,
   isClientWithAllLocalesAndWithLinkResolution,
@@ -512,7 +512,7 @@ export default function createContentfulApi<OptionType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>> {
     if (query.locale) {
-      throw new Error('locale parameter is not allowed')
+      throw new ValidationError('locale', 'locale parameter is not allowed')
     }
     return internalGetEntries<EntryCollectionWithAllLocalesAndWithLinkResolution<Fields, Locales>>(
       { ...query, locale: '*' },
@@ -554,7 +554,7 @@ export default function createContentfulApi<OptionType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     if (query.locale) {
-      throw new Error('locale parameter is not allowed')
+      throw new ValidationError('locale', 'locale parameter is not allowed')
     }
     return internalGetEntries<
       EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>

--- a/lib/utils/validate-timestamp.ts
+++ b/lib/utils/validate-timestamp.ts
@@ -1,9 +1,4 @@
-export class ValidationError extends Error {
-  constructor(name: string, message: string) {
-    super(`Invalid "${name}" provided, ` + message)
-    this.name = 'ValidationError'
-  }
-}
+import { ValidationError } from './validation-error'
 
 type Options = {
   maximum?: number

--- a/lib/utils/validation-error.ts
+++ b/lib/utils/validation-error.ts
@@ -1,0 +1,6 @@
+export class ValidationError extends Error {
+  constructor(name: string, message: string) {
+    super(`Invalid "${name}" provided, ` + message)
+    this.name = 'ValidationError'
+  }
+}

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,4 +1,5 @@
 import * as contentful from '../../lib/contentful'
+import { ValidationError } from '../../lib/utils/validate-timestamp'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {
@@ -94,40 +95,24 @@ describe('getEntries via chained clients', () => {
     })
 
     describe('Localized client', () => {
-      it('throws a warning when locale is passed to the options', async () => {
-        try {
-          const entries = await client.withAllLocales.getEntries({
+      it('throws an error when locale is passed to the options', async () => {
+        await expect(
+          client.withAllLocales.getEntries({
             'sys.id': 'nyancat',
             // @ts-ignore
             locale: '*',
           })
-          expect(entries).toBe('this should throw an error')
-        } catch (err) {
-          // @ts-ignore
-          // for (const prop in err) {
-          //   console.log(`Log: ${prop}`)
-          // }
-          // console.log(err)
-          // console.log(typeof err)
-          // console.log(JSON.stringify(err, null, 2))
-          // console.log(err)
-
-          // TODO: check why the error doesn't have prop 'message' and make a better assertion
-          expect(err).toBeDefined()
-        }
+        ).rejects.toThrow(ValidationError)
       })
-      it('.withoutLinkResolution: throws a warning when locale is passed to the options', async () => {
-        try {
-          const entries = await client.withAllLocales.withoutLinkResolution.getEntries({
+      it('.withoutLinkResolution: throws an error when locale is passed to the options', async () => {
+        await expect(
+          client.withAllLocales.withoutLinkResolution.getEntries({
             'sys.id': 'nyancat',
             // @ts-ignore
             locale: '*',
           })
-          expect(entries).toBe('this should throw an error')
-        } catch (err) {
-          expect(err).toBeDefined()
-        }
+        ).rejects.toThrow(ValidationError)
       })
     })
-  })  
+  })
 })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -83,4 +83,51 @@ describe('getEntries via chained clients', () => {
         : expect(entries.items[0].fields.bestFriend).toEqual(unresolvedLink)
     }
   )
+  describe('Restricted client params', () => {
+    describe('default client', () => {
+      it('throws a warning when locale is passed to the options', async () => {
+        // warning
+        const entries = await client.getEntries({ 'sys.id': 'nyancat', locale: '*' })
+
+        expect(entries).toBeDefined()
+      })
+    })
+
+    describe('Localized client', () => {
+      it('throws a warning when locale is passed to the options', async () => {
+        try {
+          const entries = await client.withAllLocales.getEntries({
+            'sys.id': 'nyancat',
+            // @ts-ignore
+            locale: '*',
+          })
+          expect(entries).toBe('this should throw an error')
+        } catch (err) {
+          // @ts-ignore
+          // for (const prop in err) {
+          //   console.log(`Log: ${prop}`)
+          // }
+          // console.log(err)
+          // console.log(typeof err)
+          // console.log(JSON.stringify(err, null, 2))
+          // console.log(err)
+
+          // TODO: check why the error doesn't have prop 'message' and make a better assertion
+          expect(err).toBeDefined()
+        }
+      })
+      it('.withoutLinkResolution: throws a warning when locale is passed to the options', async () => {
+        try {
+          const entries = await client.withAllLocales.withoutLinkResolution.getEntries({
+            'sys.id': 'nyancat',
+            // @ts-ignore
+            locale: '*',
+          })
+          expect(entries).toBe('this should throw an error')
+        } catch (err) {
+          expect(err).toBeDefined()
+        }
+      })
+    })
+  })  
 })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,5 +1,5 @@
 import * as contentful from '../../lib/contentful'
-import { ValidationError } from '../../lib/utils/validate-timestamp'
+import { ValidationError } from '../../lib/utils/validation-error'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {
@@ -84,37 +84,4 @@ describe('getEntries via chained clients', () => {
         : expect(entries.items[0].fields.bestFriend).toEqual(unresolvedLink)
     }
   )
-  describe('Restricted client params', () => {
-    describe('default client', () => {
-      it('throws a warning when locale is passed to the options', () => {
-        const consoleWarnSpy = jest.spyOn(global.console, 'warn')
-        client.getEntries({ 'sys.id': 'nyancat', locale: '*' })
-        expect(consoleWarnSpy).toBeCalled()
-        expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
-        )
-      })
-    })
-
-    describe('Localized client', () => {
-      it('throws an error when locale is passed to the options', async () => {
-        await expect(
-          client.withAllLocales.getEntries({
-            'sys.id': 'nyancat',
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
-      })
-      it('.withoutLinkResolution: throws an error when locale is passed to the options', async () => {
-        await expect(
-          client.withAllLocales.withoutLinkResolution.getEntries({
-            'sys.id': 'nyancat',
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
-      })
-    })
-  })
 })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -91,7 +91,7 @@ describe('getEntries via chained clients', () => {
         client.getEntries({ 'sys.id': 'nyancat', locale: '*' })
         expect(consoleWarnSpy).toBeCalled()
         expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          'If you want to fetch all the locales, we recommend to use the .withAllLocales'
+          'If you want to fetch all the locales, we recommend you to use client.withAllLocales'
         )
       })
     })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -86,11 +86,13 @@ describe('getEntries via chained clients', () => {
   )
   describe('Restricted client params', () => {
     describe('default client', () => {
-      it('throws a warning when locale is passed to the options', async () => {
-        // warning
-        const entries = await client.getEntries({ 'sys.id': 'nyancat', locale: '*' })
-
-        expect(entries).toBeDefined()
+      it('throws a warning when locale is passed to the options', () => {
+        const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+        client.getEntries({ 'sys.id': 'nyancat', locale: '*' })
+        expect(consoleWarnSpy).toBeCalled()
+        expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+          'If you want to fetch all the locales, we recommend to use the .withAllLocales'
+        )
       })
     })
 

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,5 +1,4 @@
 import * as contentful from '../../lib/contentful'
-import { ValidationError } from '../../lib/utils/validation-error'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -1,6 +1,6 @@
 import { EntryFields } from '../../lib'
 import * as contentful from '../../lib/contentful'
-import { ValidationError } from '../../lib/utils/validate-timestamp'
+import { ValidationError } from '../../lib/utils/validation-error'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/test/unit/make-contentful-api-client-chained-modifier.test.ts
+++ b/test/unit/make-contentful-api-client-chained-modifier.test.ts
@@ -72,7 +72,7 @@ describe('Contentful API client chained modifier', () => {
         api.getEntries({ locale: '*' })
         expect(consoleWarnSpy).toBeCalled()
         expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
+          `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
         )
         consoleWarnSpy.mockRestore()
       })
@@ -83,7 +83,7 @@ describe('Contentful API client chained modifier', () => {
 
         expect(consoleWarnSpy).toBeCalled()
         expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
+          `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
         )
         consoleWarnSpy.mockRestore()
       })

--- a/test/unit/make-contentful-api-client-chained-modifier.test.ts
+++ b/test/unit/make-contentful-api-client-chained-modifier.test.ts
@@ -1,0 +1,94 @@
+import { AxiosRequestHeaders, HeadersDefaults } from 'axios'
+import createGlobalOptions from '../../lib/create-global-options'
+import { makeClient } from '../../lib/make-client'
+import * as resolveCircular from '../../lib/utils/resolve-circular'
+import { ValidationError } from '../../lib/utils/validation-error'
+import * as mocks from './mocks'
+
+function setupWithData({
+  promise,
+  getGlobalOptions = jest.fn().mockReturnValue({
+    resolveLinks: true,
+    removeUnresolved: false,
+    spaceBaseUrl: 'spaceUrl',
+    environment: 'master',
+    environmentBaseUrl: 'environmentUrl',
+  }),
+}) {
+  const getStub = jest.fn()
+  const postStub = jest.fn()
+  const api = makeClient({
+    // @ts-ignore
+    http: {
+      // @ts-expect-error
+      defaults: { baseURL: 'baseURL', logHandler: jest.fn(), headers: {} as HeadersDefaults },
+      get: getStub.mockReturnValue(promise),
+      post: postStub.mockReturnValue(promise),
+    },
+    getGlobalOptions,
+  })
+
+  return {
+    api,
+    getStub,
+    postStub,
+  }
+}
+
+describe('Contentful API client chained modifier', () => {
+  const resolveCircularMock = jest.fn()
+  // @ts-ignore
+  resolveCircular.default = resolveCircularMock
+
+  const data = {
+    sys: {
+      id: 'id',
+    },
+  }
+
+  const { api } = setupWithData({
+    promise: Promise.resolve({ data }),
+  })
+
+  beforeEach(() => {
+    resolveCircularMock.mockImplementation((args) => {
+      return args
+    })
+  })
+
+  afterEach(() => {
+    resolveCircularMock.mockReset()
+  })
+
+  describe('Restricted client params', () => {
+    describe('default client', () => {
+      it('throws a warning when locale is passed to the options', () => {
+        const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+        api.getEntries({ 'sys.id': 'nyancat', locale: '*' })
+        expect(consoleWarnSpy).toBeCalled()
+        expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+          'If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales'
+        )
+      })
+    })
+
+    describe('Localized api', () => {
+      it('throws an error when locale is passed to the options', async () => {
+        await expect(
+          api.withAllLocales.getEntries({
+            // @ts-ignore
+            locale: '*',
+          })
+        ).rejects.toThrow(ValidationError)
+      })
+      it('.withoutLinkResolution: throws an error when locale is passed to the options', async () => {
+        await expect(
+          api.withAllLocales.withoutLinkResolution.getEntries({
+            // @ts-ignore
+            locale: '*',
+          })
+        ).rejects.toThrow(ValidationError)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Implementation changes  


- **Default** **client** shows a warning if `locale: '*'` param is provided, pointing to the new dedicated client 

- **Localized** **client** throws an error if `locale` property is provided 
