### PR TITLE
xspace support beta v10

### DIFF
--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -22,6 +22,13 @@ export interface ContentTypeField {
   type: ContentTypeFieldType
   validations: ContentTypeFieldValidation[]
   items?: FieldItem
+  allowedResources?: ContentTypeAllowedResources[]
+}
+
+interface ContentTypeAllowedResources {
+  type: string
+  source: string
+  contentTypes: string[]
 }
 
 export type ContentTypeFieldType =

--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -43,6 +43,7 @@ export type ContentTypeFieldType =
   | 'Array'
   | 'Object'
   | 'RichText'
+  | 'ResourceLink'
 
 export interface ContentTypeFieldValidation {
   unique?: boolean

--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -66,7 +66,7 @@ export interface ContentTypeFieldValidation {
 }
 
 export interface FieldItem {
-  type: 'Link' | 'Symbol'
+  type: 'Link' | 'Symbol' | 'ResourceLink'
   validations: ContentTypeFieldValidation[]
   linkType?: 'Entry' | 'Asset'
 }

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -59,7 +59,9 @@ test('Gets a content type that has resource links', async () => {
   expect(response.fields[0].type).toBe('Array')
   expect(response.fields[0].items?.type).toBe('ResourceLink')
   expect(response.fields[0].allowedResources?.[0].type).toBe('Contentful:Entry')
-  expect(response.fields[0].allowedResources?.[0].source).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz')
+  expect(response.fields[0].allowedResources?.[0].source).toBe(
+    'crn:contentful:::content:spaces/ocrd5ofpzqgz'
+  )
   expect(response.fields[0].allowedResources?.[0].contentTypes).toEqual(['manufacturer', 'product'])
 })
 
@@ -75,7 +77,9 @@ test('Gets entry', async () => {
 })
 
 test('Gets an entry with a specific locale', async () => {
-  const entry = await client.getEntry<{ test: EntryFields.Symbol }>('nyancat', { locale: 'tlh' })
+  const entry = await client.getEntry<{ test: EntryFields.Symbol }>('nyancat', {
+    locale: 'tlh',
+  })
   expect(entry.sys.locale).toBe('tlh')
 })
 
@@ -186,7 +190,10 @@ test('Gets entry with without link resolution but with includes', async () => {
 })
 
 test('Gets entries with link resolution and includes, does not consider global `removeUnresolved` option', async () => {
-  const removeUnresolvedClient = contentful.createClient({ ...params, removeUnresolved: true })
+  const removeUnresolvedClient = contentful.createClient({
+    ...params,
+    removeUnresolved: true,
+  })
   const response = await removeUnresolvedClient.getEntries({
     'sys.id': '4SEhTg8sYJ1H3wDAinzhTp',
     include: 2,
@@ -201,7 +208,10 @@ test('Gets entries with link resolution and includes, does not consider global `
   })
 })
 test('Gets entry with link resolution and includes, does not consider global `removeUnresolved` option', async () => {
-  const removeUnresolvedClient = contentful.createClient({ ...params, removeUnresolved: true })
+  const removeUnresolvedClient = contentful.createClient({
+    ...params,
+    removeUnresolved: true,
+  })
   const response = await removeUnresolvedClient.getEntry('4SEhTg8sYJ1H3wDAinzhTp', { include: 2 })
   expect(response.fields).toBeDefined()
   expect(response.fields.bestFriend).toMatchObject({
@@ -224,7 +234,10 @@ test('Gets entry with link resolution and includes, removing unresolvable links 
 })
 
 test('Gets entry with link resolution and includes, removing unresolvable links, overriding client config with client chain', async () => {
-  const keepUnresolvedClient = contentful.createClient({ ...params, removeUnresolved: false })
+  const keepUnresolvedClient = contentful.createClient({
+    ...params,
+    removeUnresolved: false,
+  })
   const response = await keepUnresolvedClient.withoutUnresolvableLinks.getEntry(
     '4SEhTg8sYJ1H3wDAinzhTp',
     { include: 2 }
@@ -234,7 +247,9 @@ test('Gets entry with link resolution and includes, removing unresolvable links,
 })
 
 test('Gets entry with link resolution, and includes, keeping unresolvable links', async () => {
-  const response = await client.getEntry('4SEhTg8sYJ1H3wDAinzhTp', { include: 2 })
+  const response = await client.getEntry('4SEhTg8sYJ1H3wDAinzhTp', {
+    include: 2,
+  })
   expect(response.fields).toBeDefined()
   expect(response.fields.bestFriend).toMatchObject({
     sys: {
@@ -453,11 +468,15 @@ test.only('Gets an entry that has resource links', async () => {
 
   expect(response.fields.items[0].sys.type).toBe('ResourceLink')
   expect(response.fields.items[0].sys.linkType).toBe('Contentful:Entry')
-  expect(response.fields.items[0].sys.urn).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL')
+  expect(response.fields.items[0].sys.urn).toBe(
+    'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL'
+  )
 
   expect(response.fields.items[1].sys.type).toBe('ResourceLink')
   expect(response.fields.items[1].sys.linkType).toBe('Contentful:Entry')
-  expect(response.fields.items[1].sys.urn).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ')
+  expect(response.fields.items[1].sys.urn).toBe(
+    'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ'
+  )
 })
 
 test('Gets assets with only images', async () => {
@@ -538,7 +557,11 @@ describe('Sync API', () => {
   })
 
   test('Sync space entries by content type', async () => {
-    const response = await client.sync({ initial: true, type: 'Entry', content_type: 'dog' })
+    const response = await client.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'dog',
+    })
     expect(response.entries).toBeDefined()
     expect(response.deletedEntries).toBeDefined()
     expect(response.nextSyncToken).toBeDefined()
@@ -546,7 +569,10 @@ describe('Sync API', () => {
 })
 
 test('Gets entries with linked includes with all locales using the withAllLocales client chain modifier', async () => {
-  const response = await client.withAllLocales.getEntries({ include: 5, 'sys.id': 'nyancat' })
+  const response = await client.withAllLocales.getEntries({
+    include: 5,
+    'sys.id': 'nyancat',
+  })
   assertLocalizedEntriesResponse(response)
 })
 

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -48,6 +48,21 @@ test('Gets content types', async () => {
   expect(response.items).toBeDefined()
 })
 
+test('Gets a content type that has resource links', async () => {
+  const response = await client.getContentType('catalog')
+
+  expect(response.sys).toBeDefined()
+  expect(response.name).toBeDefined()
+  expect(response.fields).toBeDefined()
+
+  expect(response.fields[0].id).toBe('items')
+  expect(response.fields[0].type).toBe('Array')
+  expect(response.fields[0].items?.type).toBe('ResourceLink')
+  expect(response.fields[0].allowedResources?.[0].type).toBe('Contentful:Entry')
+  expect(response.fields[0].allowedResources?.[0].source).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz')
+  expect(response.fields[0].allowedResources?.[0].contentTypes).toEqual(['manufacturer', 'product'])
+})
+
 test('Gets content types with search query', async () => {
   const response = await client.getContentTypes({ query: 'cat' })
   expect(response.items).toHaveLength(1)
@@ -428,6 +443,21 @@ test('Gets entries by creation order and id order', async () => {
     'testEntryReferences',
   ])
   expect(response.items[0].sys.id < response.items[1].sys.id).toBeTruthy()
+})
+
+test.only('Gets an entry that has resource links', async () => {
+  const response = await client.getEntry('6yfSzwXo99q8BKzkE5AIKo')
+
+  expect(response.sys).toBeDefined()
+  expect(response.fields).toBeDefined()
+
+  expect(response.fields.items[0].sys.type).toBe('ResourceLink')
+  expect(response.fields.items[0].sys.linkType).toBe('Contentful:Entry')
+  expect(response.fields.items[0].sys.urn).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL')
+
+  expect(response.fields.items[1].sys.type).toBe('ResourceLink')
+  expect(response.fields.items[1].sys.linkType).toBe('Contentful:Entry')
+  expect(response.fields.items[1].sys.urn).toBe('crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ')
 })
 
 test('Gets assets with only images', async () => {

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -54,20 +54,46 @@ test('Gets a content type that has resource links', async () => {
   expect(response.sys).toBeDefined()
   expect(response.name).toBeDefined()
   expect(response.fields).toBeDefined()
-
-  expect(response.fields[0].id).toBe('items')
-  expect(response.fields[0].type).toBe('Array')
-  expect(response.fields[0].items?.type).toBe('ResourceLink')
-  expect(response.fields[0].allowedResources?.[0].type).toBe('Contentful:Entry')
-  expect(response.fields[0].allowedResources?.[0].source).toBe(
-    'crn:contentful:::content:spaces/ocrd5ofpzqgz'
-  )
-  expect(response.fields[0].allowedResources?.[0].contentTypes).toEqual(['manufacturer', 'product'])
+  expect(response.fields).toEqual([
+    {
+      id: 'items',
+      name: 'items',
+      type: 'Array',
+      localized: false,
+      required: false,
+      disabled: false,
+      omitted: false,
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:contentful:::content:spaces/ocrd5ofpzqgz',
+          contentTypes: ['manufacturer', 'product'],
+        },
+      ],
+      items: { type: 'ResourceLink', validations: [] },
+    },
+    {
+      id: 'productOfTheMonth',
+      name: 'product of the month',
+      type: 'ResourceLink',
+      localized: false,
+      required: false,
+      disabled: false,
+      omitted: false,
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:contentful:::content:spaces/ocrd5ofpzqgz',
+          contentTypes: ['product'],
+        },
+      ],
+    },
+  ])
 })
 
 test('Gets content types with search query', async () => {
   const response = await client.getContentTypes({ query: 'cat' })
-  expect(response.items).toHaveLength(1)
+  expect(response.items).toHaveLength(2)
 })
 
 test('Gets entry', async () => {
@@ -451,6 +477,7 @@ test('Gets entries by creation order and id order', async () => {
   expect(contentTypeOrder).toEqual([
     '1t9IbcfdCk6m04uISSsaIK',
     'cat',
+    'catalog',
     'contentTypeWithMetadataField',
     'dog',
     'human',
@@ -460,23 +487,29 @@ test('Gets entries by creation order and id order', async () => {
   expect(response.items[0].sys.id < response.items[1].sys.id).toBeTruthy()
 })
 
-test.only('Gets an entry that has resource links', async () => {
-  const response = await client.getEntry('6yfSzwXo99q8BKzkE5AIKo')
+test('Gets an entry that has resource links', async () => {
+  const response = await client.getEntry('xspaceEntry')
 
   expect(response.sys).toBeDefined()
   expect(response.fields).toBeDefined()
-
-  expect(response.fields.items[0].sys.type).toBe('ResourceLink')
-  expect(response.fields.items[0].sys.linkType).toBe('Contentful:Entry')
-  expect(response.fields.items[0].sys.urn).toBe(
-    'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL'
-  )
-
-  expect(response.fields.items[1].sys.type).toBe('ResourceLink')
-  expect(response.fields.items[1].sys.linkType).toBe('Contentful:Entry')
-  expect(response.fields.items[1].sys.urn).toBe(
-    'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ'
-  )
+  expect(response.fields).toEqual({
+    items: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL',
+        },
+      },
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ',
+        },
+      },
+    ],
+  })
 })
 
 test('Gets assets with only images', async () => {

--- a/test/unit/make-contentful-api-client-parseentries.test.ts
+++ b/test/unit/make-contentful-api-client-parseentries.test.ts
@@ -143,7 +143,6 @@ test('Given json should be parsed correctly as a collection of entries with reso
       {
         sys: {
           type: 'Entry',
-          locale: 'en-US',
         },
         fields: {
           xspace: [

--- a/test/unit/make-contentful-api-client-parseentries.test.ts
+++ b/test/unit/make-contentful-api-client-parseentries.test.ts
@@ -129,3 +129,56 @@ test('Given json should be parsed correctly as a collection of entries where an 
   expect(parsedData).toBeDefined()
   expect(parsedData.items[0].fields.metadata.sys).toEqual(data.includes.Metadata[0].sys)
 })
+
+test('Given json should be parsed correctly as a collection of entries with resource links', () => {
+  const api = makeClient({
+    // @ts-ignore
+    http: {},
+    // @ts-ignore
+    getGlobalOptions: createGlobalOptions({ resolveLinks: false }),
+  })
+
+  const data = {
+    items: [
+      {
+        sys: {
+          type: 'Entry',
+          locale: 'en-US',
+        },
+        fields: {
+          xspace: [
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk947mdX',
+              },
+            },
+          ],
+          xspace2: [
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/8kouir73nbuz/entries/BfmNpEsQSFuh2lybiVkoq',
+              },
+            },
+            {
+              sys: {
+                type: 'ResourceLink',
+                linkType: 'Contentful:Entry',
+                urn: 'crn:test:::content:spaces/kdtd0watvk6m/entries/irF9JXBHqNhwMwelu9HYt',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  }
+
+  const parsedData = api.parseEntries<any>(data)
+  expect(parsedData).toBeDefined()
+  expect(parsedData.items[0].fields.xspace[0].sys).toEqual(data.items[0].fields.xspace[0].sys)
+  expect(parsedData.items[0].fields.xspace2[0].sys).toEqual(data.items[0].fields.xspace2[0].sys)
+  expect(parsedData.items[0].fields.xspace2[1].sys).toEqual(data.items[0].fields.xspace2[1].sys)
+})

--- a/test/unit/make-contentful-api-client.test.ts
+++ b/test/unit/make-contentful-api-client.test.ts
@@ -171,6 +171,19 @@ describe('make Contentful API client', () => {
     await expect(api.getEntries()).resolves.toEqual(data)
   })
 
+  test('API call getEntries that has resource links', async () => {
+    const data = {
+      total: 100,
+      skip: 0,
+      limit: 10,
+      items: [mocks.entryWithResourceLinksMock],
+    }
+    const { api } = setupWithData({
+      promise: Promise.resolve({ data: data }),
+    })
+    await expect(api.getEntries()).resolves.toEqual(data)
+  })
+
   test('API call getEntries with global resolveLinks overridden by chained modifier', async () => {
     const data = { sys: { id: 'id' } }
     const { api } = setupWithData({

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -91,6 +91,32 @@ const contentTypeMock: ContentType = {
       omitted: false,
       validations: [],
     },
+    {
+      id: 'resourceLinkArray',
+      name: 'resource link array',
+      type: 'Array',
+      localized: false,
+      required: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+      items: {
+        type: 'ResourceLink',
+        validations: [],
+      },
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/ywdl9lsbthy5',
+          contentTypes: ['termsAndConditions', 'sla'],
+        },
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/u57131yuvvgb',
+          contentTypes: ['oneTime', 'plan'],
+        },
+      ],
+    },
   ],
 }
 
@@ -157,4 +183,51 @@ const assetKeyMock: AssetKey = {
   secret: '-jE6hqytutc_dygbjShVq0PijvDn80SdT0EWD1mNHgc',
 }
 
-export { sysMock, contentTypeMock, entryMock, assetMock, localeMock, tagMock, assetKeyMock }
+const entryWithResourceLinksMock = {
+  sys: Object.assign(copy(sysMock), {
+    type: 'Entry',
+    contentType: Object.assign(copy(spaceLinkMock), { linkType: 'ContentType' }),
+    locale: 'locale',
+  }),
+  fields: {
+    xspace: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk947mdX',
+        },
+      },
+    ],
+    xspace2: [
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/8kouir73nbuz/entries/BfmNpEsQSFuh2lybiVkoq',
+        },
+      },
+      {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/kdtd0watvk6m/entries/irF9JXBHqNhwMwelu9HYt',
+        },
+      },
+    ],
+  },
+  metadata: {
+    tags: [],
+  },
+}
+
+export {
+  sysMock,
+  contentTypeMock,
+  entryMock,
+  assetMock,
+  localeMock,
+  tagMock,
+  assetKeyMock,
+  entryWithResourceLinksMock,
+}

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -92,6 +92,28 @@ const contentTypeMock: ContentType = {
       validations: [],
     },
     {
+      id: 'resourceLink',
+      name: 'resource link',
+      type: 'ResourceLink',
+      localized: true,
+      required: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+      allowedResources: [
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/bixqmof5ek4r',
+          contentTypes: ['aBuggyCt', 'assetLink', 'container', 'keepMeSimple'],
+        },
+        {
+          type: 'Contentful:Entry',
+          source: 'crn:test:::content:spaces/bkg4k0bz2fhq',
+          contentTypes: ['articlePage', 'topicPage', 'textBlock', 'game', 'gameDesignerPage'],
+        },
+      ],
+    },
+    {
       id: 'resourceLinkArray',
       name: 'resource link array',
       type: 'Array',
@@ -190,6 +212,22 @@ const entryWithResourceLinksMock = {
     locale: 'locale',
   }),
   fields: {
+    onereference: {
+      'en-US': {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk949999',
+        },
+      },
+      'de-DE': {
+        sys: {
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          urn: 'crn:test:::content:spaces/0i1ksbf51zos/entries/U4X2TI5qzC0w6Rk948888',
+        },
+      },
+    },
     xspace: [
       {
         sys: {


### PR DESCRIPTION
## Summary

Write tests for xspace support and update jsdocs:
- Unit tests for ResourceLink
- Integrations tests for ResourceLink
- Add types

You can find the content type for integration tests [here](https://app.contentful.com/spaces/ezs1swce23xe/content_types/catalog/fields).
You can find the entry for  integration tests [here](https://app.contentful.com/spaces/ezs1swce23xe/entries/6yfSzwXo99q8BKzkE5AIKo).