### PR TITLE
fix: expose FieldType

### DIFF
--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,1 +1,2 @@
 export { type AssetQueries, type EntriesQueries } from './query'
+export { type FieldsType } from './util'


### PR DESCRIPTION
Expose the type `FieldType` on root-level. This type is the base type for all field definitions, and is likely to be used in client code.