### PR TITLE
chore(es-check): check generated modules for es2017 instead of es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postbuild": "npm run check:browser && npm run check:modules && npm run check:node",
     "check:browser": "es-check es2017 ./dist/contentful.browser.js ./dist/contentful.browser.min.js",
     "check:node": "es-check es2017 ./dist/contentful.node.js ./dist/contentful.node.min.js",
-    "check:modules": "es-check es6 --module ./dist/es-modules/**/*.js",
+    "check:modules": "es-check es2017 --module ./dist/es-modules/**/*.js ./dist/es-modules/*.js",
     "docs:build": "jsdoc -c jsdoc.json",
     "docs:dev": "npm run build && npm run docs:build",
     "docs:watch": "nodemon --exec npm run docs:dev -w lib",


### PR DESCRIPTION
As the generated modules are currently not satisfying the `es6` check anymore anyway (due to some overlooked js files in the `es-modules` root folder), we bump to `es2017` so what we are consistent among all artifact checks (browser and node are already only satisfying `es2017`). 

We also make sure that the js files in the root folder are included in the checks from now on (if there is a better blob pattern for this, please let me know).

This is where the checks were introduced: https://github.com/contentful/contentful.js/pull/390.