### PR TITLE
feat: add allowed resources to Field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,6 +191,13 @@ export interface Field {
     type: FieldType;
     validations: FieldValidation[];
     items?: FieldItem;
+    allowedFields?: ContentTypeAllowedResources
+}
+
+interface ContentTypeAllowedResources {
+    type: string
+    source: string
+    contentTypes: string[]
 }
 
 export type FieldType =
@@ -204,7 +211,8 @@ export type FieldType =
     | 'Link'
     | 'Array'
     | 'Object'
-    | 'RichText';
+    | 'RichText'
+    | 'ResourceLink';
 
 export interface FieldValidation {
     unique?: boolean;


### PR DESCRIPTION
## Summary

Adding allowedFields to content type Field interface. This was omitted previously by mistake. It is available in beta-v10: https://github.com/contentful/contentful.js/blob/beta-v10/lib/types/content-type.ts#L25.