### PR TITLE
feat(types): suggest optional keys

### DIFF
--- a/lib/types/query/equality.ts
+++ b/lib/types/query/equality.ts
@@ -3,7 +3,7 @@ import { ConditionalQueries } from './util'
 
 // TODO: Note: Equality and inequality operators are not supported for text fields
 // What types do we hav to exclude here?
-type SupportedTypes = Exclude<BasicEntryField, EntryFields.RichText>
+type SupportedTypes = Exclude<BasicEntryField, EntryFields.RichText> | undefined
 /**
  * @desc equality - search for exact matches
  * @see [Documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/equality-operator}

--- a/lib/types/query/existence.ts
+++ b/lib/types/query/existence.ts
@@ -8,7 +8,7 @@ import { ConditionalFixedQueries } from './util'
  */
 export type ExistenceFilter<Fields, Prefix extends string> = ConditionalFixedQueries<
   Fields,
-  BasicEntryField,
+  BasicEntryField | undefined,
   boolean,
   Prefix,
   '[exists]'

--- a/lib/types/query/location.ts
+++ b/lib/types/query/location.ts
@@ -4,9 +4,9 @@ import { NonEmpty } from './util'
 
 type Types = EntryFields.Location
 
-export type ProximitySearchFilterInput = [number, number]
-export type BoundingBoxSearchFilterInput = [number, number, number, number]
-export type BoundingCircleSearchFilterInput = [number, number, number]
+export type ProximitySearchFilterInput = [number, number] | undefined
+export type BoundingBoxSearchFilterInput = [number, number, number, number] | undefined
+export type BoundingCircleSearchFilterInput = [number, number, number] | undefined
 
 type BaseLocationFilter<
   Fields,

--- a/lib/types/query/range.ts
+++ b/lib/types/query/range.ts
@@ -3,7 +3,7 @@ import { ConditionalQueries, NonEmpty } from './util'
 
 type RangeFilterTypes = 'lt' | 'lte' | 'gt' | 'gte'
 
-type SupportedTypes = EntryFields.Date | EntryFields.Number | EntryFields.Integer
+type SupportedTypes = EntryFields.Date | EntryFields.Number | EntryFields.Integer | undefined
 
 /**
  * @desc Range operators are available that you can apply to date and number fields

--- a/lib/types/query/search.ts
+++ b/lib/types/query/search.ts
@@ -2,7 +2,7 @@ import { BasicEntryField } from '../entry'
 import { ConditionalFixedQueries } from './util'
 
 // TODO: should Boolean field type be excluded
-type SupportedTypes = BasicEntryField
+type SupportedTypes = BasicEntryField | undefined
 /**
  * @desc match - full text search
  * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/full-text-search}

--- a/lib/types/query/subset.ts
+++ b/lib/types/query/subset.ts
@@ -2,10 +2,9 @@ import { BasicEntryField, EntryFields } from '..'
 import { ConditionalQueries, NonEmpty } from './util'
 
 type SubsetFilterTypes = 'in' | 'nin'
-type SupportedTypes = Exclude<
-  BasicEntryField,
-  EntryFields.Location | EntryFields.RichText | EntryFields.Object
->
+type SupportedTypes =
+  | Exclude<BasicEntryField, EntryFields.Location | EntryFields.RichText | EntryFields.Object>
+  | undefined
 
 /**
  * @desc inclusion & exclusion


### PR DESCRIPTION
Adds optional (field) keys to known field types.
If a field is optional, we also add generate a mapped type for it.
