### PR TITLE
feat(params): Remove asterisk as option for locale in client query param [SDK-1979]

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -77,7 +77,7 @@ export function createClient(params: CreateClientParams): ContentfulClientApi {
   const http = createHttpClient(axios, config)
 
   if (!http.defaults.baseURL) {
-    throw new Error('Please define a bseURL')
+    throw new Error('Please define a baseURL')
   }
 
   const getGlobalOptions = createGlobalOptions({

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -519,11 +519,7 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>> {
-    if (query.locale === '*') {
-      console.warn(
-        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
-      )
-    }
+    validateLocaleParam(query)
     if ('resolveLinks' in query) {
       console.warn(
         'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
@@ -537,11 +533,7 @@ export default function createContentfulApi<OptionType>(
   async function getEntriesWithLinkResolutionAndWithUnresolvableLinks<Fields>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>> {
-    if (query.locale === '*') {
-      console.warn(
-        `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
-      )
-    }
+    validateLocaleParam(query)
     if ('resolveLinks' in query) {
       console.warn(
         'The use of the `resolveLinks` parameter is discouraged. By default, links are resolved. If you do not want to resolve links, we recommend you to use client.withoutLinkResolution.'
@@ -557,6 +549,8 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>> {
+    validateLocaleParam(query)
+
     return internalGetEntry<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>(id, query, {
       withoutLinkResolution: false,
       withoutUnresolvableLinks: true,
@@ -566,6 +560,8 @@ export default function createContentfulApi<OptionType>(
   async function getEntriesWithLinkResolutionAndWithoutUnresolvableLinks<Fields>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>> {
+    validateLocaleParam(query)
+
     return internalGetEntries<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>(
       query,
       { withoutLinkResolution: false, withoutUnresolvableLinks: true }
@@ -646,6 +642,8 @@ export default function createContentfulApi<OptionType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithoutLinkResolution<Fields>> {
+    validateLocaleParam(query)
+
     if ('resolveLinks' in query) {
       throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
     }
@@ -657,6 +655,8 @@ export default function createContentfulApi<OptionType>(
   async function getEntriesWithoutLinkResolution<Fields>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithoutLinkResolution<Fields>> {
+    validateLocaleParam(query)
+
     if ('resolveLinks' in query) {
       throw new ValidationError('resolveLinks', 'The `resolveLinks` parameter is not allowed')
     }
@@ -876,6 +876,15 @@ export default function createContentfulApi<OptionType>(
   function parseEntries(data) {
     const { resolveLinks, removeUnresolved } = getGlobalOptions({})
     return resolveCircular(data, { resolveLinks, removeUnresolved })
+  }
+
+  function validateLocaleParam(query) {
+    if (query.locale === '*') {
+      throw new ValidationError(
+        'locale',
+        `To fetch an entry in all existing locales use client.withAllLocales instead of the locale='*' parameter.`
+      )
+    }
   }
 
   /*

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -509,8 +509,8 @@ describe('Sync API', () => {
   })
 })
 
-test("Gets entries with linked includes with all locales using locale:'*' parameter", async () => {
-  const response = await client.getEntries({ include: 5, 'sys.id': 'nyancat', locale: '*' })
+test('Gets entries with linked includes with all locales using the withAllLocales client chain modifier', async () => {
+  const response = await client.withAllLocales.getEntries({ include: 5, 'sys.id': 'nyancat' })
   assertLocalizedEntriesResponse(response)
 })
 
@@ -519,11 +519,10 @@ test('Gets entries with linked includes with all locales using withAllLocales cl
   assertLocalizedEntriesResponse(response)
 })
 
-test("Gets entries with linked includes with all locales using locale:'*' parameter in preview", async () => {
-  const response = await previewClient.getEntries({
+test('Gets entries with linked includes with all locales using the withAllLocales client chain modifier', async () => {
+  const response = await previewClient.withAllLocales.getEntries({
     include: 5,
     'sys.id': 'nyancat',
-    locale: '*',
   })
   assertLocalizedEntriesResponse(response)
 })

--- a/test/unit/make-contentful-api-client-chained-modifier.test.ts
+++ b/test/unit/make-contentful-api-client-chained-modifier.test.ts
@@ -65,13 +65,13 @@ describe('Contentful API client chained modifier', () => {
   describe('Restricted client params', () => {
     describe('Default client', () => {
       describe('getEntries', () => {
-        it('throws a warning when locale is passed to the options', async () => {
-          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
-          await api.getEntries({ locale: '*' })
-          expect(consoleWarnSpy).toBeCalled()
-          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-            `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
-          )
+        it('throws an error when locale=* is passed to the options', async () => {
+          await expect(
+            api.getEntries({
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
         })
 
         it('throws a warning when resolveLinks is explicitly set to false', async () => {
@@ -85,13 +85,13 @@ describe('Contentful API client chained modifier', () => {
       })
 
       describe('getEntry', () => {
-        it('throws a warning when locale is passed to the options', async () => {
-          const consoleWarnSpy = jest.spyOn(global.console, 'warn')
-          await api.getEntry('id', { locale: '*' })
-          expect(consoleWarnSpy).toBeCalled()
-          expect(consoleWarnSpy.mock.calls[0][0]).toBe(
-            `If you want to fetch entries in all existing locales, we recommend you to use client.withAllLocales instead of the locale='*' parameter.`
-          )
+        it('throws an error when locale=* is passed to the options', async () => {
+          await expect(
+            api.getEntry('id', {
+              // @ts-ignore
+              locale: '*',
+            })
+          ).rejects.toThrow(ValidationError)
         })
 
         it('throws a warning when resolveLinks parameter is explicitly set to false', async () => {


### PR DESCRIPTION
Remove * as an option for the locale query param for getEntries and getEntry. The query param `locale='*'` has been deprecated in favor of the client chain `withAllLocales`.