### PR TITLE
chore: add requestLogger and responseLogger to CreateClientParams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for contentful
 // Definitions by: Miika Hänninen <https://github.com/googol>
 
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+
 export interface AxiosProxyConfig {
     host: string;
     port?: number;
@@ -32,6 +34,8 @@ export interface CreateClientParams {
     logHandler?: (level: ClientLogLevel, data?: any) => void;
     timeout?: number;
     retryLimit?: number;
+    requestLogger?: (config: AxiosRequestConfig) => void;
+    responseLogger?: (response: AxiosResponse) => void;
 }
 
 export interface ContentfulClientApi {


### PR DESCRIPTION
Add missing requestLogger and responseLogger types to CreateClientParams type definition.

Fixes issue #434 
