### PR TITLE
fix: compile ESM modules

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -44,6 +44,7 @@ module.exports = function(api) {
       },
       modules: {
         presets: [['@babel/preset-env', {
+          modules: false,
           targets: {
             browsers: mainSupportedBrowsers,
             node: '12'


### PR DESCRIPTION
resolves https://github.com/contentful/contentful.js/issues/1601

---

It seems counterintuitive, but;
```
@babel/preset-env: The 'modules' option must be one of 
 - 'false' to indicate no module processing
 - a specific module type: 'commonjs', 'amd', 'umd', 'systemjs' - 'auto' (default) which will automatically select 'false' if the current
   process is known to support ES module syntax, or "commonjs" otherwise
```

Meaning by setting it to false, it won't try to process modules into CJS etc.

The contentful-sdk-core package does this as well
https://github.com/contentful/contentful-sdk-core/blob/c7841fe403e1a2f62a45b9777857a4180676afdd/rollup.config.js#L21-L26