### PR TITLE
Added embedded-asset-{inline|block} types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -211,6 +211,8 @@ export interface FieldValidation {
         'entry-hyperlink'?: FieldValidation[];
         'embedded-entry-block'?: FieldValidation[];
         'embedded-entry-inline'?: FieldValidation[];
+        'embedded-asset-block'?: FieldValidation[];
+        'embedded-asset-inline'?: FieldValidation[];
     };
     enabledNodeTypes?: string[];
 }
@@ -263,7 +265,7 @@ interface RichTextData {
 type RichTextNodeType = 'text' | 'heading-1' | 'heading-2' | 'heading-3' | 'heading-4' | 'heading-5'
     | 'heading-6' | 'paragraph' | 'hyperlink' | 'entry-hyperlink' | 'asset-hyperlink'
     | 'unordered-list' | 'ordered-list' | 'list-item' | 'blockquote' | 'hr' | 'embedded-entry-block'
-    | 'embedded-entry-inline';
+    | 'embedded-entry-inline' | 'embedded-asset-inline' | 'embedded-asset-inline';
 
 interface RichTextContent {
     data: RichTextData;


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Adds the `embedded-asset-inline` and `embedded-asset-block` `RichTextNodeType`s. 

## Description

I added two new types that I had been receiving from the API after embedding an asset in a rich text property.

## Motivation and Context

Fixes #1534 

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
