### PR TITLE
chore(test): add comment

### DIFF
--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -4,6 +4,9 @@ import sinon from 'sinon'
 import * as contentful from '../../lib/contentful'
 import { ValidationError } from '../../lib/utils/validate-timestamp'
 
+// Token values are deliberately exposed to enable integration test
+// usage which is dependent on a contentful test space.
+
 const params = {
   accessToken: 'QGT8WxED1nwrbCUpY6VEK6eFvZwvlC5ujlX-rzUq97U',
   space: 'ezs1swce23xe'


### PR DESCRIPTION
- Explain exposure of access tokens
- I decided against additionally extracting the values + space ids into their own constants, as they are only used once here in the corresponding already descriptive objects, and for any future change, all object values would have to be replaced together.