### PR TITLE
fix: broken fast-copy dependency 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
       "dependencies": {
         "axios": "^0.27.0",
         "contentful-resolve-response": "^1.3.12",
-        "contentful-sdk-core": "^7.0.1",
-        "fast-copy": "^2.1.0",
+        "contentful-sdk-core": "^7.0.4",
+        "fast-copy": "^2.1.7",
         "json-stringify-safe": "^5.0.1"
       },
       "devDependencies": {
@@ -6481,11 +6481,11 @@
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.3.tgz",
-      "integrity": "sha512-Ylr/GYIZKf/bG1hyIIl2zAPOBY/IHUKsD9GTJhXRGFlysmCAALlQkWG5uiO/IXACGnR0i12Bo7IOKacRtFMkGw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.4.tgz",
+      "integrity": "sha512-HwYdXmTsVh9rJOq+TA8CsY+vt6ivqkyJZpiEyVboZKIXAa83QmeVLAeBxK75+IiI9KpaPz7LCjVBXTGoTrhV7A==",
       "dependencies": {
-        "fast-copy": "^3.0.0",
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
@@ -6494,11 +6494,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/contentful-sdk-core/node_modules/fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
     },
     "node_modules/contentful-sdk-jsdoc": {
       "version": "3.0.0",
@@ -28720,22 +28715,15 @@
       }
     },
     "contentful-sdk-core": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.3.tgz",
-      "integrity": "sha512-Ylr/GYIZKf/bG1hyIIl2zAPOBY/IHUKsD9GTJhXRGFlysmCAALlQkWG5uiO/IXACGnR0i12Bo7IOKacRtFMkGw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.4.tgz",
+      "integrity": "sha512-HwYdXmTsVh9rJOq+TA8CsY+vt6ivqkyJZpiEyVboZKIXAa83QmeVLAeBxK75+IiI9KpaPz7LCjVBXTGoTrhV7A==",
       "requires": {
-        "fast-copy": "^3.0.0",
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
         "qs": "^6.9.4"
-      },
-      "dependencies": {
-        "fast-copy": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-          "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
-        }
       }
     },
     "contentful-sdk-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "axios": "^0.27.0",
     "contentful-resolve-response": "^1.3.12",
-    "contentful-sdk-core": "^7.0.1",
-    "fast-copy": "^2.1.0",
+    "contentful-sdk-core": "^7.0.4",
+    "fast-copy": "^2.1.7",
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Last dependency update to ensure all upstream deps lock `fast-copy`