### PR TITLE
Fix sync type to accept paginate as an option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,7 @@ export interface ContentfulClientApi {
     getTag(id: string): Promise<Tag>;
     getTags(query?: any): Promise<TagCollection>;
     parseEntries<T>(raw: any): Promise<EntryCollection<T>>;
-    sync(query: any): Promise<SyncCollection>;
+    sync(query: any, options?: { paginate?: boolean}): Promise<SyncCollection>;
 }
 
 export interface Asset {


### PR DESCRIPTION

## Summary

Sync methods accept  options as a second argument with pagination.

## Description

With typescript, compilation fail when doing
```typescript
client.sync(query, { paginate: false })
  ```
