### PR TITLE
fix: add note about new beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,16 @@
     "devdep:install": "npm run devdep:build && rm -rf node_modules/contentful-sdk-core && npm install ../contentful-sdk-core && npm run devdep:clean",
     "devdep:uninstall": "npm run devdep:clean && rimraf node_modules/contentful-sdk-core",
     "precommit": "npm run lint",
-    "prepush": "npm run test:prepush"
+    "prepush": "npm run test:prepush",
+    "postinstall": "node print-beta-v10-message.js"
   },
   "types": "./index.d.ts",
   "files": [
     "index.js",
     "version.js",
     "index.d.ts",
-    "dist"
+    "dist",
+    "print-beta-v10-message.js"
   ],
   "dependencies": {
     "axios": "^0.27.0",

--- a/print-beta-v10-message.js
+++ b/print-beta-v10-message.js
@@ -1,0 +1,15 @@
+const lines = [
+  '  ---------------------------------------------------------------------------------------------',
+  ('  contentful.js - the contentful delivery API (library)'),
+  '',
+  ('  🚨 We have just released contentful.js v10 in Beta with enhanced ✨ TypeScript ✨ support! 🚨'),
+  ('  You can check it out on npm under the beta-v10 tag (go to the "Versions" tab to find it). '),
+  '  The migration guide and updated v10 README and can be found on the beta-v10 branch.',
+  '',
+  `  ${('README:')} ${('https://github.com/contentful/contentful.js/blob/beta-v10/README.md')}`,
+  `  ${('MIGRATION GUIDE:')} ${('https://github.com/contentful/contentful.js/blob/beta-v10/MIGRATION.md')}`,
+  `  ${('BETA BRANCH:')} ${('https://github.com/contentful/contentful.js/tree/beta-v10')}`,
+  '  ---------------------------------------------------------------------------------------------'
+]
+const message = lines.join('\n')
+console.log(message)


### PR DESCRIPTION
Print note about new beta version after installation

```sh
  ---------------------------------------------------------------------------------------------
  contentful.js - the contentful delivery API (library)

  🚨 We have just released contentful.js v10 in Beta with enhanced ✨ TypeScript ✨ support! 🚨
  You can check it out on npm under the beta-v10 tag (go to the "Versions" tab to find it).
  The migration guide and updated v10 README and can be found on the beta-v10 branch.

  README: https://github.com/contentful/contentful.js/blob/beta-v10/README.md
  MIGRATION GUIDE: https://github.com/contentful/contentful.js/blob/beta-v10/MIGRATION.md
  BETA BRANCH: https://github.com/contentful/contentful.js/tree/beta-v10
  ---------------------------------------------------------------------------------------------
  ```