### PR TITLE
fix: rename prerelease channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
       "master",
       "next",
       {
-        "name": "next-typescript",
+        "name": "beta-v10",
         "channel": "beta-v10",
         "prerelease": true
       }


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Rename prerelease channel to `beta-v10`