### PR TITLE
fix: broken fast-copy dependency [NONE]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,10 @@ updates:
     ignore:
     - dependency-name: husky
       versions:
-        - ">=5.0.0"
+      - ">=5.0.0"
+    - dependency-name: "fast-copy"
+      versions:
+      - ">=3.0.0"
     commit-message:
       prefix: build
       include: scope
@@ -26,3 +29,7 @@ updates:
     commit-message:
       prefix: build-beta
       include: scope
+    ignore:
+      - dependency-name: "fast-copy"
+        versions:
+          - ">=3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.0",
-        "contentful-resolve-response": "^1.3.0",
+        "contentful-resolve-response": "^1.3.12",
         "contentful-sdk-core": "^7.0.1",
         "fast-copy": "^2.1.0",
         "json-stringify-safe": "^5.0.1"
@@ -6470,20 +6470,15 @@
       }
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.11.tgz",
-      "integrity": "sha512-QSjPwLrmrGbK3XrT1T8xGF3lE+1hPFIHIpYOBIZIOZxriFIGx5vEiW6GJFaaA+nntMLwqyzsPeStbzT15PFkug==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.12.tgz",
+      "integrity": "sha512-fe2dsACyV3jzRjHcoeAa4bBt06YwkdsY+kdQwFCcdETyBQIxifuyGamIF4NmKcDqvZ9Yhw7ujjPCadzHb9jmKw==",
       "dependencies": {
-        "fast-copy": "^3.0.0"
+        "fast-copy": "^2.1.7"
       },
       "engines": {
         "node": ">=4.7.2"
       }
-    },
-    "node_modules/contentful-resolve-response/node_modules/fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
     },
     "node_modules/contentful-sdk-core": {
       "version": "7.0.3",
@@ -9535,9 +9530,9 @@
       "dev": true
     },
     "node_modules/fast-copy": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
-      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -28717,18 +28712,11 @@
       "dev": true
     },
     "contentful-resolve-response": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.11.tgz",
-      "integrity": "sha512-QSjPwLrmrGbK3XrT1T8xGF3lE+1hPFIHIpYOBIZIOZxriFIGx5vEiW6GJFaaA+nntMLwqyzsPeStbzT15PFkug==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.12.tgz",
+      "integrity": "sha512-fe2dsACyV3jzRjHcoeAa4bBt06YwkdsY+kdQwFCcdETyBQIxifuyGamIF4NmKcDqvZ9Yhw7ujjPCadzHb9jmKw==",
       "requires": {
-        "fast-copy": "^3.0.0"
-      },
-      "dependencies": {
-        "fast-copy": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-          "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
-        }
+        "fast-copy": "^2.1.7"
       }
     },
     "contentful-sdk-core": {
@@ -31102,9 +31090,9 @@
       }
     },
     "fast-copy": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
-      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "axios": "^0.27.0",
-    "contentful-resolve-response": "^1.3.0",
+    "contentful-resolve-response": "^1.3.12",
     "contentful-sdk-core": "^7.0.1",
     "fast-copy": "^2.1.0",
     "json-stringify-safe": "^5.0.1"


### PR DESCRIPTION
Lock `fast-copy` to version `2.x`. Version 3 caused errors with default exports. 