### PR TITLE
Type json more accurately

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -26,7 +26,7 @@ export declare namespace EntryFields {
 
   type Link<T> = Asset | Entry<T>
   type Array<T = any> = symbol[] | Entry<T>[] | Asset[]
-  type Object<T extends Record<string, any> = Record<string, unknown>> = T
+  type Json = string | number | boolean | null | { [property: string]: Json } | Json[]
   type RichText = RichTextDocument
 }
 
@@ -39,7 +39,7 @@ export type BasicEntryField =
   | EntryFields.Boolean
   | EntryFields.Location
   | EntryFields.RichText
-  | EntryFields.Object
+  | EntryFields.Json
 
 /**
  * @category Entities


### PR DESCRIPTION
## Summary

This PR more accurately types Json fields on Entries.

## Motivation and Context

`[]` is valid json but does not match the type (possible in contentful app).  Furthermore, the current type uses `Record<string, any>` which is too general.

