### PR TITLE
fix: remove --dry-run from semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "browser-coverage": "npm run test:cover && opener coverage/lcov-report/index.html",
     "prepublishOnly": "npm run build",
     "postpublish": "npm run docs:publish && npm run clean",
-    "semantic-release": "semantic-release --dry-run",
+    "semantic-release": "semantic-release",
     "devdep:build": "pushd ../contentful-sdk-core && npm run build && popd",
     "devdep:clean": "pushd ../contentful-sdk-core && npm run clean && popd",
     "devdep:install": "npm run devdep:build && rm -rf node_modules/contentful-sdk-core && npm install ../contentful-sdk-core && npm run devdep:clean",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Removing the --dry-run flag from semantic-release
