### PR TITLE
chore: use simplified chain option types consistently

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -37,19 +37,19 @@ import {
   SyncCollection,
   Tag,
   TagCollection,
-  AbstractEntryCollection,
   Entry,
   ConfiguredAssetCollection,
   ConfiguredAsset,
   GenericAssetCollection,
   GenericAsset,
+  ConfiguredEntryCollection,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
 import validateTimestamp from './utils/validate-timestamp'
-import { ChainOption, ChainOptions } from './utils/client-helpers'
+import { ChainOptions } from './utils/client-helpers'
 import { validateLocaleParam, validateResolveLinksParam } from './utils/validate-params'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
@@ -589,30 +589,6 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     )
   }
 
-  type ConfiguredEntry<
-    Fields extends FieldsType,
-    Locales extends LocaleCode,
-    Options extends ChainOptions
-  > = Options extends ChainOption<'allLocales'>
-    ? EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
-    : Options extends ChainOption<'allLocales' | 'noLinkResolution'>
-    ? EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>
-    : Options extends ChainOption<'allLocales' | 'noUnresolvableLinks'>
-    ? EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
-    : Options extends ChainOption<'noLinkResolution'>
-    ? EntryWithoutLinkResolution<Fields>
-    : Options extends ChainOption
-    ? EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>
-    : Options extends ChainOption<'noUnresolvableLinks'>
-    ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>
-    : Entry<Fields>
-
-  type ConfiguredEntryCollection<
-    Fields extends FieldsType,
-    Locales extends LocaleCode,
-    Options extends ChainOptions
-  > = AbstractEntryCollection<ConfiguredEntry<Fields, Locales, Options>>
-
   async function internalGetEntries<
     Fields extends FieldsType,
     Locales extends LocaleCode,
@@ -768,7 +744,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     http.defaults.baseURL = getGlobalOptions().environmentBaseUrl
   }
 
-  return <DefaultClient>{
+  return {
     version: __VERSION__,
 
     getSpace,
@@ -790,5 +766,5 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     getEntries,
 
     createAssetKey,
-  }
+  } as unknown as DefaultClient
 }

--- a/lib/make-client.ts
+++ b/lib/make-client.ts
@@ -35,19 +35,20 @@ function create<OptionsType extends ChainOptions>(
   return Object.create(response) as ConfiguredClient<OptionsType>
 }
 
-type ConfiguredClient<Options extends ChainOptions> = Options extends ChainOption<'allLocales'>
-  ? ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  : Options extends ChainOption<'allLocales' | 'noLinkResolution'>
-  ? ClientWithAllLocalesAndWithoutLinkResolution
-  : Options extends ChainOption<'allLocales' | 'noUnresolvableLinks'>
-  ? ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  : Options extends ChainOption<'noLinkResolution'>
-  ? ClientWithoutLinkResolution
-  : Options extends ChainOption
-  ? ClientWithLinkResolutionAndWithUnresolvableLinks
-  : Options extends ChainOption<'noUnresolvableLinks'>
-  ? ClientWithLinkResolutionAndWithoutUnresolvableLinks
-  : never
+type ConfiguredClient<Options extends ChainOptions> =
+  Options extends ChainOption<'WITH_ALL_LOCALES'>
+    ? ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
+    : Options extends ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+    ? ClientWithAllLocalesAndWithoutLinkResolution
+    : Options extends ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+    ? ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
+    : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
+    ? ClientWithoutLinkResolution
+    : Options extends ChainOption
+    ? ClientWithLinkResolutionAndWithUnresolvableLinks
+    : Options extends ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>
+    ? ClientWithLinkResolutionAndWithoutUnresolvableLinks
+    : never
 
 export const makeClient = ({
   http,

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -6,6 +6,7 @@ import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { FieldsType } from './query/util'
 import { EntitySys } from './sys'
+import { ChainOption, ChainOptions } from '../utils/client-helpers'
 
 export interface EntrySys extends EntitySys {
   contentType: { sys: ContentTypeLink }
@@ -184,3 +185,27 @@ export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolv
 > = AbstractEntryCollection<
   EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
 >
+
+export type ConfiguredEntry<
+  Fields extends FieldsType,
+  Locales extends LocaleCode,
+  Options extends ChainOptions
+> = Options extends ChainOption
+  ? EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>
+  : Options extends ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>
+  ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>
+  : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
+  ? EntryWithoutLinkResolution<Fields>
+  : Options extends ChainOption<'WITH_ALL_LOCALES'>
+  ? EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
+  : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
+  ? EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>
+  : Options extends ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+  ? EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
+  : never
+
+export type ConfiguredEntryCollection<
+  Fields extends FieldsType,
+  Locales extends LocaleCode,
+  Options extends ChainOptions
+> = AbstractEntryCollection<ConfiguredEntry<Fields, Locales, Options>>

--- a/lib/utils/client-helpers.ts
+++ b/lib/utils/client-helpers.ts
@@ -2,21 +2,20 @@ export type ChainModifiers =
   | 'WITH_ALL_LOCALES'
   | 'WITHOUT_LINK_RESOLUTION'
   | 'WITHOUT_UNRESOLVABLE_LINKS'
-  | unknown
   | undefined
 
 export type ChainOption<Modifiers extends ChainModifiers = undefined> = {
-  withoutLinkResolution: unknown extends Modifiers
+  withoutLinkResolution: ChainModifiers extends Modifiers
     ? boolean
     : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? true
     : false
-  withAllLocales: unknown extends Modifiers
+  withAllLocales: ChainModifiers extends Modifiers
     ? boolean
     : 'WITH_ALL_LOCALES' extends Modifiers
     ? true
     : false
-  withoutUnresolvableLinks: unknown extends Modifiers
+  withoutUnresolvableLinks: ChainModifiers extends Modifiers
     ? boolean
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
     ? true
@@ -25,4 +24,4 @@ export type ChainOption<Modifiers extends ChainModifiers = undefined> = {
 
 export type DefaultChainOption = ChainOption
 
-export type ChainOptions = ChainOption<unknown>
+export type ChainOptions = ChainOption<ChainModifiers>

--- a/lib/utils/client-helpers.ts
+++ b/lib/utils/client-helpers.ts
@@ -1,47 +1,28 @@
 export type ChainModifiers =
-  | 'allLocales'
-  | 'noLinkResolution'
-  | 'noUnresolvableLinks'
+  | 'WITH_ALL_LOCALES'
+  | 'WITHOUT_LINK_RESOLUTION'
+  | 'WITHOUT_UNRESOLVABLE_LINKS'
   | unknown
   | undefined
 
 export type ChainOption<Modifiers extends ChainModifiers = undefined> = {
   withoutLinkResolution: unknown extends Modifiers
     ? boolean
-    : 'noLinkResolution' extends Modifiers
+    : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? true
     : false
   withAllLocales: unknown extends Modifiers
     ? boolean
-    : 'allLocales' extends Modifiers
+    : 'WITH_ALL_LOCALES' extends Modifiers
     ? true
     : false
   withoutUnresolvableLinks: unknown extends Modifiers
     ? boolean
-    : 'noUnresolvableLinks' extends Modifiers
+    : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
     ? true
     : false
 }
 
-export type BaseChainOptions = {
-  withoutLinkResolution: boolean
-  withAllLocales: boolean
-  withoutUnresolvableLinks: boolean
-}
-
-export type ChainOptionWithoutLinkResolution = ChainOption<'noLinkResolution'>
-export type ChainOptionWithLinkResolutionAndWithUnresolvableLinks = ChainOption
-export type ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks =
-  ChainOption<'noUnresolvableLinks'>
-export type ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks =
-  ChainOption<'allLocales'>
-export type ChainOptionWithAllLocalesAndWithoutLinkResolution = ChainOption<
-  'allLocales' | 'noLinkResolution'
->
-export type ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = ChainOption<
-  'allLocales' | 'noUnresolvableLinks'
->
-
-export type DefaultChainOption = ChainOptionWithLinkResolutionAndWithUnresolvableLinks
+export type DefaultChainOption = ChainOption
 
 export type ChainOptions = ChainOption<unknown>

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -18,14 +18,7 @@ import {
   ConfiguredAsset,
   ConfiguredAssetCollection,
 } from '../../lib'
-import {
-  ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  ChainOptionWithAllLocalesAndWithoutLinkResolution,
-  ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  ChainOptionWithoutLinkResolution,
-  ChainOptionWithLinkResolutionAndWithUnresolvableLinks,
-  ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks,
-} from '../../lib/utils/client-helpers'
+import { ChainOption } from '../../lib/utils/client-helpers'
 
 const stringValue = ''
 const numberValue = 123
@@ -110,108 +103,86 @@ expectAssignable<AssetCollectionWithAllLocales<AssetLocales>>(assetCollectionWit
 expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollection)
 expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollectionWithAllLocales)
 
-expectNotAssignable<
-  ConfiguredAsset<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  >
->(asset)
-expectAssignable<
-  ConfiguredAsset<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  >
->(assetWithAllLocales)
-
-expectNotAssignable<
-  ConfiguredAsset<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
->(asset)
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>>(
+expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(asset)
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
   assetWithAllLocales
 )
 
 expectNotAssignable<
-  ConfiguredAsset<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  >
+  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>
 >(asset)
 expectAssignable<
-  ConfiguredAsset<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  >
+  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>
 >(assetWithAllLocales)
 
 expectNotAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  >
->(assetCollection)
-expectAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-  >
->(assetCollectionWithAllLocales)
-
-expectNotAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
->(assetCollection)
-expectAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithAllLocalesAndWithoutLinkResolution>
->(assetCollectionWithAllLocales)
-
-expectNotAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  >
->(assetCollection)
-expectAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOptionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-  >
->(assetCollectionWithAllLocales)
-
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithoutLinkResolution>>(asset)
-expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOptionWithoutLinkResolution>>(
-  assetWithAllLocales
-)
-
-expectAssignable<
-  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>
 >(asset)
-expectNotAssignable<
-  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+expectAssignable<
+  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>
 >(assetWithAllLocales)
 
-expectAssignable<
-  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
->(asset)
-expectNotAssignable<
-  ConfiguredAsset<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
->(assetWithAllLocales)
-
-expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOptionWithoutLinkResolution>>(
+expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
   assetCollection
 )
-expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOptionWithoutLinkResolution>>(
+expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
+  assetCollectionWithAllLocales
+)
+
+expectNotAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+  >
+>(assetCollection)
+expectAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+  >
+>(assetCollectionWithAllLocales)
+
+expectNotAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+  >
+>(assetCollection)
+expectAssignable<
+  ConfiguredAssetCollection<
+    AssetLocales,
+    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+  >
+>(assetCollectionWithAllLocales)
+
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(asset)
+expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(
+  assetWithAllLocales
+)
+
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOption>>(asset)
+expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption>>(assetWithAllLocales)
+
+expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>>(asset)
+expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+  assetWithAllLocales
+)
+
+expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(
+  assetCollection
+)
+expectNotAssignable<
+  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>
+>(assetCollectionWithAllLocales)
+
+expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption>>(assetCollection)
+expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption>>(
   assetCollectionWithAllLocales
 )
 
 expectAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
+  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>
 >(assetCollection)
 expectNotAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithUnresolvableLinks>
->(assetCollectionWithAllLocales)
-
-expectAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
->(assetCollection)
-expectNotAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOptionWithLinkResolutionAndWithoutUnresolvableLinks>
+  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>
 >(assetCollectionWithAllLocales)

--- a/test/types/chain-options.test-d.ts
+++ b/test/types/chain-options.test-d.ts
@@ -13,37 +13,37 @@ expectType<ChainOption>({
   withoutUnresolvableLinks: false,
 })
 
-expectType<ChainOption<'noUnresolvableLinks'>>({
+expectType<ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>({
   withoutLinkResolution: false,
   withAllLocales: false,
   withoutUnresolvableLinks: true,
 })
 
-expectType<ChainOption<'noLinkResolution'>>({
+expectType<ChainOption<'WITHOUT_LINK_RESOLUTION'>>({
   withoutLinkResolution: true,
   withAllLocales: false,
   withoutUnresolvableLinks: false,
 })
 
-expectType<ChainOption<'allLocales'>>({
+expectType<ChainOption<'WITH_ALL_LOCALES'>>({
   withoutLinkResolution: false,
   withAllLocales: true,
   withoutUnresolvableLinks: false,
 })
 
-expectAssignable<ChainOption<'allLocales' | 'noUnresolvableLinks'>>({
+expectType<ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>({
   withoutLinkResolution: false,
   withAllLocales: true,
   withoutUnresolvableLinks: true,
 })
 
-expectNotType<ChainOption<'allLocales' | 'noUnresolvableLinks'>>({
+expectNotType<ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>({
   withoutLinkResolution: false,
   withAllLocales: true,
   withoutUnresolvableLinks: false,
 })
 
-expectType<ChainOption<'allLocales' | 'noLinkResolution'>>({
+expectType<ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>({
   withoutLinkResolution: true,
   withAllLocales: true,
   withoutUnresolvableLinks: false,

--- a/test/types/chain-options.test-d.ts
+++ b/test/types/chain-options.test-d.ts
@@ -1,5 +1,7 @@
-import { expectAssignable, expectNotType, expectType } from 'tsd'
-import { ChainOption, ChainOptions } from '../../lib/utils/client-helpers'
+import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd'
+import { ChainModifiers, ChainOption, ChainOptions } from '../../lib/utils/client-helpers'
+
+expectNotAssignable<ChainModifiers>('ANY_STRING')
 
 expectAssignable<ChainOptions>({
   withoutLinkResolution: true as boolean,


### PR DESCRIPTION
## Summary

Use new chain option types introduced in https://github.com/contentful/contentful.js/pull/1695 consistently and follow conventions for modifier names as suggested in  https://github.com/contentful/contentful.js/pull/1695#discussion_r1109549704.

## Description

* Replace remaining uses of old chain option types of format `ChainOptionWithAllLocalesAndWithoutLinkResolution`
* Move configured entry types to proper type file
* Update modifier enum names to match convention for constant names and match actual options / chain modifiers more closely.
* Make configured entry type more strict.
