### PR TITLE
Expand get entries integration tests

### DIFF
--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -185,14 +185,6 @@ test.skip('Gets entry with link resolution and includes, removing unresolvable l
 
 // TODO move tests with client.withoutUnresolvableLinks to getEntries/getEntry integration test files
 // TODO add localized
-test('Gets entries with link resolution and includes, removing unresolvable links via client chain', async () => {
-  const response = await client.withoutUnresolvableLinks.getEntries({
-    'sys.id': '4SEhTg8sYJ1H3wDAinzhTp',
-    include: 2,
-  })
-  expect(response.items[0].fields).toBeDefined()
-  expect(response.items[0].fields.bestFriend).toBeUndefined()
-})
 test('Gets entry with link resolution and includes, removing unresolvable links via client chain', async () => {
   const response = await client.withoutUnresolvableLinks.getEntry('4SEhTg8sYJ1H3wDAinzhTp', {
     include: 2,
@@ -200,7 +192,7 @@ test('Gets entry with link resolution and includes, removing unresolvable links 
   expect(response.fields).toBeDefined()
   expect(response.fields.bestFriend).toBeUndefined()
 })
-
+//TODO: Double check this behavior when we remove the support of the global config removeUnresolved
 test('Gets entries with link resolution and includes, removing unresolvable links, overriding client config with client chain', async () => {
   const keepUnresolvedClient = contentful.createClient({ ...params, removeUnresolved: false })
   const response = await keepUnresolvedClient.withoutUnresolvableLinks.getEntries({


### PR DESCRIPTION
## Summary

We changed the structure of the **getEnttries** tests, instead of adding all the tests in the matrix, we group them by client and its possible combination with other clients

We cover 🏗
 - default client
 - withoutUnresolvableLinks + combinations
 - withAllLocales + combinations
 - withoutLinkResolution + combinations


```
  getEntries via chained clients
    default client
      ✓ client (180 ms)
    client has withoutUnresolvableLinks modifier
      ✓ client.withoutUnresolvableLinks (113 ms)
      ○ skipped client.withoutUnresolvableLinks.withAllLocales
    client has withAllLocales modifier
      ✓ client.withAllLocales (112 ms)
      ✓ client.withAllLocales.withoutLinkResolution (107 ms)
      ○ skipped client.withAllLocales.withoutUnresolvableLinks
    client has withoutLinkResolution modifier
      ✓ client.withoutLinkResolution (110 ms)
      ✓ client.withoutLinkResolution.withAllLocales (116 ms)

```

## Open Question

After using `withoutUnresolvableLinks` with `withAllLocales` should I expect to don't have the property of my Link entry?

Current behavior: property exists with an empty object 
```
const response = await client.withoutUnresolvableLinks.withAllLocales.getEntries({
    'sys.id': entryWithUnresolvableLink,
    include: 2,
 })
expect(response.items[0].fields.bestFriend).toBeUndefined()
```

