### PR TITLE
fix(dep): Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@contentful/rich-text-types": "^15.3.6",
         "axios": "^0.26.0",
-        "contentful-resolve-response": "^1.3.0",
-        "contentful-sdk-core": "^7.0.1",
+        "contentful-resolve-response": "^1.3.6",
+        "contentful-sdk-core": "^7.0.2",
         "json-stringify-safe": "^5.0.1",
         "type-fest": "^2.12.0"
       },
@@ -4692,22 +4692,22 @@
       }
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.5.tgz",
-      "integrity": "sha512-Emw6zdM/+sGNwTcit4iqMg0xnNyM76S7GYMXCkZWeqTkgRoJi2XNXvy5JnWgFYQELgwdVtTUZ6lPXrGqQuX/3w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.6.tgz",
+      "integrity": "sha512-zEAx25uK48aXkMM5H8FWLqQZODKuoRbc79xbMzOnaX5xw8QEPNyqNLzuNI2CDVaeH+QK2EG5XvZ+Xeq00sAPLw==",
       "dependencies": {
-        "fast-copy": "^2.1.1"
+        "fast-copy": "^2.1.3"
       },
       "engines": {
         "node": ">=4.7.2"
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.1.tgz",
-      "integrity": "sha512-3m3RTmQHEnlOtx6f9PvkKgrv5Qpzjo8X+NysBXshCYK8OEG/vNbsfsdOaiURAxcVMQ/9vM14Og+fc+aMx79Lsg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.2.tgz",
+      "integrity": "sha512-HkBzzzJ3UGqOIJiTd4qMEMvn44ccrN7a75gEej28X1srGn05myRgJ/pWbmXJhtgpq/5gU7IURnynyKx/ecsOfg==",
       "dependencies": {
-        "fast-copy": "^2.1.0",
+        "fast-copy": "^2.1.3",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
@@ -22109,19 +22109,19 @@
       "dev": true
     },
     "contentful-resolve-response": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.5.tgz",
-      "integrity": "sha512-Emw6zdM/+sGNwTcit4iqMg0xnNyM76S7GYMXCkZWeqTkgRoJi2XNXvy5JnWgFYQELgwdVtTUZ6lPXrGqQuX/3w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.6.tgz",
+      "integrity": "sha512-zEAx25uK48aXkMM5H8FWLqQZODKuoRbc79xbMzOnaX5xw8QEPNyqNLzuNI2CDVaeH+QK2EG5XvZ+Xeq00sAPLw==",
       "requires": {
-        "fast-copy": "^2.1.1"
+        "fast-copy": "^2.1.3"
       }
     },
     "contentful-sdk-core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.1.tgz",
-      "integrity": "sha512-3m3RTmQHEnlOtx6f9PvkKgrv5Qpzjo8X+NysBXshCYK8OEG/vNbsfsdOaiURAxcVMQ/9vM14Og+fc+aMx79Lsg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.2.tgz",
+      "integrity": "sha512-HkBzzzJ3UGqOIJiTd4qMEMvn44ccrN7a75gEej28X1srGn05myRgJ/pWbmXJhtgpq/5gU7IURnynyKx/ecsOfg==",
       "requires": {
-        "fast-copy": "^2.1.0",
+        "fast-copy": "^2.1.3",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
   "dependencies": {
     "@contentful/rich-text-types": "^15.3.6",
     "axios": "^0.26.0",
-    "contentful-resolve-response": "^1.3.0",
-    "contentful-sdk-core": "^7.0.1",
+    "contentful-resolve-response": "^1.3.6",
+    "contentful-sdk-core": "^7.0.2",
     "json-stringify-safe": "^5.0.1",
     "type-fest": "^2.12.0"
   },


### PR DESCRIPTION
Update internal dependencies. Similar to https://github.com/contentful/contentful.js/pull/1216 we needed to make sure that all our dependencies use fast-copy 2.1.3 to avoid problems with the build.

See: https://github.com/planttheidea/fast-copy/pull/65