### PR TITLE
Use type only exports to support isolatedModules

### DIFF
--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,1 +1,1 @@
-export { AssetQueries, EntriesQueries } from './query'
+export { type AssetQueries, type EntriesQueries } from './query'


### PR DESCRIPTION
## Summary

See https://github.com/contentful/contentful.js/issues/1272 for context.

@marcolink 