### PR TITLE
Add support for withAllLocales client chain for getAsset/getAssets

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -13,6 +13,8 @@ import {
   AssetFields,
   AssetKey,
   AssetQueries,
+  AssetCollectionWithAllLocales,
+  AssetWithAllLocales,
   ContentType,
   ContentTypeCollection,
   EntriesQueries,
@@ -37,10 +39,10 @@ import {
   TagCollection,
   AbstractEntryCollection,
   Entry,
-  AssetCollectionWithAllLocales,
-  AssetWithAllLocales,
   ConfiguredAssetCollection,
   ConfiguredAsset,
+  GenericAssetCollection,
+  GenericAsset,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
@@ -60,90 +62,96 @@ import { validateLocaleParam, validateResolveLinksParam } from './utils/validate
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
 
-export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient & {
-  withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  withoutLinkResolution: ClientWithoutLinkResolution
-  withoutUnresolvableLinks: ClientWithLinkResolutionAndWithoutUnresolvableLinks
+export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
+  BaseClientWithAssets & {
+    withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+    withoutLinkResolution: ClientWithoutLinkResolution
+    withoutUnresolvableLinks: ClientWithLinkResolutionAndWithoutUnresolvableLinks
 
-  getEntry<Fields extends FieldsType>(
-    id: string,
-    query?: EntryQueries
-  ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+    getEntry<Fields extends FieldsType>(
+      id: string,
+      query?: EntryQueries
+    ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
 
-  getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
-  ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+    getEntries<Fields extends FieldsType>(
+      query?: EntriesQueries<Fields>
+    ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
 
-  // TODO: think about using collection generic as response type:
-  // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
-}
+    // TODO: think about using collection generic as response type:
+    // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
+  }
 
-export type ClientWithoutLinkResolution = BaseClient & {
-  withAllLocales: ClientWithAllLocalesAndWithoutLinkResolution
-  getEntry<Fields extends FieldsType>(
-    id: string,
-    query?: EntryQueries
-  ): Promise<EntryWithoutLinkResolution<Fields>>
+export type ClientWithoutLinkResolution = BaseClient &
+  BaseClientWithAssets & {
+    withAllLocales: ClientWithAllLocalesAndWithoutLinkResolution
+    getEntry<Fields extends FieldsType>(
+      id: string,
+      query?: EntryQueries
+    ): Promise<EntryWithoutLinkResolution<Fields>>
 
-  getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
-  ): Promise<EntryCollectionWithoutLinkResolution<Fields>>
-}
+    getEntries<Fields extends FieldsType>(
+      query?: EntriesQueries<Fields>
+    ): Promise<EntryCollectionWithoutLinkResolution<Fields>>
+  }
 
-export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient & {
-  withoutLinkResolution: ClientWithAllLocalesAndWithoutLinkResolution
-  withoutUnresolvableLinks: ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
-    id: string,
-    query?: EntryQueries & { locale?: never }
-  ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>>
+export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
+  BaseClientWithAssetsWithAllLocales & {
+    withoutLinkResolution: ClientWithAllLocalesAndWithoutLinkResolution
+    withoutUnresolvableLinks: ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+    getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
+      id: string,
+      query?: EntryQueries & { locale?: never }
+    ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>>
 
-  getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
-    query?: EntriesQueries<Fields> & { locale?: never }
-  ): Promise<
-    EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
-  >
-}
+    getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
+      query?: EntriesQueries<Fields> & { locale?: never }
+    ): Promise<
+      EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
+    >
+  }
 
-export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient & {
-  getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
-    id: string,
-    query?: EntryQueries & { locale?: never }
-  ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
+  BaseClientWithAssetsWithAllLocales & {
+    getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
+      id: string,
+      query?: EntryQueries & { locale?: never }
+    ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 
-  getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
-    query?: EntriesQueries<Fields> & { locale?: never }
-  ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
-}
+    getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
+      query?: EntriesQueries<Fields> & { locale?: never }
+    ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+  }
 
-export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient & {
-  withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  getEntry<Fields extends FieldsType>(
-    id: string,
-    query?: EntryQueries
-  ): Promise<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
+  BaseClientWithAssets & {
+    withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+    getEntry<Fields extends FieldsType>(
+      id: string,
+      query?: EntryQueries
+    ): Promise<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
 
-  getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
-  ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
-}
+    getEntries<Fields extends FieldsType>(
+      query?: EntriesQueries<Fields>
+    ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+  }
 
-export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient & {
-  getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
-    id: string,
-    query?: EntryQueries & { locale?: never }
-  ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>>
+export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
+  BaseClientWithAssetsWithAllLocales & {
+    getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
+      id: string,
+      query?: EntryQueries & { locale?: never }
+    ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>>
 
-  getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
-    query?: EntriesQueries<Fields> & { locale?: never }
-  ): Promise<
-    EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
-  >
-}
+    getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
+      query?: EntriesQueries<Fields> & { locale?: never }
+    ): Promise<
+      EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
+    >
+  }
 
 export type DefaultClient = ClientWithLinkResolutionAndWithUnresolvableLinks
 
-interface Base {
+interface BaseClient {
   version: string
 
   /**
@@ -331,50 +339,7 @@ interface Base {
   createAssetKey(expiresAt: number): Promise<AssetKey>
 }
 
-interface BaseClientWithEntries extends Base {
-  /**
-   * Gets a collection of Entries
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const response = await client.getEntries()
-   * console.log(response.items)
-   * ```
-   */
-  getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
-  ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
-
-  /**
-   * Gets an Entry
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const entry = await client.getEntry('<entry_id>')
-   * console.log(entry)
-   * ```
-   */
-  getEntry<Fields extends FieldsType>(
-    id: string,
-    query?: EntryQueries
-  ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
-}
-
-interface BaseClientsWithAssets extends Base {
+interface BaseClientWithAssets extends BaseClient {
   /**
    * Gets an Asset
    * @category API
@@ -412,7 +377,48 @@ interface BaseClientsWithAssets extends Base {
   getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection>
 }
 
-export type BaseClient = BaseClientWithEntries & BaseClientsWithAssets
+interface BaseClientWithAssetsWithAllLocales extends BaseClient {
+  /**
+   * Gets an Asset
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const asset = await client.getAsset('<asset_id>')
+   * console.log(asset)
+   * ```
+   */
+  getAsset<Locale extends LocaleCode>(
+    id: string,
+    query?: { locale?: string }
+  ): Promise<AssetWithAllLocales<Locale>>
+
+  /**
+   * Gets a collection of Assets
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getAssets()
+   * console.log(response.items)
+   * ```
+   */
+  getAssets<Locale extends LocaleCode>(
+    query?: AssetQueries<AssetFields>
+  ): Promise<AssetCollectionWithAllLocales<Locale>>
+}
 
 export interface CreateContentfulApiParams {
   http: AxiosInstance
@@ -641,13 +647,11 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     }
   }
 
-  async function getAsset(id: string, query: Record<string, any> = {}): Promise<Asset | AssetWithAllLocales<any>> {
+  async function getAsset(id: string, query: Record<string, any> = {}): Promise<GenericAsset<any>> {
     return makeGetAsset(id, query, options)
   }
 
-  async function getAssets(
-    query: Record<string, any> = {}
-  ): Promise<AssetCollection | AssetCollectionWithAllLocales<any>> {
+  async function getAssets(query: Record<string, any> = {}): Promise<GenericAssetCollection<any>> {
     return makeGetAssets(query, options)
   }
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -37,6 +37,10 @@ import {
   TagCollection,
   AbstractEntryCollection,
   Entry,
+  AssetCollectionWithAllLocales,
+  AssetWithAllLocales,
+  ConfiguredAssetCollection,
+  ConfiguredAsset,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
@@ -56,7 +60,7 @@ import { validateLocaleParam, validateResolveLinksParam } from './utils/validate
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
 
-export interface ClientWithLinkResolutionAndWithUnresolvableLinks extends BaseClient {
+export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient & {
   withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
   withoutLinkResolution: ClientWithoutLinkResolution
   withoutUnresolvableLinks: ClientWithLinkResolutionAndWithoutUnresolvableLinks
@@ -74,7 +78,7 @@ export interface ClientWithLinkResolutionAndWithUnresolvableLinks extends BaseCl
   // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
 }
 
-export interface ClientWithoutLinkResolution extends BaseClient {
+export type ClientWithoutLinkResolution = BaseClient & {
   withAllLocales: ClientWithAllLocalesAndWithoutLinkResolution
   getEntry<Fields extends FieldsType>(
     id: string,
@@ -86,8 +90,7 @@ export interface ClientWithoutLinkResolution extends BaseClient {
   ): Promise<EntryCollectionWithoutLinkResolution<Fields>>
 }
 
-export interface ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
+export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient & {
   withoutLinkResolution: ClientWithAllLocalesAndWithoutLinkResolution
   withoutUnresolvableLinks: ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
   getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
@@ -102,8 +105,7 @@ export interface ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLin
   >
 }
 
-export interface ClientWithAllLocalesAndWithoutLinkResolution
-  extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
+export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient & {
   getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
     id: string,
     query?: EntryQueries & { locale?: never }
@@ -114,8 +116,7 @@ export interface ClientWithAllLocalesAndWithoutLinkResolution
   ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
 }
 
-export interface ClientWithLinkResolutionAndWithoutUnresolvableLinks
-  extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
+export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient & {
   withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
   getEntry<Fields extends FieldsType>(
     id: string,
@@ -127,8 +128,7 @@ export interface ClientWithLinkResolutionAndWithoutUnresolvableLinks
   ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
 }
 
-export interface ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  extends Omit<BaseClient, 'getEntries' | 'getEntry'> {
+export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient & {
   getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
     id: string,
     query?: EntryQueries & { locale?: never }
@@ -143,44 +143,8 @@ export interface ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvable
 
 export type DefaultClient = ClientWithLinkResolutionAndWithUnresolvableLinks
 
-export interface BaseClient {
+interface Base {
   version: string
-
-  /**
-   * Gets an Asset
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const asset = await client.getAsset('<asset_id>')
-   * console.log(asset)
-   * ```
-   */
-  getAsset(id: string, query?: { locale?: string }): Promise<Asset>
-
-  /**
-   * Gets a collection of Assets
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const response = await client.getAssets()
-   * console.log(response.items)
-   * ```
-   */
-  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection>
 
   /**
    * Gets a Content Type
@@ -216,49 +180,7 @@ export interface BaseClient {
    * console.log(response.items)
    * ```
    */
-
   getContentTypes(query?: { query?: string }): Promise<ContentTypeCollection>
-
-  /**
-   * Gets a collection of Entries
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const response = await client.getEntries()
-   * console.log(response.items)
-   * ```
-   */
-  getEntries<Fields extends FieldsType>(
-    query?: EntriesQueries<Fields>
-  ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
-
-  /**
-   * Gets an Entry
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const entry = await client.getEntry('<entry_id>')
-   * console.log(entry)
-   * ```
-   */
-  getEntry<Fields extends FieldsType>(
-    id: string,
-    query?: EntryQueries
-  ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
 
   /**
    * Gets the Space which the client is currently configured to use
@@ -408,6 +330,89 @@ export interface BaseClient {
    */
   createAssetKey(expiresAt: number): Promise<AssetKey>
 }
+
+interface BaseClientWithEntries extends Base {
+  /**
+   * Gets a collection of Entries
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getEntries()
+   * console.log(response.items)
+   * ```
+   */
+  getEntries<Fields extends FieldsType>(
+    query?: EntriesQueries<Fields>
+  ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+
+  /**
+   * Gets an Entry
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const entry = await client.getEntry('<entry_id>')
+   * console.log(entry)
+   * ```
+   */
+  getEntry<Fields extends FieldsType>(
+    id: string,
+    query?: EntryQueries
+  ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+}
+
+interface BaseClientsWithAssets extends Base {
+  /**
+   * Gets an Asset
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const asset = await client.getAsset('<asset_id>')
+   * console.log(asset)
+   * ```
+   */
+  getAsset(id: string, query?: { locale?: string }): Promise<Asset>
+
+  /**
+   * Gets a collection of Assets
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getAssets()
+   * console.log(response.items)
+   * ```
+   */
+  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection>
+}
+
+export type BaseClient = BaseClientWithEntries & BaseClientsWithAssets
 
 export interface CreateContentfulApiParams {
   http: AxiosInstance
@@ -636,20 +641,78 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     }
   }
 
-  async function getAsset(id: string, query = {}): Promise<Asset> {
-    return get<Asset>({
-      context: 'environment',
-      path: `assets/${id}`,
-      config: createRequestConfig({ query: normalizeSelect(query) }),
-    })
+  async function getAsset(id: string, query: Record<string, any> = {}): Promise<Asset | AssetWithAllLocales<any>> {
+    return makeGetAsset(id, query, options)
   }
 
-  async function getAssets(query = {}): Promise<AssetCollection> {
-    return get<AssetCollection>({
-      context: 'environment',
-      path: 'assets',
-      config: createRequestConfig({ query: normalizeSelect(query) }),
-    })
+  async function getAssets(
+    query: Record<string, any> = {}
+  ): Promise<AssetCollection | AssetCollectionWithAllLocales<any>> {
+    return makeGetAssets(query, options)
+  }
+
+  async function makeGetAssets(
+    query: Record<string, any>,
+    options: ChainOptions = {
+      withAllLocales: false,
+      withoutLinkResolution: false,
+      withoutUnresolvableLinks: false,
+    }
+  ) {
+    const { withAllLocales } = options
+
+    validateLocaleParam(query, withAllLocales)
+
+    const localeSpecificQuery = withAllLocales ? { ...query, locale: '*' } : query
+
+    return internalGetAssets<any, Extract<ChainOptions, typeof options>>(localeSpecificQuery)
+  }
+
+  async function internalGetAsset<Locales extends LocaleCode, Options extends ChainOptions>(
+    id: string,
+    query: Record<string, any>
+  ): Promise<ConfiguredAsset<Locales, Options>> {
+    try {
+      return get({
+        context: 'environment',
+        path: `assets/${id}`,
+        config: createRequestConfig({ query: normalizeSelect(query) }),
+      })
+    } catch (error) {
+      errorHandler(error as AxiosError)
+    }
+  }
+
+  async function makeGetAsset(
+    id: string,
+    query: Record<string, any>,
+    options: ChainOptions = {
+      withAllLocales: false,
+      withoutLinkResolution: false,
+      withoutUnresolvableLinks: false,
+    }
+  ) {
+    const { withAllLocales } = options
+
+    validateLocaleParam(query, withAllLocales)
+
+    const localeSpecificQuery = withAllLocales ? { ...query, locale: '*' } : query
+
+    return internalGetAsset<any, Extract<ChainOptions, typeof options>>(id, localeSpecificQuery)
+  }
+
+  async function internalGetAssets<Locales extends LocaleCode, Options extends ChainOptions>(
+    query: Record<string, any>
+  ): Promise<ConfiguredAssetCollection<Locales, Options>> {
+    try {
+      return get({
+        context: 'environment',
+        path: 'assets',
+        config: createRequestConfig({ query: normalizeSelect(query) }),
+      })
+    } catch (error) {
+      errorHandler(error as AxiosError)
+    }
   }
 
   async function getTag(id: string): Promise<Tag> {

--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -1,4 +1,6 @@
+import { ChainOptions, ChainOptionWithAllLocalesAndWithoutLinkResolution } from '../utils/client-helpers'
 import { ContentfulCollection } from './collection'
+import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { EntitySys } from './sys'
 
@@ -32,6 +34,14 @@ export interface Asset {
   metadata: Metadata
 }
 
+export interface AssetWithAllLocales<Locales extends LocaleCode> {
+  sys: AssetSys
+  fields: {
+    [LocaleName in Locales]?: AssetFields
+  }
+  metadata: Metadata
+}
+
 export type AssetMimeType =
   | 'attachment'
   | 'plaintext'
@@ -47,4 +57,19 @@ export type AssetMimeType =
   | 'markup'
 
 export type AssetCollection = ContentfulCollection<Asset>
+export type AssetCollectionWithAllLocales<Locales extends LocaleCode> = ContentfulCollection<AssetWithAllLocales<Locales>>
 export type AssetSys = EntitySys
+
+export type ConfiguredAsset<
+  Locales extends LocaleCode,
+  Options extends ChainOptions
+> = Options extends ChainOptionWithAllLocalesAndWithoutLinkResolution
+  ? AssetWithAllLocales<Locales>
+  : Asset
+
+export type ConfiguredAssetCollection<
+  Locales extends LocaleCode,
+  Options extends ChainOptions
+> = Options extends ChainOptionWithAllLocalesAndWithoutLinkResolution
+  ? AssetCollectionWithAllLocales<Locales>
+  : AssetCollection

--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -42,7 +42,7 @@ export interface AssetWithAllLocales<Locales extends LocaleCode> {
   metadata: Metadata
 }
 
-export type GenericAsset<Locale extends LocaleCode> = Asset | AssetCollectionWithAllLocales<Locale>
+export type GenericAsset<Locale extends LocaleCode> = Asset | AssetWithAllLocales<Locale>
 
 export type AssetMimeType =
   | 'attachment'

--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -1,4 +1,4 @@
-import { ChainOptions, ChainOptionWithAllLocalesAndWithoutLinkResolution } from '../utils/client-helpers'
+import { ChainOptions } from '../utils/client-helpers'
 import { ContentfulCollection } from './collection'
 import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
@@ -42,6 +42,8 @@ export interface AssetWithAllLocales<Locales extends LocaleCode> {
   metadata: Metadata
 }
 
+export type GenericAsset<Locale extends LocaleCode> = Asset | AssetCollectionWithAllLocales<Locale>
+
 export type AssetMimeType =
   | 'attachment'
   | 'plaintext'
@@ -57,19 +59,22 @@ export type AssetMimeType =
   | 'markup'
 
 export type AssetCollection = ContentfulCollection<Asset>
-export type AssetCollectionWithAllLocales<Locales extends LocaleCode> = ContentfulCollection<AssetWithAllLocales<Locales>>
+export type AssetCollectionWithAllLocales<Locales extends LocaleCode> = ContentfulCollection<
+  AssetWithAllLocales<Locales>
+>
+export type GenericAssetCollection<Locales extends LocaleCode> =
+  | AssetCollection
+  | AssetCollectionWithAllLocales<Locales>
 export type AssetSys = EntitySys
 
 export type ConfiguredAsset<
   Locales extends LocaleCode,
   Options extends ChainOptions
-> = Options extends ChainOptionWithAllLocalesAndWithoutLinkResolution
-  ? AssetWithAllLocales<Locales>
-  : Asset
+> = Options extends { withAllLocales: true } ? AssetWithAllLocales<Locales> : Asset
 
 export type ConfiguredAssetCollection<
   Locales extends LocaleCode,
   Options extends ChainOptions
-> = Options extends ChainOptionWithAllLocalesAndWithoutLinkResolution
+> = Options extends { withAllLocales: true }
   ? AssetCollectionWithAllLocales<Locales>
   : AssetCollection

--- a/test/integration/getAsset.test.ts
+++ b/test/integration/getAsset.test.ts
@@ -1,0 +1,28 @@
+import * as contentful from '../../lib/contentful'
+// @ts-ignore
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe('getAsset', () => {
+  const asset = '1x0xpXu4pSGS4OukSyWGUK'
+
+  test('default client', async () => {
+    const response = await client.getAsset(asset)
+
+    expect(response.fields).toBeDefined()
+    expect(typeof response.fields.title).toBe('string')
+  })
+
+  test('client has withAllLocales modifier', async () => {
+    const response = await client.withAllLocales.getAsset(asset)
+
+    expect(response.fields).toBeDefined()
+    expect(typeof response.fields.title).toBe('object')
+  })
+})

--- a/test/integration/getAssets.test.ts
+++ b/test/integration/getAssets.test.ts
@@ -1,0 +1,36 @@
+import * as contentful from '../../lib/contentful'
+// @ts-ignore
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe('getAssets', () => {
+  test('default client', async () => {
+    const response = await client.getAssets()
+
+    expect(response.items).not.toHaveLength(0)
+
+    response.items.forEach((item) => {
+      expect(item.sys.type).toEqual('Asset')
+      expect(item.fields).toBeDefined()
+      expect(typeof item.fields.title).toBe('string')
+    })
+  })
+
+  test('client has withAllLocales modifier', async () => {
+    const response = await client.withAllLocales.getAssets()
+
+    expect(response.items).not.toHaveLength(0)
+
+    response.items.forEach((item) => {
+      expect(item.sys.type).toEqual('Asset')
+      expect(item.fields).toBeDefined()
+      expect(typeof item.fields.title).toBe('object')
+    })
+  })
+})

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -1,0 +1,172 @@
+/// <reference path="../../lib/global.d.ts" />
+import { expectAssignable, expectNotAssignable } from 'tsd'
+
+import {
+  Asset,
+  AssetCollection,
+  AssetCollectionWithAllLocales,
+  AssetDetails,
+  AssetFields,
+  AssetFile,
+  AssetWithAllLocales,
+  EntrySys,
+  GenericAsset,
+  GenericAssetCollection,
+  ConfiguredAsset,
+  ConfiguredAssetCollection,
+} from '../../lib'
+import {
+  ChainOptions,
+  ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
+  ChainOptionWithAllLocalesAndWithoutLinkResolution,
+  ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
+} from '../../lib/utils/client-helpers'
+
+const stringValue = ''
+const numberValue = 123
+const dateValue = '2018-05-03T09:18:16.329Z'
+
+const entrySysValue: EntrySys = {
+  contentType: { sys: { id: stringValue, type: 'Link', linkType: 'ContentType' } },
+  environment: { sys: { id: stringValue, type: 'Link', linkType: 'Environment' } },
+  revision: numberValue,
+  space: { sys: { id: stringValue, type: 'Link', linkType: 'Space' } },
+  type: '', //?
+  updatedAt: dateValue,
+  id: stringValue,
+  createdAt: dateValue,
+}
+const metadataValue = { tags: [] }
+
+type AssetLocales = 'US' | 'DE'
+
+const assetBasics = {
+  sys: entrySysValue,
+  metadata: metadataValue,
+}
+
+const assetDetails: AssetDetails = {
+  size: numberValue,
+  image: {
+    width: numberValue,
+    height: numberValue,
+  },
+}
+
+const assetFile: AssetFile = {
+  url: stringValue,
+  details: assetDetails,
+  fileName: stringValue,
+  contentType: stringValue,
+}
+
+const assetFields: AssetFields = {
+  title: stringValue,
+  description: stringValue,
+  file: assetFile,
+}
+
+const asset: Asset = { ...assetBasics, fields: assetFields }
+const assetWithAllLocales: AssetWithAllLocales<AssetLocales> = {
+  ...assetBasics,
+  fields: {
+    US: assetFields,
+    DE: assetFields,
+  },
+}
+
+const assetCollection: AssetCollection = {
+  total: numberValue,
+  skip: numberValue,
+  limit: numberValue,
+  items: [asset],
+}
+
+const assetCollectionWithAllLocales: AssetCollectionWithAllLocales<AssetLocales> = {
+  total: numberValue,
+  skip: numberValue,
+  limit: numberValue,
+  items: [assetWithAllLocales],
+}
+
+expectAssignable<AssetDetails>(assetDetails)
+expectAssignable<AssetFile>(assetFile)
+expectAssignable<AssetFields>(assetFields)
+
+expectAssignable<Asset>(asset)
+expectAssignable<AssetWithAllLocales<AssetLocales>>(assetWithAllLocales)
+
+expectAssignable<GenericAsset<AssetLocales>>(asset)
+expectAssignable<GenericAsset<AssetLocales>>(assetWithAllLocales)
+
+expectAssignable<AssetCollection>(assetCollection)
+expectAssignable<AssetCollectionWithAllLocales<AssetLocales>>(assetCollectionWithAllLocales)
+
+expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollection)
+expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollectionWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAsset<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+  >
+>(asset)
+expectAssignable<
+  ConfiguredAsset<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+  >
+>(assetWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAsset<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
+>(asset)
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>>(
+  assetWithAllLocales
+)
+
+expectNotAssignable<
+  ConfiguredAsset<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+  >
+>(asset)
+expectAssignable<
+  ConfiguredAsset<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+  >
+>(assetWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+  >
+>(assetCollection)
+expectAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+  >
+>(assetCollectionWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
+>(assetCollection)
+expectAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
+>(assetCollectionWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+  >
+>(assetCollection)
+expectAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+  >
+>(assetCollectionWithAllLocales)

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -19,6 +19,9 @@ import {
   ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
   ChainOptionWithAllLocalesAndWithoutLinkResolution,
   ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
+  ChainOptionWithoutLinkResolution,
+  ChainOptionWithLinkResolutionAndWithUnresolvableLinks,
+  ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks,
 } from '../../lib/utils/client-helpers'
 
 const stringValue = ''
@@ -168,4 +171,44 @@ expectAssignable<
     AssetLocales,
     ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
   >
+>(assetCollectionWithAllLocales)
+
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithoutLinkResolution>>(asset)
+expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithoutLinkResolution>>(
+  assetWithAllLocales
+)
+
+expectAssignable<
+  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+>(asset)
+expectNotAssignable<
+  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+>(assetWithAllLocales)
+
+expectAssignable<
+  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
+>(asset)
+expectNotAssignable<
+  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
+>(assetWithAllLocales)
+
+expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOptionWithoutLinkResolution>>(
+  assetCollection
+)
+expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOptionWithoutLinkResolution>>(
+  assetCollectionWithAllLocales
+)
+
+expectAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+>(assetCollection)
+expectNotAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+>(assetCollectionWithAllLocales)
+
+expectAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
+>(assetCollection)
+expectNotAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
 >(assetCollectionWithAllLocales)

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -16,7 +16,6 @@ import {
   ConfiguredAssetCollection,
 } from '../../lib'
 import {
-  ChainOptions,
   ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
   ChainOptionWithAllLocalesAndWithoutLinkResolution,
   ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -1,3 +1,6 @@
+// As tsd does not pick up the global.d.ts located in /lib we
+// explicitly reference it here once.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
 

--- a/test/types/client/createClient.test-d.ts
+++ b/test/types/client/createClient.test-d.ts
@@ -1,16 +1,21 @@
 import { expectType } from 'tsd'
 
-import { createClient } from '../../../lib';
-import { ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks, ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks, ClientWithAllLocalesAndWithoutLinkResolution, ClientWithLinkResolutionAndWithoutUnresolvableLinks, ClientWithLinkResolutionAndWithUnresolvableLinks, ClientWithoutLinkResolution } from '../../../lib/create-contentful-api';
+import { createClient } from '../../../lib'
+import {
+  ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
+  ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
+  ClientWithAllLocalesAndWithoutLinkResolution,
+  ClientWithLinkResolutionAndWithoutUnresolvableLinks,
+  ClientWithLinkResolutionAndWithUnresolvableLinks,
+  ClientWithoutLinkResolution,
+} from '../../../lib/create-contentful-api'
 
 const CLIENT_OPTIONS = {
   accessToken: 'accessToken',
   space: 'spaceId',
 }
 
-expectType<ClientWithLinkResolutionAndWithUnresolvableLinks>(
-  createClient(CLIENT_OPTIONS)
-)
+expectType<ClientWithLinkResolutionAndWithUnresolvableLinks>(createClient(CLIENT_OPTIONS))
 
 expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks>(
   createClient(CLIENT_OPTIONS).withAllLocales
@@ -23,9 +28,7 @@ expectType<ClientWithAllLocalesAndWithoutLinkResolution>(
 expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutUnresolvableLinks
 )
-expectType<ClientWithoutLinkResolution>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution
-)
+expectType<ClientWithoutLinkResolution>(createClient(CLIENT_OPTIONS).withoutLinkResolution)
 
 expectType<ClientWithLinkResolutionAndWithoutUnresolvableLinks>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks

--- a/test/types/client/createClient.test-d.ts
+++ b/test/types/client/createClient.test-d.ts
@@ -1,0 +1,32 @@
+import { expectType } from 'tsd'
+
+import { createClient } from '../../../lib';
+import { ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks, ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks, ClientWithAllLocalesAndWithoutLinkResolution, ClientWithLinkResolutionAndWithoutUnresolvableLinks, ClientWithLinkResolutionAndWithUnresolvableLinks, ClientWithoutLinkResolution } from '../../../lib/create-contentful-api';
+
+const CLIENT_OPTIONS = {
+  accessToken: 'accessToken',
+  space: 'spaceId',
+}
+
+expectType<ClientWithLinkResolutionAndWithUnresolvableLinks>(
+  createClient(CLIENT_OPTIONS)
+)
+
+expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks>(
+  createClient(CLIENT_OPTIONS).withAllLocales
+)
+
+expectType<ClientWithAllLocalesAndWithoutLinkResolution>(
+  createClient(CLIENT_OPTIONS).withAllLocales.withoutLinkResolution
+)
+
+expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks>(
+  createClient(CLIENT_OPTIONS).withAllLocales.withoutUnresolvableLinks
+)
+expectType<ClientWithoutLinkResolution>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution
+)
+
+expectType<ClientWithLinkResolutionAndWithoutUnresolvableLinks>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
+)

--- a/test/types/client/getAssets.test-d.ts
+++ b/test/types/client/getAssets.test-d.ts
@@ -1,0 +1,30 @@
+import { expectType } from 'tsd'
+import {
+  Asset,
+  AssetCollection,
+  createClient,
+  AssetCollectionWithAllLocales,
+  AssetWithAllLocales,
+  LocaleCode
+} from '../../../lib'
+
+const client = createClient({
+  accessToken: 'accessToken',
+  space: 'spaceId',
+})
+
+expectType<AssetCollection>(
+  await client.getAssets()
+)
+
+expectType<Asset>(
+  await client.getAsset('test')
+)
+
+expectType<AssetCollectionWithAllLocales<LocaleCode>>(
+  await client.withAllLocales.getAssets<LocaleCode>()
+)
+
+expectType<AssetWithAllLocales<LocaleCode>>(
+  await client.withAllLocales.getAsset<LocaleCode>('test')
+)

--- a/test/types/client/getAssets.test-d.ts
+++ b/test/types/client/getAssets.test-d.ts
@@ -5,7 +5,7 @@ import {
   createClient,
   AssetCollectionWithAllLocales,
   AssetWithAllLocales,
-  LocaleCode
+  LocaleCode,
 } from '../../../lib'
 
 const client = createClient({
@@ -13,13 +13,9 @@ const client = createClient({
   space: 'spaceId',
 })
 
-expectType<AssetCollection>(
-  await client.getAssets()
-)
+expectType<AssetCollection>(await client.getAssets())
 
-expectType<Asset>(
-  await client.getAsset('test')
-)
+expectType<Asset>(await client.getAsset('test'))
 
 expectType<AssetCollectionWithAllLocales<LocaleCode>>(
   await client.withAllLocales.getAssets<LocaleCode>()


### PR DESCRIPTION
Similar to `getEntries` and `getEntry`, we want to support client chaining of `client.withAllLocales` for `getAssets` and `getAsset`. This also includes types and type tests.
