### PR TITLE
fix(webpack): adjust bundler to avoid using function constructor

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,15 @@ browserBundle.module.rules = [
   })
 ]
 browserBundle.output.filename = `${baseFileName}.browser${PROD ? '.min' : ''}.js`
+// We remove global here to prevent a check which uses the Function constructor and runs into CSP
+// issues, see https://github.com/webpack/webpack/issues/5627#issuecomment-394309966
+browserBundle.node.global = false
+browserBundle.plugins.push(
+  new webpack.DefinePlugin({
+    global: 'window', // Placeholder for global used in any node_modules
+  })
+)
+browserBundle.target = 'web'
 
 // Node - bundled umd file
 const nodeBundle = copy(baseBundleConfig)


### PR DESCRIPTION
In order to avoid the usage of the `Function` operator in our browser bundle, as this runs into CSP issues (see https://github.com/webpack/webpack/issues/5627 and https://github.com/webpack/webpack/issues/6461) we adjust the webpack config: We set the `global` variable to `false` and by doing this avoid that webpack runs a check which makes use of the function constructor (https://github.com/webpack/webpack/blob/fb8afe71385734cfd65f47949117306a91f20753/buildin/global.js#L10).

