### PR TITLE
chore: replace old entry types

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -18,38 +18,25 @@ import {
   ContentType,
   ContentTypeCollection,
   EntriesQueries,
-  EntryCollection,
-  EntryWithoutLinkResolution,
-  EntryCollectionWithoutLinkResolution,
   LocaleCollection,
   LocaleCode,
-  EntryWithAllLocalesAndWithoutLinkResolution,
-  EntryCollectionWithAllLocalesAndWithoutLinkResolution,
-  EntryWithLinkResolutionAndWithUnresolvableLinks,
-  EntryCollectionWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
   Space,
   SyncCollection,
   Tag,
   TagCollection,
-  Entry,
   ConfiguredAssetCollection,
   ConfiguredAsset,
   GenericAssetCollection,
   GenericAsset,
-  ConfiguredEntryCollection,
+  NewEntry,
+  EntryCollection,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
 import validateTimestamp from './utils/validate-timestamp'
-import { ChainOptions } from './utils/client-helpers'
+import { ChainOption, ChainOptions } from './utils/client-helpers'
 import { validateLocaleParam, validateResolveLinksParam } from './utils/validate-params'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
@@ -63,11 +50,11 @@ export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+    ): Promise<NewEntry<Fields, undefined>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>
+    ): Promise<EntryCollection<NewEntry<Fields, undefined>>>
 
     // TODO: think about using collection generic as response type:
     // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
@@ -79,11 +66,11 @@ export type ClientWithoutLinkResolution = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<EntryWithoutLinkResolution<Fields>>
+    ): Promise<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollectionWithoutLinkResolution<Fields>>
+    ): Promise<EntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
@@ -93,13 +80,11 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = 
     getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>>
+    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<
-      EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, Locales>
-    >
+    ): Promise<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>>
   }
 
 export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
@@ -107,11 +92,13 @@ export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
     getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, Locales>>
+    ): Promise<
+      EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
+    >
   }
 
 export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
@@ -120,11 +107,11 @@ export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+    ): Promise<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>
+    ): Promise<EntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
@@ -132,12 +119,12 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
     getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>>
+    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
     ): Promise<
-      EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, Locales>
+      EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
     >
   }
 
@@ -251,7 +238,7 @@ interface BaseClient {
    * ```
    */
   // TODO: type properly
-  parseEntries<T>(raw: any): EntryCollection<any>
+  parseEntries<T>(raw: any): any
 
   /**
    * Synchronizes either all the content or only new content since last sync
@@ -596,7 +583,11 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   >(
     query: Record<string, any>,
     options: Options
-  ): Promise<ConfiguredEntryCollection<Fields, Locales, Options>> {
+  ): Promise<
+    EntryCollection<
+      Options extends ChainOption<infer Modifiers> ? NewEntry<Fields, Modifiers, Locales> : never
+    >
+  > {
     const { withoutLinkResolution, withoutUnresolvableLinks } = options
 
     try {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -13,8 +13,6 @@ import {
   AssetFields,
   AssetKey,
   AssetQueries,
-  AssetCollectionWithAllLocales,
-  AssetWithAllLocales,
   ContentType,
   ContentTypeCollection,
   EntriesQueries,
@@ -24,10 +22,6 @@ import {
   SyncCollection,
   Tag,
   TagCollection,
-  ConfiguredAssetCollection,
-  ConfiguredAsset,
-  GenericAssetCollection,
-  GenericAsset,
   Entry,
   EntryCollection,
 } from './types'
@@ -330,7 +324,7 @@ interface BaseClientWithAssets extends BaseClient {
    * console.log(asset)
    * ```
    */
-  getAsset(id: string, query?: { locale?: string }): Promise<Asset>
+  getAsset(id: string, query?: { locale?: string }): Promise<Asset<undefined>>
 
   /**
    * Gets a collection of Assets
@@ -348,7 +342,7 @@ interface BaseClientWithAssets extends BaseClient {
    * console.log(response.items)
    * ```
    */
-  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection>
+  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection<undefined>>
 }
 
 interface BaseClientWithAssetsWithAllLocales extends BaseClient {
@@ -371,7 +365,7 @@ interface BaseClientWithAssetsWithAllLocales extends BaseClient {
   getAsset<Locale extends LocaleCode>(
     id: string,
     query?: { locale?: string }
-  ): Promise<AssetWithAllLocales<Locale>>
+  ): Promise<Asset<'WITH_ALL_LOCALES', Locale>>
 
   /**
    * Gets a collection of Assets
@@ -389,9 +383,9 @@ interface BaseClientWithAssetsWithAllLocales extends BaseClient {
    * console.log(response.items)
    * ```
    */
-  getAssets<Locale extends LocaleCode>(
+  getAssets<Locales extends LocaleCode>(
     query?: AssetQueries<AssetFields>
-  ): Promise<AssetCollectionWithAllLocales<Locale>>
+  ): Promise<AssetCollection<'WITH_ALL_LOCALES', Locales>>
 }
 
 export interface CreateContentfulApiParams {
@@ -601,11 +595,11 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     }
   }
 
-  async function getAsset(id: string, query: Record<string, any> = {}): Promise<GenericAsset<any>> {
+  async function getAsset(id: string, query: Record<string, any> = {}): Promise<Asset> {
     return makeGetAsset(id, query, options)
   }
 
-  async function getAssets(query: Record<string, any> = {}): Promise<GenericAssetCollection<any>> {
+  async function getAssets(query: Record<string, any> = {}): Promise<AssetCollection> {
     return makeGetAssets(query, options)
   }
 
@@ -629,7 +623,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   async function internalGetAsset<Locales extends LocaleCode, Options extends ChainOptions>(
     id: string,
     query: Record<string, any>
-  ): Promise<ConfiguredAsset<Locales, Options>> {
+  ): Promise<Options extends ChainOption<infer Modifiers> ? Asset<Modifiers, Locales> : never> {
     try {
       return get({
         context: 'environment',
@@ -661,7 +655,9 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
 
   async function internalGetAssets<Locales extends LocaleCode, Options extends ChainOptions>(
     query: Record<string, any>
-  ): Promise<ConfiguredAssetCollection<Locales, Options>> {
+  ): Promise<
+    Options extends ChainOption<infer Modifiers> ? AssetCollection<Modifiers, Locales> : never
+  > {
     try {
       return get({
         context: 'environment',

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -54,7 +54,7 @@ export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Entry<Fields, undefined>>>
+    ): Promise<EntryCollection<Fields, undefined>>
 
     // TODO: think about using collection generic as response type:
     // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
@@ -70,7 +70,7 @@ export type ClientWithoutLinkResolution = BaseClient &
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>
+    ): Promise<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
@@ -84,7 +84,7 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = 
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES', Locales>>>
+    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>
   }
 
 export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
@@ -96,9 +96,7 @@ export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<
-      EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
-    >
+    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
   }
 
 export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
@@ -108,10 +106,9 @@ export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
       id: string,
       query?: EntryQueries
     ): Promise<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
-
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>
+    ): Promise<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
@@ -123,9 +120,7 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<
-      EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
-    >
+    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
   }
 
 export type DefaultClient = ClientWithLinkResolutionAndWithUnresolvableLinks
@@ -584,9 +579,9 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     query: Record<string, any>,
     options: Options
   ): Promise<
-    EntryCollection<
-      Options extends ChainOption<infer Modifiers> ? Entry<Fields, Modifiers, Locales> : never
-    >
+    Options extends ChainOption<infer Modifiers>
+      ? EntryCollection<Fields, Modifiers, Locales>
+      : never
   > {
     const { withoutLinkResolution, withoutUnresolvableLinks } = options
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -28,7 +28,7 @@ import {
   ConfiguredAsset,
   GenericAssetCollection,
   GenericAsset,
-  NewEntry,
+  Entry,
   EntryCollection,
 } from './types'
 import { EntryQueries } from './types/query/query'
@@ -50,11 +50,11 @@ export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<NewEntry<Fields, undefined>>
+    ): Promise<Entry<Fields, undefined>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<NewEntry<Fields, undefined>>>
+    ): Promise<EntryCollection<Entry<Fields, undefined>>>
 
     // TODO: think about using collection generic as response type:
     // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
@@ -66,11 +66,11 @@ export type ClientWithoutLinkResolution = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
+    ): Promise<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>
+    ): Promise<EntryCollection<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
@@ -80,11 +80,11 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = 
     getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>
+    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>>
+    ): Promise<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES', Locales>>>
   }
 
 export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
@@ -92,12 +92,12 @@ export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
     getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
+    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
     ): Promise<
-      EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
+      EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
     >
   }
 
@@ -107,11 +107,11 @@ export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
     getEntry<Fields extends FieldsType>(
       id: string,
       query?: EntryQueries
-    ): Promise<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
+    ): Promise<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
 
     getEntries<Fields extends FieldsType>(
       query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>
+    ): Promise<EntryCollection<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>
   }
 
 export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
@@ -119,12 +119,12 @@ export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
     getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
       id: string,
       query?: EntryQueries & { locale?: never }
-    ): Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
+    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
 
     getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
       query?: EntriesQueries<Fields> & { locale?: never }
     ): Promise<
-      EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
+      EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
     >
   }
 
@@ -585,7 +585,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     options: Options
   ): Promise<
     EntryCollection<
-      Options extends ChainOption<infer Modifiers> ? NewEntry<Fields, Modifiers, Locales> : never
+      Options extends ChainOption<infer Modifiers> ? Entry<Fields, Modifiers, Locales> : never
     >
   > {
     const { withoutLinkResolution, withoutUnresolvableLinks } = options

--- a/lib/make-client.ts
+++ b/lib/make-client.ts
@@ -44,7 +44,7 @@ type ConfiguredClient<Options extends ChainOptions> =
     ? ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
     : Options extends ChainOption<'WITHOUT_LINK_RESOLUTION'>
     ? ClientWithoutLinkResolution
-    : Options extends ChainOption
+    : Options extends DefaultChainOption
     ? ClientWithLinkResolutionAndWithUnresolvableLinks
     : Options extends ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>
     ? ClientWithLinkResolutionAndWithoutUnresolvableLinks

--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -1,4 +1,4 @@
-import { ChainOptions } from '../utils/client-helpers'
+import { ChainModifiers } from '../utils/client-helpers'
 import { ContentfulCollection } from './collection'
 import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
@@ -28,21 +28,24 @@ export interface AssetFields {
 /**
  * @category Entities
  */
-export interface Asset {
+export interface Asset<
+  Modifiers extends ChainModifiers = ChainModifiers,
+  Locales extends LocaleCode = LocaleCode
+> {
   sys: AssetSys
-  fields: AssetFields
+  fields: ChainModifiers extends Modifiers
+    ?
+        | {
+            [LocaleName in Locales]?: AssetFields
+          }
+        | AssetFields
+    : 'WITH_ALL_LOCALES' extends Modifiers
+    ? {
+        [LocaleName in Locales]?: AssetFields
+      }
+    : AssetFields
   metadata: Metadata
 }
-
-export interface AssetWithAllLocales<Locales extends LocaleCode> {
-  sys: AssetSys
-  fields: {
-    [LocaleName in Locales]?: AssetFields
-  }
-  metadata: Metadata
-}
-
-export type GenericAsset<Locale extends LocaleCode> = Asset | AssetWithAllLocales<Locale>
 
 export type AssetMimeType =
   | 'attachment'
@@ -58,25 +61,10 @@ export type AssetMimeType =
   | 'code'
   | 'markup'
 
-export type AssetCollection = ContentfulCollection<Asset>
-export type AssetCollectionWithAllLocales<Locales extends LocaleCode> = ContentfulCollection<
-  AssetWithAllLocales<Locales>
->
-export type GenericAssetCollection<Locales extends LocaleCode> =
-  | AssetCollection
-  | AssetCollectionWithAllLocales<Locales>
+export type AssetCollection<
+  Modifiers extends ChainModifiers = ChainModifiers,
+  Locales extends LocaleCode = LocaleCode
+> = ContentfulCollection<Asset<Modifiers, Locales>>
 export type AssetSys = EntitySys & {
   type: 'Asset'
 }
-
-export type ConfiguredAsset<
-  Locales extends LocaleCode,
-  Options extends ChainOptions
-> = Options extends { withAllLocales: true } ? AssetWithAllLocales<Locales> : Asset
-
-export type ConfiguredAssetCollection<
-  Locales extends LocaleCode,
-  Options extends ChainOptions
-> = Options extends { withAllLocales: true }
-  ? AssetCollectionWithAllLocales<Locales>
-  : AssetCollection

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -28,7 +28,7 @@ export declare namespace EntryFields {
     lon: number
   }
 
-  type EntryLink<Fields extends FieldsType> = NewEntry<Fields>
+  type EntryLink<Fields extends FieldsType> = Entry<Fields>
   type AssetLink = Asset
   type Link<Fields extends FieldsType> = AssetLink | EntryLink<Fields>
   type Array<Item extends EntryFields.Symbol | AssetLink | EntryLink<FieldsType>> = Item[]
@@ -66,12 +66,12 @@ type ResolvedLink<
   Locales extends LocaleCode = LocaleCode
 > = Field extends EntryFields.EntryLink<infer LinkedFields>
   ? ChainModifiers extends Modifiers
-    ? NewEntry<LinkedFields, Modifiers, Locales> | EntryLink | undefined
+    ? Entry<LinkedFields, Modifiers, Locales> | EntryLink | undefined
     : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? EntryLink
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
-    ? NewEntry<LinkedFields, Modifiers, Locales> | undefined
-    : NewEntry<LinkedFields, Modifiers, Locales> | EntryLink
+    ? Entry<LinkedFields, Modifiers, Locales> | undefined
+    : Entry<LinkedFields, Modifiers, Locales> | EntryLink
   : Field extends EntryFields.AssetLink
   ? ChainModifiers extends Modifiers
     ? Asset | AssetLink | undefined
@@ -90,7 +90,7 @@ export type ResolvedField<
   ? Array<ResolvedLink<Item, Modifiers, Locales>>
   : ResolvedLink<Field, Modifiers, Locales>
 
-export type NewEntry<
+export type Entry<
   Fields extends FieldsType = FieldsType,
   Modifiers extends ChainModifiers = ChainModifiers,
   Locales extends LocaleCode = LocaleCode
@@ -116,7 +116,7 @@ export type NewEntry<
       }
 }
 
-export type EntryCollection<TEntry extends NewEntry> = ContentfulCollection<TEntry> & {
+export type EntryCollection<TEntry extends Entry> = ContentfulCollection<TEntry> & {
   errors?: Array<any>
   includes?: {
     Entry?: any[]

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -6,7 +6,7 @@ import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { FieldsType } from './query/util'
 import { EntitySys } from './sys'
-import { ChainModifiers, ChainOption, ChainOptions } from '../utils/client-helpers'
+import { ChainModifiers } from '../utils/client-helpers'
 
 export interface EntrySys extends EntitySys {
   contentType: { sys: ContentTypeLink }
@@ -28,7 +28,7 @@ export declare namespace EntryFields {
     lon: number
   }
 
-  type EntryLink<Fields extends FieldsType> = GenericEntry<Fields>
+  type EntryLink<Fields extends FieldsType> = NewEntry<Fields>
   type AssetLink = Asset
   type Link<Fields extends FieldsType> = AssetLink | EntryLink<Fields>
   type Array<Item extends EntryFields.Symbol | AssetLink | EntryLink<FieldsType>> = Item[]
@@ -55,54 +55,27 @@ export type EntryField<Fields extends FieldsType> =
   | EntryFields.Array<EntryFields.AssetLink>
   | EntryFields.Array<EntryFields.EntryLink<Fields>>
 
-type BaseEntry = {
+export type BaseEntry = {
   sys: EntrySys
   metadata: Metadata
 }
 
-type LocalizedFields<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode> = {
-  [key in keyof Fields]: { [locale in Locales]?: Fields[key] }
-}
-
-/**
- * @category Entities
- */
-export type LocalizedGenericEntry<Fields extends FieldsType> = BaseEntry & {
-  fields: LocalizedFields<Fields>
-}
-
-/**
- * @category Entities
- */
-export type UnlocalizedGenericEntry<Fields extends FieldsType> = BaseEntry & {
-  fields: Fields
-}
-
-/**
- * @category Entities
- */
-export type GenericEntry<Fields extends FieldsType> =
-  | LocalizedGenericEntry<Fields>
-  | UnlocalizedGenericEntry<Fields>
-
-/**
- * @category Entities
- * @deprecated
- */
-export type Entry<Fields extends FieldsType> = GenericEntry<Fields>
-
 type ResolvedLink<
   Field extends EntryField<FieldsType>,
-  Modifiers extends ChainModifiers,
-  Locales extends LocaleCode
+  Modifiers extends ChainModifiers = ChainModifiers,
+  Locales extends LocaleCode = LocaleCode
 > = Field extends EntryFields.EntryLink<infer LinkedFields>
-  ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
+  ? ChainModifiers extends Modifiers
+    ? NewEntry<LinkedFields, Modifiers, Locales> | EntryLink | undefined
+    : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? EntryLink
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
     ? NewEntry<LinkedFields, Modifiers, Locales> | undefined
     : NewEntry<LinkedFields, Modifiers, Locales> | EntryLink
   : Field extends EntryFields.AssetLink
-  ? 'WITHOUT_LINK_RESOLUTION' extends Modifiers
+  ? ChainModifiers extends Modifiers
+    ? Asset | AssetLink | undefined
+    : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? AssetLink
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
     ? Asset | undefined
@@ -117,13 +90,22 @@ export type ResolvedField<
   ? Array<ResolvedLink<Item, Modifiers, Locales>>
   : ResolvedLink<Field, Modifiers, Locales>
 
-// TODO: rename after renaming generic Entry type
 export type NewEntry<
-  Fields extends FieldsType,
-  Modifiers extends ChainModifiers,
+  Fields extends FieldsType = FieldsType,
+  Modifiers extends ChainModifiers = ChainModifiers,
   Locales extends LocaleCode = LocaleCode
 > = BaseEntry & {
-  fields: 'WITH_ALL_LOCALES' extends Modifiers
+  fields: ChainModifiers extends Modifiers
+    ?
+        | {
+            [FieldName in keyof Fields]: {
+              [LocaleName in Locales]?: ResolvedField<Fields[FieldName], Modifiers, Locales>
+            }
+          }
+        | {
+            [FieldName in keyof Fields]: ResolvedField<Fields[FieldName], Modifiers, Locales>
+          }
+    : 'WITH_ALL_LOCALES' extends Modifiers
     ? {
         [FieldName in keyof Fields]: {
           [LocaleName in Locales]?: ResolvedField<Fields[FieldName], Modifiers, Locales>
@@ -134,90 +116,10 @@ export type NewEntry<
       }
 }
 
-export type EntryWithoutLinkResolution<Fields extends FieldsType> = NewEntry<
-  Fields,
-  'WITHOUT_LINK_RESOLUTION'
->
-
-export type EntryWithAllLocalesAndWithoutLinkResolution<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
-
-export type EntryWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> = NewEntry<
-  Fields,
-  undefined,
-  LocaleCode
->
-
-export type EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>
-
-export type EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields extends FieldsType> =
-  NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS', LocaleCode>
-
-export type EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
-
-export interface AbstractEntryCollection<TEntry> extends ContentfulCollection<TEntry> {
+export type EntryCollection<TEntry extends NewEntry> = ContentfulCollection<TEntry> & {
   errors?: Array<any>
   includes?: {
     Entry?: any[]
     Asset?: any[]
   }
 }
-
-export type GenericEntryCollection<Fields extends FieldsType> = AbstractEntryCollection<
-  GenericEntry<Fields>
->
-
-/**
- * @deprecated
- */
-
-export type EntryCollection<Fields extends FieldsType> = GenericEntryCollection<Fields>
-
-export type EntryCollectionWithoutLinkResolution<Fields extends FieldsType> =
-  AbstractEntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
-
-export type EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields extends FieldsType> =
-  AbstractEntryCollection<NewEntry<Fields, undefined>>
-
-export type EntryCollectionWithAllLocalesAndWithoutLinkResolution<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = AbstractEntryCollection<
-  NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
->
-
-export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = AbstractEntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES', Locales>>
-
-export type EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<
-  Fields extends FieldsType
-> = AbstractEntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
-
-export type EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
-  Fields extends FieldsType,
-  Locales extends LocaleCode
-> = AbstractEntryCollection<
-  NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
->
-
-export type ConfiguredEntry<
-  Fields extends FieldsType,
-  Locales extends LocaleCode,
-  Options extends ChainOptions
-> = Options extends ChainOption<infer Modifiers> ? NewEntry<Fields, Modifiers, Locales> : never
-
-export type ConfiguredEntryCollection<
-  Fields extends FieldsType,
-  Locales extends LocaleCode,
-  Options extends ChainOptions
-> = AbstractEntryCollection<ConfiguredEntry<Fields, Locales, Options>>

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -116,7 +116,11 @@ export type Entry<
       }
 }
 
-export type EntryCollection<TEntry extends Entry> = ContentfulCollection<TEntry> & {
+export type EntryCollection<
+  Fields extends FieldsType = FieldsType,
+  Modifiers extends ChainModifiers = ChainModifiers,
+  Locales extends LocaleCode = LocaleCode
+> = ContentfulCollection<Entry<Fields, Modifiers, Locales>> & {
   errors?: Array<any>
   includes?: {
     Entry?: any[]

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -1,10 +1,10 @@
 import { Asset } from './asset'
-import { Entry } from './entry'
+import { NewEntry } from './entry'
 
 export interface SyncCollection {
-  entries: Array<Entry<any>>
+  entries: Array<NewEntry>
   assets: Array<Asset>
-  deletedEntries: Array<Entry<any>>
+  deletedEntries: Array<NewEntry>
   deletedAssets: Array<Asset>
   nextSyncToken: string
 }

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -1,10 +1,10 @@
 import { Asset } from './asset'
-import { NewEntry } from './entry'
+import { Entry } from './entry'
 
 export interface SyncCollection {
-  entries: Array<NewEntry>
+  entries: Array<Entry>
   assets: Array<Asset>
-  deletedEntries: Array<NewEntry>
+  deletedEntries: Array<Entry>
   deletedAssets: Array<Asset>
   nextSyncToken: string
 }

--- a/lib/utils/client-helpers.ts
+++ b/lib/utils/client-helpers.ts
@@ -4,7 +4,7 @@ export type ChainModifiers =
   | 'WITHOUT_UNRESOLVABLE_LINKS'
   | undefined
 
-export type ChainOption<Modifiers extends ChainModifiers = undefined> = {
+export type ChainOption<Modifiers extends ChainModifiers = ChainModifiers> = {
   withoutLinkResolution: ChainModifiers extends Modifiers
     ? boolean
     : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
@@ -22,6 +22,6 @@ export type ChainOption<Modifiers extends ChainModifiers = undefined> = {
     : false
 }
 
-export type DefaultChainOption = ChainOption
+export type DefaultChainOption = ChainOption<undefined>
 
-export type ChainOptions = ChainOption<ChainModifiers>
+export type ChainOptions = ChainOption

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -4,26 +4,14 @@
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
 
-import {
-  Asset,
-  AssetCollection,
-  AssetCollectionWithAllLocales,
-  AssetDetails,
-  AssetFields,
-  AssetFile,
-  AssetWithAllLocales,
-  GenericAsset,
-  GenericAssetCollection,
-  ConfiguredAsset,
-  ConfiguredAssetCollection,
-} from '../../lib'
-import { ChainOption, DefaultChainOption } from '../../lib/utils/client-helpers'
+import { Asset, AssetCollection, AssetDetails, AssetFields, AssetFile } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
+import { ChainModifiers } from '../../lib/utils/client-helpers'
 
 type AssetLocales = 'US' | 'DE'
 
-const assetWithAllLocales: AssetWithAllLocales<AssetLocales> = {
+const assetWithAllLocales: Asset<'WITH_ALL_LOCALES', AssetLocales> = {
   ...mocks.assetBasics,
   fields: {
     US: mocks.assetFields,
@@ -38,7 +26,7 @@ const assetCollection: AssetCollection = {
   items: [mocks.asset],
 }
 
-const assetCollectionWithAllLocales: AssetCollectionWithAllLocales<AssetLocales> = {
+const assetCollectionWithAllLocales: AssetCollection<'WITH_ALL_LOCALES', AssetLocales> = {
   total: mocks.numberValue,
   skip: mocks.numberValue,
   limit: mocks.numberValue,
@@ -49,100 +37,70 @@ expectAssignable<AssetDetails>(mocks.assetDetails)
 expectAssignable<AssetFile>(mocks.assetFile)
 expectAssignable<AssetFields>(mocks.assetFields)
 
-expectAssignable<Asset>(mocks.asset)
-expectAssignable<AssetWithAllLocales<AssetLocales>>(assetWithAllLocales)
+expectAssignable<Asset<undefined>>(mocks.asset)
+expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(assetWithAllLocales)
 
-expectAssignable<GenericAsset<AssetLocales>>(mocks.asset)
-expectAssignable<GenericAsset<AssetLocales>>(assetWithAllLocales)
+expectAssignable<Asset<ChainModifiers, AssetLocales>>(mocks.asset)
+expectAssignable<Asset<ChainModifiers, AssetLocales>>(assetWithAllLocales)
 
-expectAssignable<AssetCollection>(assetCollection)
-expectAssignable<AssetCollectionWithAllLocales<AssetLocales>>(assetCollectionWithAllLocales)
+expectAssignable<AssetCollection<undefined>>(assetCollection)
+expectAssignable<AssetCollection<'WITH_ALL_LOCALES', AssetLocales>>(assetCollectionWithAllLocales)
 
-expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollection)
-expectAssignable<GenericAssetCollection<AssetLocales>>(assetCollectionWithAllLocales)
+expectAssignable<AssetCollection<ChainModifiers, AssetLocales>>(assetCollection)
+expectAssignable<AssetCollection<ChainModifiers, AssetLocales>>(assetCollectionWithAllLocales)
 
-expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(mocks.asset)
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
-  assetWithAllLocales
-)
+expectNotAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(mocks.asset)
+expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(assetWithAllLocales)
 
-expectNotAssignable<
-  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>
->(mocks.asset)
-expectAssignable<
-  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>
->(assetWithAllLocales)
-
-expectNotAssignable<
-  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>
->(mocks.asset)
-expectAssignable<
-  ConfiguredAsset<AssetLocales, ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>
->(assetWithAllLocales)
-
-expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
-  assetCollection
-)
-expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITH_ALL_LOCALES'>>>(
-  assetCollectionWithAllLocales
-)
-
-expectNotAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
-  >
->(assetCollection)
-expectAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
-  >
->(assetCollectionWithAllLocales)
-
-expectNotAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
-  >
->(assetCollection)
-expectAssignable<
-  ConfiguredAssetCollection<
-    AssetLocales,
-    ChainOption<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
-  >
->(assetCollectionWithAllLocales)
-
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(mocks.asset)
-expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(
-  assetWithAllLocales
-)
-
-expectAssignable<ConfiguredAsset<AssetLocales, DefaultChainOption>>(mocks.asset)
-expectNotAssignable<ConfiguredAsset<AssetLocales, DefaultChainOption>>(assetWithAllLocales)
-
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectNotAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
   mocks.asset
 )
-expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
   assetWithAllLocales
 )
 
-expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>>(
+expectNotAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
+  mocks.asset
+)
+expectAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
+  assetWithAllLocales
+)
+
+expectNotAssignable<AssetCollection<'WITH_ALL_LOCALES', AssetLocales>>(assetCollection)
+expectAssignable<AssetCollection<'WITH_ALL_LOCALES', AssetLocales>>(assetCollectionWithAllLocales)
+
+expectNotAssignable<AssetCollection<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
   assetCollection
 )
-expectNotAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>
->(assetCollectionWithAllLocales)
-
-expectAssignable<ConfiguredAssetCollection<AssetLocales, DefaultChainOption>>(assetCollection)
-expectNotAssignable<ConfiguredAssetCollection<AssetLocales, DefaultChainOption>>(
+expectAssignable<AssetCollection<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
   assetCollectionWithAllLocales
 )
 
-expectAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>
->(assetCollection)
 expectNotAssignable<
-  ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>
->(assetCollectionWithAllLocales)
+  AssetCollection<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>
+>(assetCollection)
+expectAssignable<AssetCollection<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
+  assetCollectionWithAllLocales
+)
+
+expectAssignable<Asset<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(mocks.asset)
+expectNotAssignable<Asset<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(assetWithAllLocales)
+
+expectAssignable<Asset<undefined, AssetLocales>>(mocks.asset)
+expectNotAssignable<Asset<undefined, AssetLocales>>(assetWithAllLocales)
+
+expectAssignable<Asset<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(mocks.asset)
+expectNotAssignable<Asset<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(assetWithAllLocales)
+
+expectAssignable<AssetCollection<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(assetCollection)
+expectNotAssignable<AssetCollection<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
+  assetCollectionWithAllLocales
+)
+
+expectAssignable<AssetCollection<undefined, AssetLocales>>(assetCollection)
+expectNotAssignable<AssetCollection<undefined, AssetLocales>>(assetCollectionWithAllLocales)
+
+expectAssignable<AssetCollection<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(assetCollection)
+expectNotAssignable<AssetCollection<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
+  assetCollectionWithAllLocales
+)

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -17,7 +17,7 @@ import {
   ConfiguredAsset,
   ConfiguredAssetCollection,
 } from '../../lib'
-import { ChainOption } from '../../lib/utils/client-helpers'
+import { ChainOption, DefaultChainOption } from '../../lib/utils/client-helpers'
 // @ts-ignore
 import * as mocks from './mocks'
 
@@ -118,8 +118,8 @@ expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_LINK_RESO
   assetWithAllLocales
 )
 
-expectAssignable<ConfiguredAsset<AssetLocales, ChainOption>>(mocks.asset)
-expectNotAssignable<ConfiguredAsset<AssetLocales, ChainOption>>(assetWithAllLocales)
+expectAssignable<ConfiguredAsset<AssetLocales, DefaultChainOption>>(mocks.asset)
+expectNotAssignable<ConfiguredAsset<AssetLocales, DefaultChainOption>>(assetWithAllLocales)
 
 expectAssignable<ConfiguredAsset<AssetLocales, ChainOption<'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   mocks.asset
@@ -135,8 +135,8 @@ expectNotAssignable<
   ConfiguredAssetCollection<AssetLocales, ChainOption<'WITHOUT_LINK_RESOLUTION'>>
 >(assetCollectionWithAllLocales)
 
-expectAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption>>(assetCollection)
-expectNotAssignable<ConfiguredAssetCollection<AssetLocales, ChainOption>>(
+expectAssignable<ConfiguredAssetCollection<AssetLocales, DefaultChainOption>>(assetCollection)
+expectNotAssignable<ConfiguredAssetCollection<AssetLocales, DefaultChainOption>>(
   assetCollectionWithAllLocales
 )
 

--- a/test/types/chain-options.test-d.ts
+++ b/test/types/chain-options.test-d.ts
@@ -9,7 +9,7 @@ expectAssignable<ChainOptions>({
   withoutUnresolvableLinks: true as boolean,
 })
 
-expectType<ChainOption>({
+expectType<ChainOption<undefined>>({
   withoutLinkResolution: false,
   withAllLocales: false,
   withoutUnresolvableLinks: false,

--- a/test/types/client/getAssets.test-d.ts
+++ b/test/types/client/getAssets.test-d.ts
@@ -1,26 +1,15 @@
 import { expectType } from 'tsd'
-import {
-  Asset,
-  AssetCollection,
-  createClient,
-  AssetCollectionWithAllLocales,
-  AssetWithAllLocales,
-  LocaleCode,
-} from '../../../lib'
+import { Asset, AssetCollection, createClient, LocaleCode } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
   space: 'spaceId',
 })
 
-expectType<AssetCollection>(await client.getAssets())
+expectType<AssetCollection<undefined>>(await client.getAssets())
 
-expectType<Asset>(await client.getAsset('test'))
+expectType<Asset<undefined>>(await client.getAsset('test'))
 
-expectType<AssetCollectionWithAllLocales<LocaleCode>>(
-  await client.withAllLocales.getAssets<LocaleCode>()
-)
+expectType<AssetCollection<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAssets<LocaleCode>())
 
-expectType<AssetWithAllLocales<LocaleCode>>(
-  await client.withAllLocales.getAsset<LocaleCode>('test')
-)
+expectType<Asset<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAsset<LocaleCode>('test'))

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -17,39 +17,39 @@ type Fields = {
 }
 
 expectType<Entry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
-expectType<EntryCollection<Entry<Fields, undefined>>>(await client.getEntries<Fields>())
+expectType<EntryCollection<Fields, undefined>>(await client.getEntries<Fields>())
 
 expectType<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollection<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntries<Fields>()
 )
 
 expectType<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollection<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>(
+expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntries<Fields>()
 )
 
 expectType<Entry<Fields, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES'>>>(
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntries<Fields, LocaleCode>()
 )
 
 expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, LocaleCode>()
 )
 
 expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
   client.withAllLocales.withoutLinkResolution.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withAllLocales.withoutLinkResolution.getEntries<Fields, LocaleCode>()
 )

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,21 +1,5 @@
 import { expectType } from 'tsd'
-import {
-  createClient,
-  Entry,
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  EntryCollectionWithAllLocalesAndWithoutLinkResolution,
-  EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryCollectionWithLinkResolutionAndWithUnresolvableLinks,
-  EntryCollectionWithoutLinkResolution,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithAllLocalesAndWithoutLinkResolution,
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithoutLinkResolution,
-  LocaleCode,
-} from '../../../lib'
+import { createClient, EntryCollection, LocaleCode, NewEntry } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -28,49 +12,44 @@ type LinkedFields = {
 
 type Fields = {
   title: string
-  link: Entry<LinkedFields>
-  moreLinks: Entry<LinkedFields>[]
+  link: NewEntry<LinkedFields>
+  moreLinks: NewEntry<LinkedFields>[]
 }
 
-expectType<EntryWithLinkResolutionAndWithUnresolvableLinks<Fields>>(
-  await client.getEntry<Fields>('entry-id')
-)
-expectType<EntryCollectionWithLinkResolutionAndWithUnresolvableLinks<Fields>>(
-  await client.getEntries<Fields>()
-)
+expectType<NewEntry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
+expectType<EntryCollection<NewEntry<Fields, undefined>>>(await client.getEntries<Fields>())
 
-// @ts-ignore
-expectType<EntryWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>(
+expectType<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollectionWithLinkResolutionAndWithoutUnresolvableLinks<Fields>>(
+expectType<EntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   await client.withoutUnresolvableLinks.getEntries<Fields>()
 )
 
-expectType<EntryWithoutLinkResolution<Fields>>(
+expectType<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollectionWithoutLinkResolution<Fields>>(
+expectType<EntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>(
   await client.withoutLinkResolution.getEntries<Fields>()
 )
 
-expectType<EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, LocaleCode>>(
+expectType<NewEntry<Fields, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<Fields, LocaleCode>
->(await client.withAllLocales.getEntries<Fields, LocaleCode>())
+expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES'>>>(
+  await client.withAllLocales.getEntries<Fields, LocaleCode>()
+)
 
-expectType<
-  Promise<EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, LocaleCode>>
->(client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, LocaleCode>('entry-id'))
-expectType<
-  EntryCollectionWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<Fields, LocaleCode>
->(await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, LocaleCode>())
+expectType<Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+  client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, LocaleCode>('entry-id')
+)
+expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, LocaleCode>()
+)
 
-expectType<Promise<EntryWithAllLocalesAndWithoutLinkResolution<Fields, LocaleCode>>>(
+expectType<Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
   client.withAllLocales.withoutLinkResolution.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollectionWithAllLocalesAndWithoutLinkResolution<Fields, LocaleCode>>(
+expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
   await client.withAllLocales.withoutLinkResolution.getEntries<Fields, LocaleCode>()
 )

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd'
-import { createClient, EntryCollection, LocaleCode, NewEntry } from '../../../lib'
+import { createClient, EntryCollection, LocaleCode, Entry } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -12,44 +12,44 @@ type LinkedFields = {
 
 type Fields = {
   title: string
-  link: NewEntry<LinkedFields>
-  moreLinks: NewEntry<LinkedFields>[]
+  link: Entry<LinkedFields>
+  moreLinks: Entry<LinkedFields>[]
 }
 
-expectType<NewEntry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
-expectType<EntryCollection<NewEntry<Fields, undefined>>>(await client.getEntries<Fields>())
+expectType<Entry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
+expectType<EntryCollection<Entry<Fields, undefined>>>(await client.getEntries<Fields>())
 
-expectType<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollection<NewEntry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectType<EntryCollection<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   await client.withoutUnresolvableLinks.getEntries<Fields>()
 )
 
-expectType<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry<Fields>('entry-id')
 )
-expectType<EntryCollection<NewEntry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>(
+expectType<EntryCollection<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>>(
   await client.withoutLinkResolution.getEntries<Fields>()
 )
 
-expectType<NewEntry<Fields, 'WITH_ALL_LOCALES'>>(
+expectType<Entry<Fields, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES'>>>(
+expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES'>>>(
   await client.withAllLocales.getEntries<Fields, LocaleCode>()
 )
 
-expectType<Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
+expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, LocaleCode>()
 )
 
-expectType<Promise<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
+expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
   client.withAllLocales.withoutLinkResolution.getEntry<Fields, LocaleCode>('entry-id')
 )
-expectType<EntryCollection<NewEntry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
+expectType<EntryCollection<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
   await client.withAllLocales.withoutLinkResolution.getEntries<Fields, LocaleCode>()
 )

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, NewEntry } from '../../lib'
+import { EntryFields, Entry } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
 
@@ -11,7 +11,7 @@ import * as mocks from './mocks'
  * @namespace: Typescript - type test
  * @description: A simple Entry with generic fields
  */
-expectAssignable<NewEntry<Record<string, any>>>({
+expectAssignable<Entry<Record<string, any>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -23,7 +23,7 @@ expectAssignable<NewEntry<Record<string, any>>>({
  * @namespace: Typescript - type test
  * @description: A simple Entry generic
  */
-expectAssignable<NewEntry<{ stringField: EntryFields.Text }>>({
+expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -35,7 +35,7 @@ expectAssignable<NewEntry<{ stringField: EntryFields.Text }>>({
  * @description: A simple Entry generic with a referenced fields wildcard
  */
 expectAssignable<
-  NewEntry<{
+  Entry<{
     stringField: EntryFields.Text
     referenceField: EntryFields.Link<Record<string, any>>
   }>
@@ -55,7 +55,7 @@ expectAssignable<
  * @description: EntryWithoutLinkResolution linked entities are all rendered as links
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -76,45 +76,42 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
     'WITHOUT_LINK_RESOLUTION'
   >
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields> }, 'WITHOUT_LINK_RESOLUTION'>
+  Entry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields> }, 'WITHOUT_LINK_RESOLUTION'>
 >(mocks.getEntry({ referenceField: mocks.entry }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITHOUT_LINK_RESOLUTION'
   >
 >(mocks.getEntry({ referenceField: [undefined] }))
 
 expectNotAssignable<
-  NewEntry<
-    { referenceField: EntryFields.Link<mocks.SimpleEntryFields>[] },
-    'WITHOUT_LINK_RESOLUTION'
-  >
+  Entry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields>[] }, 'WITHOUT_LINK_RESOLUTION'>
 >(mocks.getEntry({ referenceField: [mocks.entry] }))
 
-expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
   mocks.getEntry({ referenceField: undefined })
 )
 
-expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
   mocks.getEntry({ referenceField: mocks.asset })
 )
 
-expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>
->(mocks.getEntry({ referenceField: [undefined] }))
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>(
+  mocks.getEntry({ referenceField: [undefined] })
+)
 
-expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>
->(mocks.getEntry({ referenceField: [mocks.asset] }))
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>(
+  mocks.getEntry({ referenceField: [mocks.asset] })
+)
 
 /**
  * @namespace: Typescript - type test
@@ -122,7 +119,7 @@ expectNotAssignable<
  * unresolved entities are referenced as links. Fields with multiple references can have resolved and unresolved mixed.
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -155,18 +152,18 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> }, undefined>
+  Entry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> }, undefined>
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] }, undefined>
+  Entry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] }, undefined>
 >(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, undefined>>(
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, undefined>>(
   mocks.getEntry({ referenceField: undefined })
 )
 
-expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink[] }, undefined>>(
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, undefined>>(
   mocks.getEntry({ referenceField: [undefined] })
 )
 
@@ -176,7 +173,7 @@ expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink[] }, undefi
  * linked entites are all rendered as links.
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -199,7 +196,7 @@ expectAssignable<
 
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
       assetReferenceField: EntryFields.AssetLink
@@ -212,7 +209,7 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -220,7 +217,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: mocks.localizedEntry } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -228,7 +225,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -236,7 +233,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: [mocks.localizedEntry] } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.AssetLink },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -244,7 +241,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: mocks.asset } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.AssetLink[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -252,7 +249,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.AssetLink[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -265,7 +262,7 @@ expectNotAssignable<
  * linked entities are all rendered as inlined references, or if not resolvable, as links. multi reference fields can have mixed content.
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -307,7 +304,7 @@ expectAssignable<
 
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
       assetReferenceField: EntryFields.AssetLink
@@ -320,7 +317,7 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITH_ALL_LOCALES',
     'US' | 'DE'
@@ -328,7 +325,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITH_ALL_LOCALES', 'US' | 'DE'>
+  Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITH_ALL_LOCALES', 'US' | 'DE'>
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 /**
@@ -337,7 +334,7 @@ expectNotAssignable<
  * unresolvable links are completely removed.
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -370,25 +367,25 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: mocks.entryLink }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: [mocks.entryLink] }))
 
-expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_UNRESOLVABLE_LINKS'>
->(mocks.getEntry({ referenceField: mocks.assetLink }))
+expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  mocks.getEntry({ referenceField: mocks.assetLink })
+)
 
 expectNotAssignable<
-  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_UNRESOLVABLE_LINKS'>
+  Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.getEntry({ referenceField: [mocks.assetLink] }))
 
 /**
@@ -396,7 +393,7 @@ expectNotAssignable<
  * @description: EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks All unresolvable fields are removed
  */
 expectAssignable<
-  NewEntry<
+  Entry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -433,7 +430,7 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
@@ -441,7 +438,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: mocks.entryLink } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
@@ -449,7 +446,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: [mocks.entryLink] } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.AssetLink },
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
@@ -457,7 +454,7 @@ expectNotAssignable<
 >(mocks.getEntry({ referenceField: { US: mocks.assetLink } }))
 
 expectNotAssignable<
-  NewEntry<
+  Entry<
     { referenceField: EntryFields.AssetLink[] },
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -3,16 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import {
-  Entry,
-  EntryFields,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithAllLocalesAndWithoutLinkResolution,
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks,
-  EntryWithLinkResolutionAndWithUnresolvableLinks,
-  EntryWithoutLinkResolution,
-} from '../../lib'
+import { EntryFields, NewEntry } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
 
@@ -20,7 +11,7 @@ import * as mocks from './mocks'
  * @namespace: Typescript - type test
  * @description: A simple Entry with generic fields
  */
-expectAssignable<Entry<Record<string, any>>>({
+expectAssignable<NewEntry<Record<string, any>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -32,7 +23,7 @@ expectAssignable<Entry<Record<string, any>>>({
  * @namespace: Typescript - type test
  * @description: A simple Entry generic
  */
-expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
+expectAssignable<NewEntry<{ stringField: EntryFields.Text }>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -44,7 +35,7 @@ expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
  * @description: A simple Entry generic with a referenced fields wildcard
  */
 expectAssignable<
-  Entry<{
+  NewEntry<{
     stringField: EntryFields.Text
     referenceField: EntryFields.Link<Record<string, any>>
   }>
@@ -64,13 +55,16 @@ expectAssignable<
  * @description: EntryWithoutLinkResolution linked entities are all rendered as links
  */
 expectAssignable<
-  EntryWithoutLinkResolution<{
-    stringField: EntryFields.Text
-    entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-    multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    assetReferenceField: EntryFields.AssetLink
-    multiAssetReferenceField: EntryFields.AssetLink[]
-  }>
+  NewEntry<
+    {
+      stringField: EntryFields.Text
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      assetReferenceField: EntryFields.AssetLink
+      multiAssetReferenceField: EntryFields.AssetLink[]
+    },
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(
   mocks.getEntry({
     stringField: mocks.stringValue,
@@ -82,36 +76,45 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithoutLinkResolution<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> }>
+  NewEntry<
+    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  EntryWithoutLinkResolution<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields> }>
+  NewEntry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields> }, 'WITHOUT_LINK_RESOLUTION'>
 >(mocks.getEntry({ referenceField: mocks.entry }))
 
 expectNotAssignable<
-  EntryWithoutLinkResolution<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] }>
+  NewEntry<
+    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(mocks.getEntry({ referenceField: [undefined] }))
 
 expectNotAssignable<
-  EntryWithoutLinkResolution<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields>[] }>
+  NewEntry<
+    { referenceField: EntryFields.Link<mocks.SimpleEntryFields>[] },
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(mocks.getEntry({ referenceField: [mocks.entry] }))
 
-expectNotAssignable<EntryWithoutLinkResolution<{ referenceField: EntryFields.AssetLink }>>(
+expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
   mocks.getEntry({ referenceField: undefined })
 )
 
-expectNotAssignable<EntryWithoutLinkResolution<{ referenceField: EntryFields.AssetLink }>>(
+expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
   mocks.getEntry({ referenceField: mocks.asset })
 )
 
-expectNotAssignable<EntryWithoutLinkResolution<{ referenceField: EntryFields.AssetLink[] }>>(
-  mocks.getEntry({ referenceField: [undefined] })
-)
+expectNotAssignable<
+  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>
+>(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<EntryWithoutLinkResolution<{ referenceField: EntryFields.AssetLink[] }>>(
-  mocks.getEntry({ referenceField: [mocks.asset] })
-)
+expectNotAssignable<
+  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>
+>(mocks.getEntry({ referenceField: [mocks.asset] }))
 
 /**
  * @namespace: Typescript - type test
@@ -119,19 +122,22 @@ expectNotAssignable<EntryWithoutLinkResolution<{ referenceField: EntryFields.Ass
  * unresolved entities are referenced as links. Fields with multiple references can have resolved and unresolved mixed.
  */
 expectAssignable<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<{
-    stringField: EntryFields.Text
-    resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-    unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-    resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    resolvableAssetReferenceField: EntryFields.AssetLink
-    unresolvableAssetReferenceField: EntryFields.AssetLink
-    resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
-    unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
-    mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-  }>
+  NewEntry<
+    {
+      stringField: EntryFields.Text
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableAssetReferenceField: EntryFields.AssetLink
+      unresolvableAssetReferenceField: EntryFields.AssetLink
+      resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
+      unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
+      mixedMultiAssetReferenceField: EntryFields.AssetLink[]
+    },
+    undefined
+  >
 >(
   mocks.getEntry({
     stringField: mocks.stringValue,
@@ -149,28 +155,20 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<{
-    referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-  }>
+  NewEntry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> }, undefined>
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<{
-    referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-  }>
+  NewEntry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] }, undefined>
 >(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<{
-    referenceField: EntryFields.AssetLink
-  }>
->(mocks.getEntry({ referenceField: undefined }))
+expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink }, undefined>>(
+  mocks.getEntry({ referenceField: undefined })
+)
 
-expectNotAssignable<
-  EntryWithLinkResolutionAndWithUnresolvableLinks<{
-    referenceField: EntryFields.AssetLink[]
-  }>
->(mocks.getEntry({ referenceField: [undefined] }))
+expectNotAssignable<NewEntry<{ referenceField: EntryFields.AssetLink[] }, undefined>>(
+  mocks.getEntry({ referenceField: [undefined] })
+)
 
 /**
  * @namespace: Typescript - type test
@@ -178,7 +176,7 @@ expectNotAssignable<
  * linked entites are all rendered as links.
  */
 expectAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     {
       stringField: EntryFields.Text
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -186,6 +184,7 @@ expectAssignable<
       assetReferenceField: EntryFields.AssetLink
       multiAssetReferenceField: EntryFields.AssetLink[]
     },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(
@@ -200,11 +199,12 @@ expectAssignable<
 
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     {
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
       assetReferenceField: EntryFields.AssetLink
     },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(
@@ -212,43 +212,49 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: mocks.localizedEntry } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [mocks.localizedEntry] } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.AssetLink },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: mocks.asset } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.AssetLink[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithoutLinkResolution<
+  NewEntry<
     { referenceField: EntryFields.AssetLink[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [mocks.asset] } }))
@@ -259,7 +265,7 @@ expectNotAssignable<
  * linked entities are all rendered as inlined references, or if not resolvable, as links. multi reference fields can have mixed content.
  */
 expectAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
+  NewEntry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -273,6 +279,7 @@ expectAssignable<
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
     },
+    'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
 >({
@@ -300,11 +307,12 @@ expectAssignable<
 
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
+  NewEntry<
     {
       entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
       assetReferenceField: EntryFields.AssetLink
     },
+    'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
 >(
@@ -312,17 +320,15 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks<
-    { referenceField: EntryFields.AssetLink[] },
-    'US' | 'DE'
-  >
+  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITH_ALL_LOCALES', 'US' | 'DE'>
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 /**
@@ -331,19 +337,22 @@ expectNotAssignable<
  * unresolvable links are completely removed.
  */
 expectAssignable<
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
-    stringField: EntryFields.Text
-    resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-    unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-    resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-    resolvableAssetReferenceField: EntryFields.AssetLink
-    unresolvableAssetReferenceField: EntryFields.AssetLink
-    resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
-    unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
-    mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-  }>
+  NewEntry<
+    {
+      stringField: EntryFields.Text
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableAssetReferenceField: EntryFields.AssetLink
+      unresolvableAssetReferenceField: EntryFields.AssetLink
+      resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
+      unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
+      mixedMultiAssetReferenceField: EntryFields.AssetLink[]
+    },
+    'WITHOUT_UNRESOLVABLE_LINKS'
+  >
 >(
   mocks.getEntry({
     stringField: mocks.stringValue,
@@ -361,27 +370,25 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
-    referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-  }>
+  NewEntry<
+    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    'WITHOUT_UNRESOLVABLE_LINKS'
+  >
 >(mocks.getEntry({ referenceField: mocks.entryLink }))
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
-    referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-  }>
+  NewEntry<
+    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITHOUT_UNRESOLVABLE_LINKS'
+  >
 >(mocks.getEntry({ referenceField: [mocks.entryLink] }))
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
-    referenceField: EntryFields.AssetLink
-  }>
+  NewEntry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.getEntry({ referenceField: mocks.assetLink }))
 
 expectNotAssignable<
-  EntryWithLinkResolutionAndWithoutUnresolvableLinks<{
-    referenceField: EntryFields.AssetLink[]
-  }>
+  NewEntry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.getEntry({ referenceField: [mocks.assetLink] }))
 
 /**
@@ -389,7 +396,7 @@ expectNotAssignable<
  * @description: EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks All unresolvable fields are removed
  */
 expectAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+  NewEntry<
     {
       stringField: EntryFields.Text
       resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
@@ -403,6 +410,7 @@ expectAssignable<
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
     },
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
 >(
@@ -425,29 +433,33 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: mocks.entryLink } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+  NewEntry<
     { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [mocks.entryLink] } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+  NewEntry<
     { referenceField: EntryFields.AssetLink },
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: mocks.assetLink } }))
 
 expectNotAssignable<
-  EntryWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks<
+  NewEntry<
     { referenceField: EntryFields.AssetLink[] },
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [mocks.assetLink] } }))

--- a/test/types/mocks.ts
+++ b/test/types/mocks.ts
@@ -5,11 +5,10 @@ import {
   AssetFile,
   AssetLink,
   AssetSys,
+  BaseEntry,
   EntryLink,
   EntrySys,
   FieldsType,
-  GenericEntry,
-  UnlocalizedGenericEntry,
 } from '../../lib'
 
 export const stringValue = ''
@@ -63,10 +62,9 @@ export const localizedEntry = {
   },
 }
 
-export const getEntry = <T extends FieldsType>(fields: T): UnlocalizedGenericEntry<T> => ({
-  ...entryBasics,
-  fields,
-})
+export const getEntry = <Fields extends FieldsType>(
+  fields: Fields
+): BaseEntry & { fields: Fields } => ({ ...entryBasics, fields })
 
 export const assetLink: AssetLink = {
   type: 'Link',

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -5,7 +5,6 @@ import {
   Asset,
   ContentType,
   ContentTypeLink,
-  Entry,
   EnvironmentLink,
   Locale,
   EntrySys,
@@ -13,6 +12,7 @@ import {
   EntryFields,
   Tag,
   TagSys,
+  NewEntry,
 } from '../../lib'
 
 const date: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -146,7 +146,7 @@ export type EntryFields = {
   field1: string
 }
 
-const entryMock: Entry<EntryFields> = {
+const entryMock: NewEntry<EntryFields> = {
   sys: {
     ...copy(sysMock),
     locale: 'locale',

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -12,7 +12,7 @@ import {
   EntryFields,
   Tag,
   TagSys,
-  NewEntry,
+  Entry,
 } from '../../lib'
 
 const date: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -146,7 +146,7 @@ export type EntryFields = {
   field1: string
 }
 
-const entryMock: NewEntry<EntryFields> = {
+const entryMock: Entry<EntryFields> = {
   sys: {
     ...copy(sysMock),
     locale: 'locale',


### PR DESCRIPTION
## Summary

The newly introduced `NewEntry` type was already used for all cases where we know exactly what the entry shape is but we kept the old `Entry` type for some cases where a generic entry type was needed. This PR expands the `NewEntry` type to support generic cases and replace all existing entry types, namely `Entry`, `EntryWith…`, `GenericEntry`, `ConfiguredEntry`, `EntryCollection`, `EntryCollectionWith…`, `ConfiguredEntryCollection`.

## Description

* Replace existing entry types with `NewEntry`
* Replace `EntryCollectionWith…` types with a new `EntryCollection<NewEntry<…>>` type format
* Rename `NewEntry` to `Entry`
* Introduce new `Asset` type following the same structure as the new entry
* Replace existing asset types `AssetWithAllLocales`, `GenericAsset`, `ConfiguredAsset`, `AssetCollectionWithAllLocales`

## Motivation and Context

Whatever an entry is needed, we only need one `Entry` type.
* `Entry` – Describes any entry shape.
* `Entry<FieldsType>` – Describes any entry shape where we know the fields (`FieldsType`), but do not know whether links are resolved or whether it has multiple locales.
* `Entry<FieldsType, ChainModifiers>` – Describes an entry shape where we know the fields (`FieldsType`), whether links are resolved (`ChainModifiers`), and whether it has multiple locales but not which ones (`ChainModifiers`).
* `Entry<FieldsType, ChainModifiers, LocaleCode>` – Describes a specific entry shape where we know the fields (FieldsType), whether links are resolved (ChainModifiers), and how many locales it has (ChainModifiers and LocaleCode).