### PR TITLE
feat: xspace support

### DIFF
--- a/lib/create-contentful-api.js
+++ b/lib/create-contentful-api.js
@@ -32,6 +32,15 @@
  */
 
 /**
+ * Link to another entity in a different space.
+ * @memberof Entities
+ * @typedef ResourceLink
+ * @prop {string} type - type of this entity. Always ResourceLink.
+ * @prop {string} urn
+ * @prop {string} linkType - type of this link. Always Contentful:Entry
+ */
+
+/**
  * @memberof ContentfulClientAPI
  * @typedef {Object} ClientAPI
  * @prop {function} getSpace

--- a/lib/entities/entry.js
+++ b/lib/entities/entry.js
@@ -55,7 +55,7 @@ import resolveResponse from 'contentful-resolve-response'
  * A Field in an Entry can have one of the following types that can be defined in Contentful. See <a href="https://www.contentful.com/developers/docs/references/field-type/">Field Types</a> for more details.
  * @memberof Entities
  * @typedef Field
- * @type EntryFields.Symbol | EntryFields.Text | EntryFields.Integer | EntryFields.Number | EntryFields.Date | EntryFields.Boolean | EntryFields.Location | Entities.Link | Array<EntryFields.Symbol|Entities.Link> | Object
+ * @type EntryFields.Symbol | EntryFields.Text | EntryFields.Integer | EntryFields.Number | EntryFields.Date | EntryFields.Boolean | EntryFields.Location | Entities.Link | Entities.ResourceLink | Array<EntryFields.Symbol|Entities.Link|Entities.ResourceLink> | Object
  */
 
 /**

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -65,6 +65,21 @@ test('Gets content types', async (t) => {
   t.ok(response.items, 'items')
 })
 
+test('Gets a content type that has resource links', async (t) => {
+  t.plan(9)
+  const response = await client.getContentType('catalog')
+  t.ok(response.sys, 'sys')
+  t.ok(response.name, 'name')
+  t.ok(response.fields, 'fields')
+
+  t.equal(response.fields[0].id, 'items')
+  t.equal(response.fields[0].type, 'Array')
+  t.equal(response.fields[0].items.type, 'ResourceLink')
+  t.equal(response.fields[0].allowedResources[0].type, 'Contentful:Entry')
+  t.equal(response.fields[0].allowedResources[0].source, 'crn:contentful:::content:spaces/ocrd5ofpzqgz')
+  t.deepEqual(response.fields[0].allowedResources[0].contentTypes, ['manufacturer', 'product'])
+})
+
 test('Gets entry', async (t) => {
   t.plan(2)
   const response = await client.getEntry('nyancat')
@@ -377,6 +392,22 @@ test('Gets entries by creation order and id order', async (t) => {
     response.items[0].sys.id < response.items[1].sys.id,
     'id of entry with index 1 is higher than the one of index 0 since they share content type'
   )
+})
+
+test.only('Gets an entry that has resource links', async (t) => {
+  t.plan(8)
+  const response = await client.getEntry('6yfSzwXo99q8BKzkE5AIKo')
+
+  t.ok(response.sys, 'sys')
+  t.ok(response.fields, 'fields')
+
+  t.equal(response.fields.items[0].sys.type, 'ResourceLink')
+  t.equal(response.fields.items[0].sys.linkType, 'Contentful:Entry')
+  t.equal(response.fields.items[0].sys.urn, 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL')
+
+  t.equal(response.fields.items[1].sys.type, 'ResourceLink')
+  t.equal(response.fields.items[1].sys.linkType, 'Contentful:Entry')
+  t.equal(response.fields.items[1].sys.urn, 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ')
 })
 
 test('Gets assets with only images', async (t) => {

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -72,7 +72,7 @@ test('Gets a content type that has resource links', async (t) => {
   t.ok(response.sys, 'sys');
   t.ok(response.name, 'name');
   t.ok(response.fields, 'fields');
-  t.deepEqual(response.fields[
+  t.deepEqual(response.fields, [
       {
         id: 'items',
         name: 'items',
@@ -407,20 +407,29 @@ test('Gets entries by creation order and id order', async (t) => {
   )
 })
 
-test('Gets an entry that has resource links', async (t) => {
-  t.plan(8)
-  const response = await client.getEntry('6yfSzwXo99q8BKzkE5AIKo')
+test.only('Gets an entry that has resource links', async (t) => {
+  t.plan(3)
+  const response = await client.getEntry('xspaceEntry')
 
   t.ok(response.sys, 'sys')
   t.ok(response.fields, 'fields')
-
-  t.equal(response.fields.items[0].sys.type, 'ResourceLink')
-  t.equal(response.fields.items[0].sys.linkType, 'Contentful:Entry')
-  t.equal(response.fields.items[0].sys.urn, 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL')
-
-  t.equal(response.fields.items[1].sys.type, 'ResourceLink')
-  t.equal(response.fields.items[1].sys.linkType, 'Contentful:Entry')
-  t.equal(response.fields.items[1].sys.urn, 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ')
+  t.deepEqual(response.fields, {items: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL'
+        }
+      },
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ'
+        }
+      }
+    ]
+  })
 })
 
 test('Gets assets with only images', async (t) => {

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -400,7 +400,7 @@ test('Gets entries by creation order and id order', async (t) => {
     .map((item) => item.sys.contentType.sys.id)
     .filter((value, index, self) => self.indexOf(value) === index)
 
-  t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'contentTypeWithMetadataField', 'dog', 'human', 'kangaroo', 'testEntryReferences'], 'orders')
+  t.deepEqual(contentTypeOrder, ['1t9IbcfdCk6m04uISSsaIK', 'cat', 'catalog', 'contentTypeWithMetadataField', 'dog', 'human', 'kangaroo', 'testEntryReferences'], 'orders')
   t.ok(
     response.items[0].sys.id < response.items[1].sys.id,
     'id of entry with index 1 is higher than the one of index 0 since they share content type'

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -66,19 +66,32 @@ test('Gets content types', async (t) => {
 })
 
 test('Gets a content type that has resource links', async (t) => {
-  t.plan(9)
-  const response = await client.getContentType('catalog')
-  t.ok(response.sys, 'sys')
-  t.ok(response.name, 'name')
-  t.ok(response.fields, 'fields')
+  t.plan(4);
+  const response = await client.getContentType("catalog");
 
-  t.equal(response.fields[0].id, 'items')
-  t.equal(response.fields[0].type, 'Array')
-  t.equal(response.fields[0].items.type, 'ResourceLink')
-  t.equal(response.fields[0].allowedResources[0].type, 'Contentful:Entry')
-  t.equal(response.fields[0].allowedResources[0].source, 'crn:contentful:::content:spaces/ocrd5ofpzqgz')
-  t.deepEqual(response.fields[0].allowedResources[0].contentTypes, ['manufacturer', 'product'])
-})
+  t.ok(response.sys, 'sys');
+  t.ok(response.name, 'name');
+  t.ok(response.fields, 'fields');
+  t.deepEqual(response.fields[
+      {
+        id: 'items',
+        name: 'items',
+        type: 'Array',
+        localized: false,
+        required: false,
+        disabled: false,
+        omitted: false,
+        allowedResources: [
+          {
+            type: 'Contentful:Entry',
+            source: 'crn:contentful:::content:spaces/ocrd5ofpzqgz',
+            contentTypes: [ 'manufacturer', 'product' ]
+          }
+        ],
+        items: { type: 'ResourceLink', validations: [] }
+      }
+      ]);
+});
 
 test('Gets entry', async (t) => {
   t.plan(2)
@@ -394,7 +407,7 @@ test('Gets entries by creation order and id order', async (t) => {
   )
 })
 
-test.only('Gets an entry that has resource links', async (t) => {
+test('Gets an entry that has resource links', async (t) => {
   t.plan(8)
   const response = await client.getEntry('6yfSzwXo99q8BKzkE5AIKo')
 

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -89,8 +89,23 @@ test('Gets a content type that has resource links', async (t) => {
           }
         ],
         items: { type: 'ResourceLink', validations: [] }
+      },
+      {
+        id: 'productOfTheMonth',
+        name: 'product of the month',
+        type: 'ResourceLink',
+        localized: false,
+        required: false,
+        disabled: false,
+        omitted: false,
+        allowedResources: [{
+          type: 'Contentful:Entry',
+          source: 'crn:contentful:::content:spaces/ocrd5ofpzqgz',
+          contentTypes: [ 'product' ]
+        }]
       }
-      ]);
+    ]
+  );
 });
 
 test('Gets entry', async (t) => {
@@ -413,7 +428,7 @@ test('Gets an entry that has resource links', async (t) => {
 
   t.ok(response.sys, 'sys')
   t.ok(response.fields, 'fields')
-  t.deepEqual(response.fields, {items: [
+  t.deepEqual(response.fields, { items: [
       {
         sys: {
           type: 'ResourceLink',

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -407,7 +407,7 @@ test('Gets entries by creation order and id order', async (t) => {
   )
 })
 
-test.only('Gets an entry that has resource links', async (t) => {
+test('Gets an entry that has resource links', async (t) => {
   t.plan(3)
   const response = await client.getEntry('xspaceEntry')
 

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -237,7 +237,7 @@ test('API call getEntry fails', async (t) => {
   }
 })
 
-test.only('API call getEntry that has resource links', async (t) => {
+test('API call getEntry that has resource links', async (t) => {
   t.plan(2)
   const { api } = setupWithData({
     promise: Promise.resolve({ data: entryWithResourceLinksMock })

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -650,3 +650,52 @@ test('Given json should be parsed correctly as a collection of entries with meta
   t.looseEquals(parsedData.items[0].fields.metadata.sys, data.includes.Metadata[0].sys, 'metadata field is included')
   t.end()
 })
+
+test('resource links should be parsed correctly', (t) => {
+  const api = createContentfulApi({
+    http: {},
+    getGlobalOptions: sinon.stub().returns({ resolveLinks: true })
+  })
+  const data = {
+    items: [
+      {
+        sys: {
+          type: 'Entry',
+          locale: 'en-US'
+        },
+        fields: {
+          xspace: [
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk947mdX'
+              }
+            }
+          ],
+          xspace2: [
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/8kouir73nbuz/entries/BfmNpEsQSFuh2lybiVkoq'
+              }
+            },
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/kdtd0watvk6m/entries/irF9JXBHqNhwMwelu9HYt'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+  const parsedData = api.parseEntries(data)
+
+  t.ok(parsedData)
+  t.looseEquals(parsedData.items[0].fields.xspace[0].sys, data.items[0].fields.xspace[0].sys)
+  t.end()
+})

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon'
 import createGlobalOptions from '../../lib/create-global-options'
 
 import createContentfulApi, { __RewireAPI__ as createContentfulApiRewireApi } from '../../lib/create-contentful-api'
-import { contentTypeMock, assetMock, assetKeyMock, entryMock, localeMock } from './mocks'
+import { contentTypeMock, assetMock, assetKeyMock, entryMock, localeMock, entryWithResourceLinksMock } from './mocks'
 
 const now = () => Math.floor(Date.now() / 1000)
 
@@ -237,6 +237,23 @@ test('API call getEntry fails', async (t) => {
   }
 })
 
+test.only('API call getEntry that has resource links', async (t) => {
+  t.plan(2)
+  const { api } = setupWithData({
+    promise: Promise.resolve({ data: entryWithResourceLinksMock })
+  })
+  api.getEntries = sinon.stub().resolves({ items: [entryWithResourceLinksMock] })
+  entitiesMock.entry.wrapEntry.returns(entryWithResourceLinksMock)
+
+  try {
+    const r = await api.getEntry('id')
+    t.looseEqual(r, entryWithResourceLinksMock)
+    t.true(api.getEntries.calledOnce)
+  } finally {
+    teardown()
+  }
+})
+
 test('API call getEntries', async (t) => {
   t.plan(2)
 
@@ -318,6 +335,27 @@ test('API call getEntries fails', async (t) => {
     await api.getEntries()
   } catch (r) {
     t.looseEqual(r.data, data)
+  } finally {
+    teardown()
+  }
+})
+
+test('API call getEntries that has resource links', async (t) => {
+  t.plan(1)
+  const data = {
+    total: 100,
+    skip: 0,
+    limit: 10,
+    items: [entryWithResourceLinksMock]
+  }
+  const { api } = setupWithData({
+    promise: Promise.resolve({ data: data })
+  })
+  entitiesMock.entry.wrapEntryCollection.returns(data)
+
+  try {
+    const r = await api.getEntries()
+    t.looseEqual(r, data, 'returns expected data')
   } finally {
     teardown()
   }

--- a/test/unit/create-contentful-api-test.js
+++ b/test/unit/create-contentful-api-test.js
@@ -698,8 +698,7 @@ test('resource links should be parsed correctly', (t) => {
     items: [
       {
         sys: {
-          type: 'Entry',
-          locale: 'en-US'
+          type: 'Entry'
         },
         fields: {
           xspace: [

--- a/test/unit/entities/entry-test.js
+++ b/test/unit/entities/entry-test.js
@@ -1,7 +1,7 @@
 import test from 'blue-tape'
 import copy from 'fast-copy'
 
-import { entryMock, assetMock } from '../mocks'
+import { entryMock, assetMock, entryWithResourceLinksMock } from '../mocks'
 import { wrapEntry, wrapEntryCollection } from '../../../lib/entities/entry'
 
 test('Entry is wrapped', (t) => {
@@ -111,5 +111,26 @@ test('Entry collection links are resolved', (t) => {
   t.equals(wrappedEntry.items[1].fields.linked1.sys.type, 'Entry', 'third linked entity is resolved')
   t.ok(wrappedEntry.items[1].fields.linked1.fields, 'third linked entity has fields')
   t.ok(wrappedCollection.stringifySafe(), 'stringifies safely')
+  t.end()
+})
+
+test('Entry with resource links is wrapped', (t) => {
+  const wrappedEntry = wrapEntry(entryWithResourceLinksMock)
+  t.looseEqual(wrappedEntry.toPlainObject(), entryWithResourceLinksMock)
+  t.end()
+})
+
+test('Entry collection with resource links is wrapped', (t) => {
+  const entryCollection = {
+    total: 1,
+    skip: 0,
+    limit: 100,
+    items: [
+      entryWithResourceLinksMock,
+      entryWithResourceLinksMock
+    ]
+  }
+  const wrappedEntry = wrapEntryCollection(entryCollection, true)
+  t.looseEqual(wrappedEntry.toPlainObject(), entryCollection)
   t.end()
 })

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -29,6 +29,38 @@ const contentTypeMock = {
       type: 'Text',
       localized: true,
       required: false
+    },
+    {
+      id: 'resourceLinkArray',
+      name: 'resource link array',
+      type: 'Array',
+      localized: false,
+      required: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+      items: {
+        type: 'ResourceLink',
+        validations: []
+      },
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/ywdl9lsbthy5',
+          contentTypes: [
+            'termsAndConditions',
+            'sla'
+          ]
+        },
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/u57131yuvvgb',
+          contentTypes: [
+            'oneTime',
+            'plan'
+          ]
+        }
+      ]
     }
   ]
 }
@@ -114,6 +146,44 @@ const tagMock = {
   name: 'mock tag'
 }
 
+const entryWithResourceLinksMock = {
+  sys: Object.assign(copy(sysMock), {
+    type: 'Entry',
+    contentType: Object.assign(copy(linkMock), { linkType: 'ContentType' }),
+    locale: 'locale'
+  }),
+  fields: {
+    xspace: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk947mdX'
+        }
+      }
+    ],
+    xspace2: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/8kouir73nbuz/entries/BfmNpEsQSFuh2lybiVkoq'
+        }
+      },
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/kdtd0watvk6m/entries/irF9JXBHqNhwMwelu9HYt'
+        }
+      }
+    ]
+  },
+  metadata: {
+    tags: []
+  }
+}
+
 export {
   linkMock,
   sysMock,
@@ -122,5 +192,6 @@ export {
   assetMock,
   assetKeyMock,
   localeMock,
-  tagMock
+  tagMock,
+  entryWithResourceLinksMock
 }

--- a/test/unit/mocks.js
+++ b/test/unit/mocks.js
@@ -31,6 +31,39 @@ const contentTypeMock = {
       required: false
     },
     {
+      id: 'resourceLink',
+      name: 'resource link',
+      type: 'ResourceLink',
+      localized: true,
+      required: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/bixqmof5ek4r',
+          contentTypes: [
+            'aBuggyCt',
+            'assetLink',
+            'container',
+            'keepMeSimple'
+          ]
+        },
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/bkg4k0bz2fhq',
+          contentTypes: [
+            'articlePage',
+            'topicPage',
+            'textBlock',
+            'game',
+            'gameDesignerPage'
+          ]
+        }
+      ]
+    },
+    {
       id: 'resourceLinkArray',
       name: 'resource link array',
       type: 'Array',
@@ -153,6 +186,22 @@ const entryWithResourceLinksMock = {
     locale: 'locale'
   }),
   fields: {
+    onereference: {
+      "en-US": {
+        sys: {
+          type: "ResourceLink",
+          linkType: "Contentful:Entry",
+          urn: "crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk949999"
+        }
+      },
+      "de-DE": {
+        sys: {
+          type: "ResourceLink",
+          linkType: "Contentful:Entry",
+          urn: "crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk948888"
+        }
+      }
+    },
     xspace: [
       {
         sys: {


### PR DESCRIPTION
## Summary

Write tests for xspace support and update jsdocs:
- Unit tests for ResourceLink
- Integrations tests for ResourceLink
- Add ResourceLink to jsdocs

You can find the content type for integration tests [here](https://app.contentful.com/spaces/ezs1swce23xe/content_types/catalog/fields).
You can find the entry for  integration tests [here](https://app.contentful.com/spaces/ezs1swce23xe/entries/6yfSzwXo99q8BKzkE5AIKo).
