### PR TITLE
Fix TypeScript generic constraints

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -436,7 +436,7 @@ class NotFoundError extends Error {
   }
 }
 
-export default function createContentfulApi<OptionType>(
+export default function createContentfulApi<OptionType extends ChainOptions>(
   { http, getGlobalOptions }: CreateContentfulApiParams,
   options?: OptionType
 ): DefaultClient {
@@ -511,11 +511,11 @@ export default function createContentfulApi<OptionType>(
     })
   }
 
-  async function getEntry<Fields>(id: string, query: EntryQueries = {}) {
+  async function getEntry<Fields extends FieldsType>(id: string, query: EntryQueries = {}) {
     return makeGetEntry<Fields>(id, query, options) as unknown
   }
 
-  async function getEntries<Fields>(query: EntriesQueries<Fields> = {}) {
+  async function getEntries<Fields extends FieldsType>(query: EntriesQueries<Fields> = {}) {
     return makeGetEntries<Fields>(query, options) as unknown
   }
 
@@ -523,7 +523,7 @@ export default function createContentfulApi<OptionType>(
 
   const getEntriesDefault = getEntriesWithLinkResolutionAndWithUnresolvableLinks
 
-  async function getEntryWithLinkResolutionAndWithUnresolvableLinks<Fields>(
+  async function getEntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>> {
@@ -532,7 +532,7 @@ export default function createContentfulApi<OptionType>(
     })
   }
 
-  async function getEntriesWithLinkResolutionAndWithUnresolvableLinks<Fields>(
+  async function getEntriesWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>> {
     return internalGetEntries<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>(
@@ -541,7 +541,7 @@ export default function createContentfulApi<OptionType>(
     )
   }
 
-  async function getEntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>(
+  async function getEntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType>(
     id: string,
     query: EntryQueries = {}
   ): Promise<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>> {
@@ -551,7 +551,7 @@ export default function createContentfulApi<OptionType>(
     })
   }
 
-  async function getEntriesWithLinkResolutionAndWithoutUnresolvableLinks<Fields>(
+  async function getEntriesWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>> {
     return internalGetEntries<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>(
@@ -561,7 +561,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-    Fields,
+    Fields extends FieldsType,
     SpaceLocales extends LocaleCode = any
   >(
     id: string,
@@ -582,7 +582,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntriesWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-    Fields,
+    Fields extends FieldsType,
     Locales extends LocaleCode = any
   >(
     query: EntriesQueries<Fields> = {}
@@ -601,7 +601,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-    Fields,
+    Fields extends FieldsType,
     SpaceLocales extends LocaleCode = any
   >(
     id: string,
@@ -619,7 +619,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntriesWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-    Fields,
+    Fields extends FieldsType,
     Locales extends LocaleCode = any
   >(
     query: EntriesQueries<Fields> = {}
@@ -646,7 +646,7 @@ export default function createContentfulApi<OptionType>(
     })
   }
 
-  async function getEntriesWithoutLinkResolution<Fields>(
+  async function getEntriesWithoutLinkResolution<Fields extends FieldsType>(
     query: EntriesQueries<Fields> = {}
   ): Promise<EntryCollectionWithoutLinkResolution<Fields>> {
     return internalGetEntries<EntryCollectionWithoutLinkResolution<Fields>>(query, {
@@ -655,7 +655,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntryWithAllLocalesAndWithoutLinkResolution<
-    Fields,
+    Fields extends FieldsType,
     Locales extends LocaleCode = any
   >(
     id: string,
@@ -669,7 +669,7 @@ export default function createContentfulApi<OptionType>(
   }
 
   async function getEntriesWithAllLocalesAndWithoutLinkResolution<
-    Fields,
+    Fields extends FieldsType,
     Locales extends LocaleCode = any
   >(
     query: EntriesQueries<Fields> = {}
@@ -685,7 +685,7 @@ export default function createContentfulApi<OptionType>(
     )
   }
 
-  async function makeGetEntry<Fields>(
+  async function makeGetEntry<Fields extends FieldsType>(
     id: string,
     query,
     options: ChainOptions = {
@@ -748,7 +748,7 @@ export default function createContentfulApi<OptionType>(
     }
   }
 
-  async function makeGetEntries<Fields>(
+  async function makeGetEntries<Fields extends FieldsType>(
     query,
     options: ChainOptions = {
       withoutLinkResolution: false,

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -24,7 +24,7 @@ export declare namespace EntryFields {
     lon: number
   }
 
-  type Link<T> = Asset | Entry<T>
+  type Link<T extends FieldsType> = Asset | Entry<T>
   type Array<T = any> = symbol[] | Entry<T>[] | Asset[]
   type Object<T extends Record<string, any> = Record<string, unknown>> = T
   type RichText = RichTextDocument
@@ -159,27 +159,27 @@ export type EntryWithoutLinkResolution<T> = Entry<T>
 
 export type EntryCollectionWithoutLinkResolution<T> = EntryCollection<T>
 
-export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<T> = AbstractEntryCollection<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<T>
->
+export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<T extends FieldsType> =
+  AbstractEntryCollection<EntryWithLinkResolutionAndWithUnresolvableLinks<T>>
 
 export type EntryCollectionWithAllLocalesAndWithoutLinkResolution<
-  Fields,
+  Fields extends FieldsType,
   Locales extends LocaleCode
 > = AbstractEntryCollection<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 
 export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-  Fields,
+  Fields extends FieldsType,
   Locales extends LocaleCode
 > = AbstractEntryCollection<
   EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
 >
 
-export type EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields> =
-  AbstractEntryCollection<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+export type EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<
+  Fields extends FieldsType
+> = AbstractEntryCollection<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
 
 export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-  Fields,
+  Fields extends FieldsType,
   Locales extends LocaleCode
 > = AbstractEntryCollection<
   EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -20,7 +20,7 @@ type FixedQueryOptions = {
   query?: string
 }
 
-export type SysQueries<Sys> = ExistenceFilter<Sys, 'sys'> &
+export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   EqualityFilter<Sys, 'sys'> &
   InequalityFilter<Sys, 'sys'> &
   SubsetFilters<Sys, 'sys'> &


### PR DESCRIPTION
## Description

Hey. I'm using your library in version `10.0.0-beta-v10.8` in a Next.js based project. Currently I'm getting the following TypeScript errors with TypeScript v4.8.3. This merge request fixes the errors.

Edit: I think TypeScript has become more strict in current versions concerning generics. I've tested it with different TypeScript versions. 4.5, 4.6 and 4.7 work fine, no type errors. Since 4.8 you get below errors.

```shell
yarn run v1.22.19
$ nextjs-project/node_modules/.bin/tsc
node_modules/contentful/lib/types/entry.ts:75:57 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

75       ? EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink
                                                           ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:74:83
    74     [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
                                                                                         ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:77:58 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

77       ? (EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink)[]
                                                            ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:76:58
    76       : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
                                                                ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:93:17 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

93                 LinkedEntryFields,
                   ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:90:82
    90       [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
                                                                                        ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:100:17 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

100                 LinkedEntryFields,
                    ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:97:66
    97         : Fields[FieldName] extends Array<EntryFields.Link<infer LinkedEntryFields>>
                                                                        ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:114:60 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

114       ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields> | undefined
                                                               ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:113:83
    113     [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
                                                                                          ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:116:60 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

116       ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields>[] | undefined
                                                               ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:115:58
    115       : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
                                                                 ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:132:17 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

132                 LinkedEntryFields,
                    ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:129:82
    129       [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
                                                                                         ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:139:17 - error TS2344: Type 'LinkedEntryFields' does not satisfy the constraint 'FieldsType'.

139                 LinkedEntryFields,
                    ~~~~~~~~~~~~~~~~~

  node_modules/contentful/lib/types/entry.ts:136:60
    136         : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
                                                                   ~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:163:51 - error TS2344: Type 'T' does not satisfy the constraint 'FieldsType'.

163   EntryWithLinkResolutionAndWithUnresolvableLinks<T>
                                                      ~

  node_modules/contentful/lib/types/entry.ts:162:71
    162 export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<T> = AbstractEntryCollection<
                                                                              ~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:169:73 - error TS2344: Type 'Fields' does not satisfy the constraint 'FieldsType'.

169 > = AbstractEntryCollection<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
                                                                            ~~~~~~

  node_modules/contentful/lib/types/entry.ts:167:3
    167   Fields,
          ~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:175:68 - error TS2344: Type 'Fields' does not satisfy the constraint 'FieldsType'.

175   EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
                                                                       ~~~~~~

  node_modules/contentful/lib/types/entry.ts:172:3
    172   Fields,
          ~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:179:78 - error TS2344: Type 'Fields' does not satisfy the constraint 'FieldsType'.

179   AbstractEntryCollection<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
                                                                                 ~~~~~~

  node_modules/contentful/lib/types/entry.ts:178:74
    178 export type EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields> =
                                                                                 ~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/entry.ts:185:71 - error TS2344: Type 'Fields' does not satisfy the constraint 'FieldsType'.

185   EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
                                                                          ~~~~~~

  node_modules/contentful/lib/types/entry.ts:182:3
    182   Fields,
          ~~~~~~
    This type parameter might need an `extends FieldsType` constraint.

node_modules/contentful/lib/types/query/query.ts:28:16 - error TS2344: Type 'Sys' does not satisfy the constraint 'FieldsType'.

28   SelectFilter<Sys, 'sys'>
                  ~~~

  node_modules/contentful/lib/types/query/query.ts:23:24
    23 export type SysQueries<Sys> = ExistenceFilter<Sys, 'sys'> &
                              ~~~
    This type parameter might need an `extends FieldsType` constraint.


Found 14 errors in 2 files.

Errors  Files
    13  node_modules/contentful/lib/types/entry.ts:75
     1  node_modules/contentful/lib/types/query/query.ts:28
```

## Motivation and Context

It fixes the TypeScript types. I suppose this is desirable ^^.