### PR TITLE
fix(readme): point to docs for v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ const client = contentful.createClient({
 });
 ```
 
-You can find all available methods of our client in our [reference documentation](https://contentful.github.io/contentful.js)
+You can find all available methods of our client in our [reference documentation](https://contentful.github.io/contentful.js/contentful/9.1.14/)
 
 ### Authentication
 
@@ -370,7 +370,7 @@ contentful.createClient({
 
 ### Reference documentation
 
-The [JS library reference](https://contentful.github.io/contentful.js) documents what objects and methods are exposed by this library, what arguments they expect and what kind of data is returned.
+The [JS library reference](https://contentful.github.io/contentful.js/contentful/9.1.14/) documents what objects and methods are exposed by this library, what arguments they expect and what kind of data is returned.
 
 Most methods also have examples which show you how to use them.
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Temporarily hardcoding v9 into docs link, so that it doesn't automatically point to v10-beta