### PR TITLE
fix: correct entry types and add chain modifiers

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -251,7 +251,7 @@ interface BaseClient {
    * ```
    */
   // TODO: type properly
-  parseEntries<T>(raw: any): EntryCollection<T>
+  parseEntries<T extends FieldsType>(raw: any): EntryCollection<T>
 
   /**
    * Synchronizes either all the content or only new content since last sync

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -42,21 +42,22 @@ export type BasicEntryField =
   | EntryFields.RichText
   | EntryFields.Object
 
+type BaseEntry = {
+  sys: EntrySys
+  metadata: Metadata
+}
+
 /**
  * @category Entities
  */
-export interface Entry<T> {
-  sys: EntrySys
-  metadata: Metadata
+export type Entry<T> = BaseEntry & {
   fields: T
 }
 
-export interface EntryWithAllLocalesAndWithoutLinkResolution<
+export type EntryWithAllLocalesAndWithoutLinkResolution<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> {
-  sys: EntrySys
-  metadata: Metadata
+> = BaseEntry & {
   fields: {
     [FieldName in keyof Fields]: {
       [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<any>
@@ -68,24 +69,23 @@ export interface EntryWithAllLocalesAndWithoutLinkResolution<
   }
 }
 
-export type EntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> = {
-  sys: EntrySys
-  metadata: Metadata
-  fields: {
-    [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
-      ? EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink
-      : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
-      ? (EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink)[]
-      : Fields[FieldName]
+export type EntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> =
+  BaseEntry & {
+    fields: {
+      [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<
+        infer LinkedEntryFields
+      >
+        ? EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink
+        : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
+        ? (EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink)[]
+        : Fields[FieldName]
+    }
   }
-}
 
 export type EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = {
-  sys: EntrySys
-  metadata: Metadata
+> = BaseEntry & {
   fields: {
     [FieldName in keyof Fields]: {
       [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
@@ -94,37 +94,37 @@ export type EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
                 LinkedEntryFields,
                 Locales
               >
-            | undefined
+            | EntryLink
         : Fields[FieldName] extends Array<EntryFields.Link<infer LinkedEntryFields>>
-        ?
+        ? (
             | EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
                 LinkedEntryFields,
                 Locales
-              >[]
-            | undefined
+              >
+            | EntryLink
+          )[]
         : Fields[FieldName]
     }
   }
 }
 
-export type EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType> = {
-  sys: EntrySys
-  metadata: Metadata
-  fields: {
-    [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
-      ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields> | undefined
-      : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
-      ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields>[] | undefined
-      : Fields[FieldName]
+export type EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType> =
+  BaseEntry & {
+    fields: {
+      [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<
+        infer LinkedEntryFields
+      >
+        ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields> | undefined
+        : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
+        ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields>[] | undefined
+        : Fields[FieldName]
+    }
   }
-}
 
 export type EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = {
-  sys: EntrySys
-  metadata: Metadata
+> = BaseEntry & {
   fields: {
     [FieldName in keyof Fields]: {
       [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
@@ -156,7 +156,15 @@ export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TE
 
 export type EntryCollection<T> = AbstractEntryCollection<Entry<T>>
 
-export type EntryWithoutLinkResolution<T> = Entry<T>
+export type EntryWithoutLinkResolution<Fields extends FieldsType> = BaseEntry & {
+  fields: {
+    [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<any>
+      ? EntryLink
+      : Fields[FieldName] extends EntryFields.Link<any>[]
+      ? EntryLink[]
+      : Fields[FieldName]
+  }
+}
 
 export type EntryCollectionWithoutLinkResolution<T> = EntryCollection<T>
 

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -6,7 +6,7 @@ import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { FieldsType } from './query/util'
 import { EntitySys } from './sys'
-import { ChainOption, ChainOptions } from '../utils/client-helpers'
+import { ChainModifiers, ChainOption, ChainOptions } from '../utils/client-helpers'
 
 export interface EntrySys extends EntitySys {
   contentType: { sys: ContentTypeLink }
@@ -25,8 +25,8 @@ export declare namespace EntryFields {
     lon: number
   }
 
-  type Link<T extends FieldsType> = Asset | Entry<T>
-  type Array<T = any> = symbol[] | Entry<T>[] | Asset[]
+  type Link<T extends FieldsType> = Asset | GenericEntry<T>
+  type Array<T extends FieldsType = any> = symbol[] | GenericEntry<T>[] | Asset[]
   type Object<T extends Record<string, any> = Record<string, unknown>> = T
   type RichText = RichTextDocument
 }
@@ -50,101 +50,80 @@ type BaseEntry = {
 /**
  * @category Entities
  */
-export type Entry<T> = BaseEntry & {
-  fields: T
+export type GenericEntry<Fields extends FieldsType> = BaseEntry & {
+  fields: Fields
 }
+
+/**
+ * @category Entities
+ * @deprecated
+ */
+export type Entry<Fields extends FieldsType> = GenericEntry<Fields>
+
+export type ResolvedField<
+  Fields extends FieldsType,
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode = any
+> = Fields extends EntryFields.Link<infer LinkedFields>
+  ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
+    ? EntryLink
+    :
+        | NewEntry<LinkedFields, Modifiers, Locales>
+        | ('WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers ? undefined : EntryLink)
+  : Fields extends EntryFields.Link<infer LinkedFields>[]
+  ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
+    ? EntryLink[]
+    : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
+    ? (NewEntry<LinkedFields, Modifiers, Locales> | undefined)[]
+    : (NewEntry<LinkedFields, Modifiers, Locales> | EntryLink)[]
+  : Fields
+
+// TODO: rename after renaming generic Entry type
+export type NewEntry<
+  Fields extends FieldsType,
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode = any
+> = BaseEntry & {
+  fields: 'WITH_ALL_LOCALES' extends Modifiers
+    ? {
+        [FieldName in keyof Fields]: {
+          [LocaleName in Locales]?: ResolvedField<Fields[FieldName], Modifiers, Locales>
+        }
+      }
+    : {
+        [FieldName in keyof Fields]: ResolvedField<Fields[FieldName], Modifiers, Locales>
+      }
+}
+
+export type EntryWithoutLinkResolution<Fields extends FieldsType> = NewEntry<
+  Fields,
+  'WITHOUT_LINK_RESOLUTION',
+  LocaleCode
+>
 
 export type EntryWithAllLocalesAndWithoutLinkResolution<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = BaseEntry & {
-  fields: {
-    [FieldName in keyof Fields]: {
-      [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<any>
-        ? EntryLink
-        : Fields[FieldName] extends EntryFields.Link<any>[]
-        ? EntryLink[]
-        : Fields[FieldName]
-    }
-  }
-}
+> = NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
 
-export type EntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> =
-  BaseEntry & {
-    fields: {
-      [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<
-        infer LinkedEntryFields
-      >
-        ? EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink
-        : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
-        ? (EntryWithLinkResolutionAndWithUnresolvableLinks<LinkedEntryFields> | EntryLink)[]
-        : Fields[FieldName]
-    }
-  }
+export type EntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> = NewEntry<
+  Fields,
+  undefined,
+  LocaleCode
+>
 
 export type EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = BaseEntry & {
-  fields: {
-    [FieldName in keyof Fields]: {
-      [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
-        ?
-            | EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-                LinkedEntryFields,
-                Locales
-              >
-            | EntryLink
-        : Fields[FieldName] extends Array<EntryFields.Link<infer LinkedEntryFields>>
-        ? (
-            | EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-                LinkedEntryFields,
-                Locales
-              >
-            | EntryLink
-          )[]
-        : Fields[FieldName]
-    }
-  }
-}
+> = NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>
 
 export type EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType> =
-  BaseEntry & {
-    fields: {
-      [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<
-        infer LinkedEntryFields
-      >
-        ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields> | undefined
-        : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
-        ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<LinkedEntryFields>[] | undefined
-        : Fields[FieldName]
-    }
-  }
+  NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS', LocaleCode>
 
 export type EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = BaseEntry & {
-  fields: {
-    [FieldName in keyof Fields]: {
-      [LocaleName in Locales]?: Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>
-        ?
-            | EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-                LinkedEntryFields,
-                Locales
-              >
-            | undefined
-        : Fields[FieldName] extends EntryFields.Link<infer LinkedEntryFields>[]
-        ?
-            | EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-                LinkedEntryFields,
-                Locales
-              >[]
-            | undefined
-        : Fields[FieldName]
-    }
-  }
-}
+> = NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
 
 export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TEntry> {
   errors?: Array<any>
@@ -154,63 +133,49 @@ export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TE
   }
 }
 
-export type EntryCollection<T> = AbstractEntryCollection<Entry<T>>
+export type GenericEntryCollection<Fields extends FieldsType> = AbstractEntryCollection<
+  GenericEntry<Fields>
+>
 
-export type EntryWithoutLinkResolution<Fields extends FieldsType> = BaseEntry & {
-  fields: {
-    [FieldName in keyof Fields]: Fields[FieldName] extends EntryFields.Link<any>
-      ? EntryLink
-      : Fields[FieldName] extends EntryFields.Link<any>[]
-      ? EntryLink[]
-      : Fields[FieldName]
-  }
-}
+/**
+ * @deprecated
+ */
+export type EntryCollection<Fields extends FieldsType> = GenericEntryCollection<Fields>
 
-export type EntryCollectionWithoutLinkResolution<T> = EntryCollection<T>
+export type EntryCollectionWithoutLinkResolution<Fields extends FieldsType> =
+  AbstractEntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
 
-export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<T extends FieldsType> =
-  AbstractEntryCollection<EntryWithLinkResolutionAndWithUnresolvableLinks<T>>
+export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> =
+  AbstractEntryCollection<NewEntry<Fields, undefined>>
 
 export type EntryCollectionWithAllLocalesAndWithoutLinkResolution<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = AbstractEntryCollection<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+> = AbstractEntryCollection<
+  NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
+>
 
 export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
-> = AbstractEntryCollection<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
->
+> = AbstractEntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>
 
 export type EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<
   Fields extends FieldsType
-> = AbstractEntryCollection<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+> = AbstractEntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
 
 export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
   Fields extends FieldsType,
   Locales extends LocaleCode
 > = AbstractEntryCollection<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
+  NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
 >
 
 export type ConfiguredEntry<
   Fields extends FieldsType,
   Locales extends LocaleCode,
   Options extends ChainOptions
-> = Options extends ChainOption
-  ? EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>
-  : Options extends ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>
-  ? EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>
-  : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
-  ? EntryWithoutLinkResolution<Fields>
-  : Options extends ChainOption<'WITH_ALL_LOCALES'>
-  ? EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
-  : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
-  ? EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>
-  : Options extends ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
-  ? EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
-  : never
+> = Options extends ChainOption<infer Modifiers> ? NewEntry<Fields, Modifiers, Locales> : never
 
 export type ConfiguredEntryCollection<
   Fields extends FieldsType,

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -61,28 +61,28 @@ export type GenericEntry<Fields extends FieldsType> = BaseEntry & {
 export type Entry<Fields extends FieldsType> = GenericEntry<Fields>
 
 export type ResolvedField<
-  Fields extends FieldsType,
+  Field,
   Modifiers extends ChainModifiers,
-  Locales extends LocaleCode = any
-> = Fields extends EntryFields.Link<infer LinkedFields>
+  Locales extends LocaleCode = LocaleCode
+> = Field extends EntryFields.Link<infer LinkedFields>
   ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? EntryLink
     :
         | NewEntry<LinkedFields, Modifiers, Locales>
         | ('WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers ? undefined : EntryLink)
-  : Fields extends EntryFields.Link<infer LinkedFields>[]
+  : Field extends EntryFields.Link<infer LinkedFields>[]
   ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? EntryLink[]
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
     ? (NewEntry<LinkedFields, Modifiers, Locales> | undefined)[]
     : (NewEntry<LinkedFields, Modifiers, Locales> | EntryLink)[]
-  : Fields
+  : Field
 
 // TODO: rename after renaming generic Entry type
 export type NewEntry<
   Fields extends FieldsType,
   Modifiers extends ChainModifiers,
-  Locales extends LocaleCode = any
+  Locales extends LocaleCode = LocaleCode
 > = BaseEntry & {
   fields: 'WITH_ALL_LOCALES' extends Modifiers
     ? {

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -440,7 +440,7 @@ expectAssignable<
         },
       },
     ],
-    unresolvableMultiReferenceField: undefined,
+    unresolvableMultiReferenceField: [undefined],
   },
 })
 

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -13,6 +13,7 @@ import {
   EntryWithAllLocalesAndWithoutLinkResolution,
   EntryWithLinkResolutionAndWithoutUnresolvableLinks,
   EntryWithLinkResolutionAndWithUnresolvableLinks,
+  EntryWithoutLinkResolution,
 } from '../../lib'
 
 export const stringValue = ''
@@ -91,6 +92,67 @@ expectAssignable<
 
 /**
  * @namespace: Typescript - type test
+ * @description: EntryWithoutLinkResolution linked entries are all rendered as entry links
+ */
+expectAssignable<
+  EntryWithoutLinkResolution<{
+    stringField: EntryFields.Text
+    referenceField: EntryFields.Link<ExampleEntryFields>
+    multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    stringField: stringValue,
+    referenceField: entryLinkValue,
+    multiReferenceField: [entryLinkValue, entryLinkValue],
+  },
+})
+
+expectNotAssignable<
+  EntryWithoutLinkResolution<{
+    stringField: EntryFields.Text
+    referenceField: EntryFields.Link<ExampleEntryFields>
+    multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    stringField: stringValue,
+    referenceField: undefined,
+    multiReferenceField: [undefined, undefined],
+  },
+})
+
+expectNotAssignable<
+  EntryWithoutLinkResolution<{
+    stringField: EntryFields.Text
+    referenceField: EntryFields.Link<ExampleEntryFields>
+    multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    stringField: stringValue,
+    referenceField: {
+      ...entryBasics,
+      fields: {
+        numberField: numberValue,
+      },
+    },
+    multiReferenceField: [
+      {
+        ...entryBasics,
+        fields: {
+          numberField: numberValue,
+        },
+      },
+    ],
+  },
+})
+
+/**
+ * @namespace: Typescript - type test
  * @description: EntryWithLinkResolutionAndWithUnresolvableLinks referenced entries can be either resolved or unresolved.
  * unresolved entries are referenced as entry links. Fields with multiple references can have resolved and unresolved mixed.
  */
@@ -131,6 +193,40 @@ expectAssignable<
         },
       },
       entryLinkValue,
+    ],
+  },
+})
+
+/* unresolved links in reference fields cannot be undefined */
+expectNotAssignable<
+  EntryWithLinkResolutionAndWithUnresolvableLinks<{
+    unresolvableReferenceField: EntryFields.Link<ExampleEntryFields>
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    unresolvableReferenceField: undefined,
+  },
+})
+
+/* unresolved links in multi reference fields cannot be undefined */
+expectNotAssignable<
+  EntryWithLinkResolutionAndWithUnresolvableLinks<{
+    unresolvableMultiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+    mixedMultiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    unresolvableMultiReferenceField: [undefined],
+    mixedMultiReferenceField: [
+      {
+        ...entryBasics,
+        fields: {
+          numberField: numberValue,
+        },
+      },
+      undefined,
     ],
   },
 })
@@ -185,6 +281,42 @@ expectNotAssignable<
   },
 })
 
+/* links in reference fields can be undefined because we can’t distinguish between missing translation and missing link */
+expectAssignable<
+  EntryWithAllLocalesAndWithoutLinkResolution<
+    {
+      referenceField: EntryFields.Link<ExampleEntryFields>
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    referenceField: {
+      DE: undefined,
+      US: undefined,
+    },
+  },
+})
+
+/* links in multi reference fields cannot be undefined */
+expectNotAssignable<
+  EntryWithAllLocalesAndWithoutLinkResolution<
+    {
+      multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    multiReferenceField: {
+      DE: [undefined],
+      US: [undefined],
+    },
+  },
+})
+
 /**
  * @namespace: Typescript - type test
  * @description: EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks All fields are mapped to the given set of locales.
@@ -194,8 +326,10 @@ expectAssignable<
   EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
     {
       stringField: EntryFields.Text
-      referenceField: EntryFields.Link<ExampleEntryFields>
-      multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+      resolvableReferenceField: EntryFields.Link<ExampleEntryFields>
+      unresolvableReferenceField: EntryFields.Link<ExampleEntryFields>
+      resolvableMultiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+      unresolvableMultiReferenceField: EntryFields.Link<ExampleEntryFields>[]
     },
     'US' | 'DE'
   >
@@ -206,7 +340,7 @@ expectAssignable<
       US: stringValue,
       DE: stringValue,
     },
-    referenceField: {
+    resolvableReferenceField: {
       DE: {
         ...entryBasics,
         fields: { numberField: { US: numberValue, DE: numberValue } },
@@ -216,7 +350,8 @@ expectAssignable<
         fields: { numberField: { US: numberValue } },
       },
     },
-    multiReferenceField: {
+    unresolvableReferenceField: { US: entryLinkValue, DE: entryLinkValue },
+    resolvableMultiReferenceField: {
       DE: [
         {
           ...entryBasics,
@@ -229,6 +364,46 @@ expectAssignable<
           fields: { numberField: { US: numberValue, DE: numberValue } },
         },
       ],
+    },
+    unresolvableMultiReferenceField: {
+      DE: [entryLinkValue],
+      US: [entryLinkValue],
+    },
+  },
+})
+
+/* links in reference fields can be undefined because we can’t distinguish between missing translation and missing link */
+expectAssignable<
+  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
+    {
+      referenceField: EntryFields.Link<ExampleEntryFields>
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    referenceField: {
+      DE: undefined,
+      US: undefined,
+    },
+  },
+})
+
+/* links in multi reference fields cannot be undefined */
+expectNotAssignable<
+  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
+    {
+      multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    multiReferenceField: {
+      DE: [undefined],
+      US: [undefined],
     },
   },
 })
@@ -266,6 +441,30 @@ expectAssignable<
       },
     ],
     unresolvableMultiReferenceField: undefined,
+  },
+})
+
+/* links in reference fields cannot be resolved links */
+expectNotAssignable<
+  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
+    unresolvableReferenceField: EntryFields.Link<ExampleEntryFields>
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    unresolvableReferenceField: entryLinkValue,
+  },
+})
+
+/* links in reference fields cannot be resolved links */
+expectNotAssignable<
+  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
+    unresolvableMultiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+  }>
+>({
+  ...entryBasics,
+  fields: {
+    unresolvableMultiReferenceField: [entryLinkValue],
   },
 })
 
@@ -307,5 +506,35 @@ expectAssignable<
         },
       ],
     },
+  },
+})
+
+/* links in reference fields cannot be resolved links */
+expectNotAssignable<
+  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+    {
+      referenceField: EntryFields.Link<ExampleEntryFields>
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    referenceField: { DE: entryLinkValue, US: entryLinkValue },
+  },
+})
+
+/* links in reference fields cannot be resolved links */
+expectNotAssignable<
+  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+    {
+      multiReferenceField: EntryFields.Link<ExampleEntryFields>[]
+    },
+    'US' | 'DE'
+  >
+>({
+  ...entryBasics,
+  fields: {
+    multiReferenceField: { DE: [entryLinkValue], US: [entryLinkValue] },
   },
 })

--- a/test/types/resolved-field.test-d.ts
+++ b/test/types/resolved-field.test-d.ts
@@ -1,0 +1,64 @@
+// As tsd does not pick up the global.d.ts located in /lib we
+// explicitly reference it here once.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../lib/global.d.ts" />
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { Entry, EntryLink, EntrySys, ResolvedField } from '../../lib'
+
+export const stringValue = ''
+export const numberValue = 123
+export const booleanValue = true
+export const dateValue = '2018-05-03T09:18:16.329Z'
+export const metadataValue = { tags: [] }
+export const entryLinkValue: EntryLink = {
+  type: 'Link',
+  linkType: 'Entry',
+  id: stringValue,
+}
+
+const entrySysValue: EntrySys = {
+  contentType: { sys: { id: stringValue, type: 'Link', linkType: 'ContentType' } },
+  environment: { sys: { id: stringValue, type: 'Link', linkType: 'Environment' } },
+  revision: numberValue,
+  space: { sys: { id: stringValue, type: 'Link', linkType: 'Space' } },
+  type: '', //?
+  updatedAt: dateValue,
+  id: stringValue,
+  createdAt: dateValue,
+}
+
+const entryBasics = {
+  sys: entrySysValue,
+  metadata: metadataValue,
+}
+
+const entryValue = {
+  ...entryBasics,
+  fields: {
+    title: 'title',
+  },
+}
+
+type SimpleEntryFields = { title: string }
+
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>, undefined>>(entryValue)
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>, undefined>>(entryLinkValue)
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], undefined>>([entryValue])
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], undefined>>([entryLinkValue])
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], undefined>>([entryValue, entryLinkValue])
+
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>, 'WITHOUT_UNRESOLVABLE_LINKS'>>(entryValue)
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>, 'WITHOUT_UNRESOLVABLE_LINKS'>>(undefined)
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], 'WITHOUT_UNRESOLVABLE_LINKS'>>([
+  entryValue,
+])
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], 'WITHOUT_UNRESOLVABLE_LINKS'>>([
+  undefined,
+])
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>[], 'WITHOUT_UNRESOLVABLE_LINKS'>>([
+  entryValue,
+  undefined,
+])
+
+expectNotAssignable<ResolvedField<Entry<SimpleEntryFields>, 'WITHOUT_LINK_RESOLUTION'>>(entryValue)
+expectAssignable<ResolvedField<Entry<SimpleEntryFields>, 'WITHOUT_LINK_RESOLUTION'>>(entryLinkValue)


### PR DESCRIPTION
## Summary

Fix two issues with `Entry…` types and introduce a new configurable entry type to avoid similar issues in the future because we don’t have to write new definitions for every combination of modifiers.

## Description

### What’s in here
* Fix: `EntryWithoutLinkResolution` no longer allows resolved entries for reference fields.
* Fix: `EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks` now allows unresolvable links.
* Introduce `NewEntry` type that takes `ChainModifiers` to get the specific type.
* Introduce `GenericEntry` alias for `Entry` type and deprecate `Entry` type
* Introduce `GenericEntryCollection` alias for `EntryCollection` type and deprecate `EntryCollection` type.

### What’s not in here
The following changes will be done in a separate PR to reduce conflicts.
* Renaming the generic `Entry` type `GenericEntry`.
* Renaming the `NewEntry` type `Entry` and use it everywhere.
* Removing `ConfiguredEntry` in favor of `NewEntry`.
* Align entry collection naming with entry naming.
