### PR TITLE
fix: location type (string -> number)

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -20,8 +20,8 @@ export declare namespace EntryFields {
   type Boolean = boolean
 
   type Location = {
-    lat: string
-    lon: string
+    lat: number
+    lon: number
   }
 
   type Link<T> = Asset | Entry<T>

--- a/test/types/query-location.test-d.ts
+++ b/test/types/query-location.test-d.ts
@@ -15,17 +15,18 @@ import { SubsetFilters } from '../../lib/types/query/subset'
 
 const stringValue = ''
 const booleanValue = true
+const numberValue = 12.11
 export const nearLocationValue: ProximitySearchFilterInput = [1, 0]
 export const withinCircleLocationValue: BoundingCircleSearchFilterInput = [1, 0, 2]
 export const withinBoxLocationValue: BoundingBoxSearchFilterInput = [1, 0, 2, 1]
 
 //TODO:  Does this work?
 expectAssignable<EqualityFilter<{ testField: EntryFields.Location }, 'fields'>>({
-  'fields.testField': { lat: stringValue, lon: stringValue },
+  'fields.testField': { lat: numberValue, lon: numberValue },
 })
 //TODO:  Does this work?
 expectAssignable<InequalityFilter<{ testField: EntryFields.Location }, 'fields'>>({
-  'fields.testField[ne]': { lat: stringValue, lon: stringValue },
+  'fields.testField[ne]': { lat: numberValue, lon: numberValue },
 })
 expectAssignable<ExistenceFilter<{ testField: EntryFields.Location }, 'fields'>>({
   'fields.testField[exists]': booleanValue,


### PR DESCRIPTION
Fix location type from `string` to `number`

Related to: [#1274](https://github.com/contentful/contentful.js/issues/1274)
