### PR TITLE
Restrict usage of unresolved param

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -62,10 +62,10 @@ export interface ClientWithLinkResolution extends BaseClient {
 export interface ClientWithoutLinkResolution extends BaseClient {
   getEntry<Fields extends FieldsType>(
     id: string,
-    query?: EntryQueries
+    query?: EntryQueries & { resolveLinks?: never }
   ): Promise<EntryWithoutLinkResolution<Fields>>
   getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
+    query?: EntriesQueries<Fields> & { resolveLinks?: never }
   ): Promise<EntryCollectionWithoutLinkResolution<Fields>>
 }
 export interface ClientWithAllLocalesAndWithLinkResolution
@@ -82,10 +82,10 @@ export interface ClientWithAllLocalesAndWithoutLinkResolution
   extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
   getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
     id: string,
-    query?: EntryQueries & { locale?: never }
+    query?: EntryQueries & { locale?: never; resolveLinks?: never }
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = string>(
-    query?: EntriesQueries<Fields> & { locale?: never }
+    query?: EntriesQueries<Fields> & { locale?: never; resolveLinks?: never }
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 }
 
@@ -485,7 +485,12 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
+        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
+      )
+    }
+    if ('resolveLinks' in query) {
+      console.warn(
+        'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
       )
     }
     return internalGetEntry<EntryWithLinkResolution<Fields>>(id, query, true)
@@ -496,7 +501,12 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryCollectionWithLinkResolution<Fields>> {
     if (query.locale === '*') {
       console.warn(
-        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
+        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
+      )
+    }
+    if ('resolveLinks' in query) {
+      console.warn(
+        'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
       )
     }
     return internalGetEntries<EntryCollectionWithLinkResolution<Fields>>(query, true)
@@ -538,12 +548,18 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithoutLinkResolution<Fields>> {
+    if ('resolveLinks' in query) {
+      throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
+    }
     return internalGetEntry<EntryWithoutLinkResolution<Fields>>(id, query, false)
   }
 
   async function getEntriesWithoutLinkResolution<Fields>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithoutLinkResolution<Fields>> {
+    if ('resolveLinks' in query) {
+      throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
+    }
     return internalGetEntries<EntryCollectionWithoutLinkResolution<Fields>>(query, false)
   }
 
@@ -556,6 +572,9 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     if (query.locale) {
       throw new ValidationError('locale', 'The `locale` parameter is not allowed')
+    }
+    if ('resolveLinks' in query) {
+      throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
     }
     return internalGetEntry<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>(
       id,
@@ -572,6 +591,9 @@ export default function createContentfulApi<OptionType>(
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>> {
     if (query.locale) {
       throw new ValidationError('locale', 'The `locale` parameter is not allowed')
+    }
+    if ('resolveLinks' in query) {
+      throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
     }
     return internalGetEntries<
       EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>

--- a/test/unit/make-contentful-api-client-chained-modifier.test.ts
+++ b/test/unit/make-contentful-api-client-chained-modifier.test.ts
@@ -67,63 +67,147 @@ describe('Contentful API client chained modifier', () => {
 
   describe('Restricted client params', () => {
     describe('Default client', () => {
-      it('getEntries: throws a warning when locale is passed to the options', () => {
-        const consoleWarnSpy = jest.spyOn(global.console, 'warn')
-        api.getEntries({ locale: '*' })
-        expect(consoleWarnSpy).toBeCalled()
-        expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
-        )
-        consoleWarnSpy.mockRestore()
+      describe('getEntries', () => {
+        it('throws a warning when locale is passed to the options', async () => {
+          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+          await api.getEntries({ locale: '*' })
+          expect(consoleWarnSpy).toBeCalled()
+          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+            `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
+          )
+          consoleWarnSpy.mockRestore()
+        })
+
+        it('throws a warning when resolveLinks is explicitly set to false', async () => {
+          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+          await api.getEntries({ resolveLinks: false })
+          expect(consoleWarnSpy).toBeCalled()
+          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+            'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
+          )
+          consoleWarnSpy.mockRestore()
+        })
       })
 
-      it('getEntry: throws a warning when locale is passed to the options', async () => {
-        const consoleWarnSpy = jest.spyOn(global.console, 'warn')
-        await api.getEntry('id', { locale: '*' })
+      describe('getEntry', () => {
+        it('throws a warning when locale is passed to the options', async () => {
+          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+          await api.getEntry('id', { locale: '*' })
+          expect(consoleWarnSpy).toBeCalled()
+          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+            `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
+          )
+          consoleWarnSpy.mockRestore()
+        })
 
-        expect(consoleWarnSpy).toBeCalled()
-        expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-          `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter`
-        )
-        consoleWarnSpy.mockRestore()
+        it('throws a warning when resolveLinks parameter is explicitly set to false', async () => {
+          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
+          await api.getEntry('id', { resolveLinks: false })
+          expect(consoleWarnSpy).toBeCalled()
+          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
+            'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
+          )
+          consoleWarnSpy.mockRestore()
+        })
       })
     })
 
-    describe('Localized client', () => {
-      it('getEntries: throws an error when locale is passed to the options', async () => {
-        await expect(
-          api.withAllLocales.getEntries({
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
+    describe('client with chained modifiers', () => {
+      describe('getEntries', () => {
+        it('throws error when locale parameter is passed to client.withAllLocales', async () => {
+          await expect(
+            api.withAllLocales.getEntries({
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
+        })
+
+        it('throws error when locale parameter is passed to client.withAllLocales.withoutLinkResolution', async () => {
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntries({
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
+        })
+        it('throws error when resolveLinks parameter is passed to client.withoutLinkResolution', async () => {
+          await expect(
+            api.withoutLinkResolution.getEntries({
+              // @ts-ignore
+              resolveLinks: false,
+            })
+          ).rejects.toThrow(ValidationError)
+          await expect(
+            api.withoutLinkResolution.getEntries({
+              // @ts-ignore
+              resolveLinks: true,
+            })
+          ).rejects.toThrow(ValidationError)
+        })
+        it('throws error when resolveLinks parameter is passed to client.withoutLinkResolution.withAllLocales', async () => {
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntries({
+              // @ts-ignore
+              resolveLinks: false,
+            })
+          ).rejects.toThrow(ValidationError)
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntries({
+              // @ts-ignore
+              resolveLinks: true,
+            })
+          ).rejects.toThrow(ValidationError)
+        })
       })
 
-      it('getEntries: .withoutLinkResolution: throws an error when locale is passed to the options', async () => {
-        await expect(
-          api.withAllLocales.withoutLinkResolution.getEntries({
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
-      })
+      describe('getEntry', () => {
+        it('throws error when locale parameter is passed to client.withAllLocales', async () => {
+          await expect(
+            api.withAllLocales.getEntry('id', {
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
+        })
 
-      it('getEntry: throws an error when locale is passed to the options', async () => {
-        await expect(
-          api.withAllLocales.getEntry('id', {
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
-      })
+        it('throws error when locale parameter is passed to client.withAllLocales.withoutLinkResolution', async () => {
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntry('id', {
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
+        })
 
-      it('getEntry: .withoutLinkResolution: throws an error when locale is passed to the options', async () => {
-        await expect(
-          api.withAllLocales.withoutLinkResolution.getEntry('id', {
-            // @ts-ignore
-            locale: '*',
-          })
-        ).rejects.toThrow(ValidationError)
+        it('throws error when resolveLinks parameter is passed to client.withoutLinkResolution', async () => {
+          await expect(
+            api.withoutLinkResolution.getEntry('id', {
+              // @ts-ignore
+              resolveLinks: false,
+            })
+          ).rejects.toThrow(ValidationError)
+          await expect(
+            api.withoutLinkResolution.getEntry('id', {
+              // @ts-ignore
+              resolveLinks: true,
+            })
+          ).rejects.toThrow(ValidationError)
+        })
+        it('throws error when resolveLinks parameter is passed to client.withoutLinkResolution.withAllLocales', async () => {
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntry('id', {
+              // @ts-ignore
+              resolveLinks: false,
+            })
+          ).rejects.toThrow(ValidationError)
+          await expect(
+            api.withAllLocales.withoutLinkResolution.getEntry('id', {
+              // @ts-ignore
+              resolveLinks: true,
+            })
+          ).rejects.toThrow(ValidationError)
+        })
       })
     })
   })


### PR DESCRIPTION
- add tests for resolveLinks warnings and errors ✅ 
- implement according to test structure ✅ 
- Double check potential "false positive" warnings when parameter is set not by the user but programmatically. ✅ 

Should be merged into `next-typescript` after [feat/localized-client-restrict-locale-param](https://github.com/contentful/contentful.js/tree/feat/localized-client-restrict-locale-param).
