### PR TITLE
fix(): release config for beta-resource-links [DANTE-852]

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
         "name": "beta-v10",
         "channel": "beta-v10",
         "prerelease": true
+      },
+      {
+        "name": "beta-resource-links",
+        "channel": "beta-resource-links",
+        "prerelease": true
       }
     ],
     "plugins": [


### PR DESCRIPTION
Cherry-picked commit from master to allow release of resource links beta.