### PR TITLE
chore: introduce generic client type

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -30,118 +30,75 @@ import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
 import validateTimestamp from './utils/validate-timestamp'
-import { ChainOption, ChainOptions } from './utils/client-helpers'
+import {
+  AddChainModifier,
+  ChainModifiers,
+  ChainOptions,
+  ModifiersFromOptions,
+} from './utils/client-helpers'
 import { validateLocaleParam, validateResolveLinksParam } from './utils/validate-params'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
 
-export type ClientWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
-  BaseClientWithAssets & {
-    withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-    withoutLinkResolution: ClientWithoutLinkResolution
-    withoutUnresolvableLinks: ClientWithLinkResolutionAndWithoutUnresolvableLinks
+type ClientMethodsWithAllLocales<Modifiers extends ChainModifiers> = {
+  getEntry<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
+    id: string,
+    query?: Omit<EntryQueries, 'locale'>
+  ): Promise<Entry<Fields, Modifiers, Locales>>
 
-    getEntry<Fields extends FieldsType>(
-      id: string,
-      query?: EntryQueries
-    ): Promise<Entry<Fields, undefined>>
+  getEntries<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
+    query?: Omit<EntriesQueries, 'locale'>
+  ): Promise<EntryCollection<Fields, Modifiers, Locales>>
 
-    getEntries<Fields extends FieldsType>(
-      query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Fields, undefined>>
+  parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(
+    data: EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
+  ): EntryCollection<Fields, Modifiers, Locales>
 
-    // TODO: think about using collection generic as response type:
-    // ): Promise<Collection<EntryWithLinkResolution<Fields>>>
+  getAsset<Locales extends LocaleCode = LocaleCode>(
+    id: string
+  ): Promise<Asset<'WITH_ALL_LOCALES', Locales>>
 
-    parseEntries<Fields extends FieldsType = FieldsType>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>
-    ): EntryCollection<Fields, undefined>
-  }
+  getAssets<Locales extends LocaleCode = LocaleCode>(
+    query?: Omit<AssetQueries<AssetFields>, 'locale'>
+  ): Promise<AssetCollection<'WITH_ALL_LOCALES', Locales>>
+}
 
-export type ClientWithoutLinkResolution = BaseClient &
-  BaseClientWithAssets & {
-    withAllLocales: ClientWithAllLocalesAndWithoutLinkResolution
-    getEntry<Fields extends FieldsType>(
-      id: string,
-      query?: EntryQueries
-    ): Promise<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>
+type ClientMethodsWithoutAllLocales<Modifiers extends ChainModifiers> = {
+  withAllLocales: Client<AddChainModifier<Modifiers, 'WITH_ALL_LOCALES'>>
+  getEntry<Fields extends FieldsType>(
+    id: string,
+    query?: EntryQueries
+  ): Promise<Entry<Fields, Modifiers>>
 
-    getEntries<Fields extends FieldsType>(
-      query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>
+  getEntries<Fields extends FieldsType>(
+    query?: EntriesQueries<Fields>
+  ): Promise<EntryCollection<Fields, Modifiers>>
 
-    parseEntries<Fields extends FieldsType = FieldsType>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>
-    ): EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>
-  }
+  parseEntries<Fields extends FieldsType = FieldsType>(
+    data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>
+  ): EntryCollection<Fields, Modifiers>
 
-export type ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks = BaseClient &
-  BaseClientWithAssetsWithAllLocales & {
-    withoutLinkResolution: ClientWithAllLocalesAndWithoutLinkResolution
-    withoutUnresolvableLinks: ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks
-    getEntry<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(
-      id: string,
-      query?: EntryQueries & { locale?: never }
-    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES', Locales>>
+  getAsset(id: string, query?: { locale?: string }): Promise<Asset<undefined>>
 
-    getEntries<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
-      query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>
+  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection<undefined>>
+}
 
-    parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES', Locales>
-    ): EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>
-  }
+export type Client<Modifiers extends ChainModifiers> = BaseClient &
+  ('WITHOUT_LINK_RESOLUTION' extends Modifiers
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : {
+        withoutLinkResolution: Client<AddChainModifier<Modifiers, 'WITHOUT_LINK_RESOLUTION'>>
+        withoutUnresolvableLinks: Client<AddChainModifier<Modifiers, 'WITHOUT_UNRESOLVABLE_LINKS'>>
+      }) &
+  ('WITH_ALL_LOCALES' extends Modifiers
+    ? ClientMethodsWithAllLocales<Modifiers>
+    : ClientMethodsWithoutAllLocales<Modifiers>)
 
-export type ClientWithAllLocalesAndWithoutLinkResolution = BaseClient &
-  BaseClientWithAssetsWithAllLocales & {
-    getEntry<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
-      id: string,
-      query?: EntryQueries & { locale?: never }
-    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
-
-    getEntries<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
-      query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>
-
-    parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES', Locales>
-    ): EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
-  }
-
-export type ClientWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
-  BaseClientWithAssets & {
-    withAllLocales: ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks
-    getEntry<Fields extends FieldsType>(
-      id: string,
-      query?: EntryQueries
-    ): Promise<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
-    getEntries<Fields extends FieldsType>(
-      query?: EntriesQueries<Fields>
-    ): Promise<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>
-
-    parseEntries<Fields extends FieldsType = FieldsType>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>
-    ): EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>
-  }
-
-export type ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks = BaseClient &
-  BaseClientWithAssetsWithAllLocales & {
-    getEntry<Fields extends FieldsType, Locales extends LocaleCode = any>(
-      id: string,
-      query?: EntryQueries & { locale?: never }
-    ): Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
-
-    getEntries<Fields extends FieldsType, Locales extends LocaleCode = any>(
-      query?: EntriesQueries<Fields> & { locale?: never }
-    ): Promise<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>
-
-    parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(
-      data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES', Locales>
-    ): EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
-  }
-
-export type DefaultClient = ClientWithLinkResolutionAndWithUnresolvableLinks
+export type DefaultClient = Client<undefined>
 
 interface BaseClient {
   version: string
@@ -295,87 +252,6 @@ interface BaseClient {
    * console.log(assetKey)
    */
   createAssetKey(expiresAt: number): Promise<AssetKey>
-}
-
-interface BaseClientWithAssets extends BaseClient {
-  /**
-   * Gets an Asset
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const asset = await client.getAsset('<asset_id>')
-   * console.log(asset)
-   * ```
-   */
-  getAsset(id: string, query?: { locale?: string }): Promise<Asset<undefined>>
-
-  /**
-   * Gets a collection of Assets
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const response = await client.getAssets()
-   * console.log(response.items)
-   * ```
-   */
-  getAssets(query?: AssetQueries<AssetFields>): Promise<AssetCollection<undefined>>
-}
-
-interface BaseClientWithAssetsWithAllLocales extends BaseClient {
-  /**
-   * Gets an Asset
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const asset = await client.getAsset('<asset_id>')
-   * console.log(asset)
-   * ```
-   */
-  getAsset<Locale extends LocaleCode>(
-    id: string,
-    query?: { locale?: string }
-  ): Promise<Asset<'WITH_ALL_LOCALES', Locale>>
-
-  /**
-   * Gets a collection of Assets
-   * @category API
-   * @example
-   * ```javascript
-   * const contentful = require('contentful')
-   *
-   * const client = contentful.createClient({
-   *   space: '<space_id>',
-   *   accessToken: '<content_delivery_api_key>'
-   * })
-   *
-   * const response = await client.getAssets()
-   * console.log(response.items)
-   * ```
-   */
-  getAssets<Locales extends LocaleCode>(
-    query?: AssetQueries<AssetFields>
-  ): Promise<AssetCollection<'WITH_ALL_LOCALES', Locales>>
 }
 
 export interface CreateContentfulApiParams {
@@ -562,11 +438,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   >(
     query: Record<string, any>,
     options: Options
-  ): Promise<
-    Options extends ChainOption<infer Modifiers>
-      ? EntryCollection<Fields, Modifiers, Locales>
-      : never
-  > {
+  ): Promise<EntryCollection<Fields, ModifiersFromOptions<Options>, Locales>> {
     const { withoutLinkResolution, withoutUnresolvableLinks } = options
 
     try {
@@ -613,7 +485,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   async function internalGetAsset<Locales extends LocaleCode, Options extends ChainOptions>(
     id: string,
     query: Record<string, any>
-  ): Promise<Options extends ChainOption<infer Modifiers> ? Asset<Modifiers, Locales> : never> {
+  ): Promise<Asset<ModifiersFromOptions<Options>, Locales>> {
     try {
       return get({
         context: 'environment',
@@ -645,9 +517,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
 
   async function internalGetAssets<Locales extends LocaleCode, Options extends ChainOptions>(
     query: Record<string, any>
-  ): Promise<
-    Options extends ChainOption<infer Modifiers> ? AssetCollection<Modifiers, Locales> : never
-  > {
+  ): Promise<AssetCollection<ModifiersFromOptions<Options>, Locales>> {
     try {
       return get({
         context: 'environment',
@@ -726,9 +596,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   >(
     data: unknown,
     options: Options
-  ): Options extends ChainOption<infer Modifiers>
-    ? EntryCollection<Fields, Modifiers, Locales>
-    : never {
+  ): EntryCollection<Fields, ModifiersFromOptions<Options>, Locales> {
     const { withoutLinkResolution, withoutUnresolvableLinks } = options
 
     return resolveCircular(data, {

--- a/lib/utils/client-helpers.ts
+++ b/lib/utils/client-helpers.ts
@@ -4,6 +4,11 @@ export type ChainModifiers =
   | 'WITHOUT_UNRESOLVABLE_LINKS'
   | undefined
 
+export type AddChainModifier<
+  Modifiers extends ChainModifiers,
+  AddedModifiers extends Exclude<ChainModifiers, undefined>
+> = undefined extends Modifiers ? AddedModifiers : Modifiers | AddedModifiers
+
 export type ChainOption<Modifiers extends ChainModifiers = ChainModifiers> = {
   withoutLinkResolution: ChainModifiers extends Modifiers
     ? boolean
@@ -25,3 +30,9 @@ export type ChainOption<Modifiers extends ChainModifiers = ChainModifiers> = {
 export type DefaultChainOption = ChainOption<undefined>
 
 export type ChainOptions = ChainOption
+
+export type ModifiersFromOptions<Options extends ChainOption> = Options extends ChainOption<
+  infer Modifiers
+>
+  ? Modifiers
+  : never

--- a/test/types/client/createClient.test-d.ts
+++ b/test/types/client/createClient.test-d.ts
@@ -1,35 +1,66 @@
-import { expectType } from 'tsd'
+import { expectNotAssignable, expectType } from 'tsd'
 
 import { createClient } from '../../../lib'
-import {
-  ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks,
-  ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks,
-  ClientWithAllLocalesAndWithoutLinkResolution,
-  ClientWithLinkResolutionAndWithoutUnresolvableLinks,
-  ClientWithLinkResolutionAndWithUnresolvableLinks,
-  ClientWithoutLinkResolution,
-} from '../../../lib/create-contentful-api'
+import { Client } from '../../../lib/create-contentful-api'
 
 const CLIENT_OPTIONS = {
   accessToken: 'accessToken',
   space: 'spaceId',
 }
 
-expectType<ClientWithLinkResolutionAndWithUnresolvableLinks>(createClient(CLIENT_OPTIONS))
+expectType<Client<undefined>>(createClient(CLIENT_OPTIONS))
 
-expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithUnresolvableLinks>(
-  createClient(CLIENT_OPTIONS).withAllLocales
+expectType<Client<'WITHOUT_LINK_RESOLUTION'>>(createClient(CLIENT_OPTIONS).withoutLinkResolution)
+expectNotAssignable<{ withoutLinkResolution: any }>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution
+)
+expectNotAssignable<{ withoutUnresolvableLinks: any }>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution
 )
 
-expectType<ClientWithAllLocalesAndWithoutLinkResolution>(
+expectType<Client<'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES'>>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+)
+expectNotAssignable<{ withoutLinkResolution: any }>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+)
+expectNotAssignable<{ withAllLocales: any }>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+)
+expectNotAssignable<{ withoutLinkResolution: any }>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+)
+
+expectType<Client<'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
+)
+expectNotAssignable<{ withoutUnresolvableLinks: any }>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
+)
+expectNotAssignable<{ withoutLinkResolution: any }>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
+)
+
+expectType<Client<'WITHOUT_UNRESOLVABLE_LINKS' | 'WITH_ALL_LOCALES'>>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+)
+expectNotAssignable<{ withoutUnresolvableLinks: any }>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+)
+expectNotAssignable<{ withAllLocales: any }>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+)
+expectNotAssignable<{ withoutLinkResolution: any }>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+)
+
+expectType<Client<'WITH_ALL_LOCALES'>>(createClient(CLIENT_OPTIONS).withAllLocales)
+expectNotAssignable<{ withAllLocales: any }>(createClient(CLIENT_OPTIONS).withAllLocales)
+
+expectType<Client<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutLinkResolution
 )
 
-expectType<ClientWithAllLocalesAndWithLinkResolutionAndWithoutUnresolvableLinks>(
+expectType<Client<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutUnresolvableLinks
-)
-expectType<ClientWithoutLinkResolution>(createClient(CLIENT_OPTIONS).withoutLinkResolution)
-
-expectType<ClientWithLinkResolutionAndWithoutUnresolvableLinks>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
 )

--- a/test/types/client/getAssets.test-d.ts
+++ b/test/types/client/getAssets.test-d.ts
@@ -1,15 +1,21 @@
 import { expectType } from 'tsd'
-import { Asset, AssetCollection, createClient, LocaleCode } from '../../../lib'
+import { Asset, AssetCollection, createClient } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
   space: 'spaceId',
 })
 
-expectType<AssetCollection<undefined>>(await client.getAssets())
+type Locale = 'en'
 
 expectType<Asset<undefined>>(await client.getAsset('test'))
 
-expectType<AssetCollection<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAssets<LocaleCode>())
+expectType<AssetCollection<undefined>>(await client.getAssets())
 
-expectType<Asset<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAsset<LocaleCode>('test'))
+expectType<Asset<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAsset('test'))
+expectType<Asset<'WITH_ALL_LOCALES', Locale>>(await client.withAllLocales.getAsset<Locale>('test'))
+
+expectType<AssetCollection<'WITH_ALL_LOCALES'>>(await client.withAllLocales.getAssets())
+expectType<AssetCollection<'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getAssets<Locale>()
+)

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd'
-import { createClient, EntryCollection, LocaleCode, Entry } from '../../../lib'
+import { createClient, EntryCollection, Entry, FieldsType } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -16,40 +16,90 @@ type Fields = {
   moreLinks: Entry<LinkedFields>[]
 }
 
+type Locale = 'en'
+
+expectType<Entry<FieldsType, undefined>>(await client.getEntry('entry-id'))
 expectType<Entry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
+expectType<EntryCollection<FieldsType, undefined>>(await client.getEntries())
 expectType<EntryCollection<Fields, undefined>>(await client.getEntries<Fields>())
 
+expectType<Entry<FieldsType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntry('entry-id')
+)
 expectType<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
+)
+expectType<EntryCollection<FieldsType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntries()
 )
 expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntries<Fields>()
 )
 
+expectType<Entry<FieldsType, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntry('entry-id')
+)
 expectType<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry<Fields>('entry-id')
+)
+expectType<EntryCollection<FieldsType, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntries()
 )
 expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntries<Fields>()
 )
 
+expectType<Entry<FieldsType, 'WITH_ALL_LOCALES'>>(await client.withAllLocales.getEntry('entry-id'))
 expectType<Entry<Fields, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntry<Fields, LocaleCode>('entry-id')
+  await client.withAllLocales.getEntry<Fields>('entry-id')
+)
+expectType<Entry<Fields, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntry<Fields, Locale>('entry-id')
+)
+expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntries()
 )
 expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntries<Fields, LocaleCode>()
+  await client.withAllLocales.getEntries<Fields>()
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntries<Fields, Locale>()
 )
 
-expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>>(
-  client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, LocaleCode>('entry-id')
+expectType<Entry<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry('entry-id')
+)
+expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
+)
+expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, Locale>('entry-id')
+)
+expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries()
 )
 expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, LocaleCode>()
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields>()
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, Locale>()
 )
 
-expectType<Promise<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>>(
-  client.withAllLocales.withoutLinkResolution.getEntry<Fields, LocaleCode>('entry-id')
+expectType<Entry<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry('entry-id')
+)
+expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<Fields>('entry-id')
+)
+expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<Fields, Locale>('entry-id')
+)
+expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries()
 )
 expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries<Fields, LocaleCode>()
+  await client.withAllLocales.withoutLinkResolution.getEntries<Fields>()
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries<Fields, Locale>()
 )

--- a/test/types/client/parseEntries.test-d.ts
+++ b/test/types/client/parseEntries.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd'
-import { createClient, EntryCollection, EntrySys, Link, LocaleCode } from '../../../lib'
+import { createClient, EntryCollection, EntrySys, FieldsType, Link, LocaleCode } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -47,10 +47,12 @@ const data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'> = {
   ],
 }
 
+type Locales = 'en' | 'de'
+
 const dataWithAllLocales: EntryCollection<
   Fields,
   'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES',
-  'en' | 'de'
+  Locales
 > = {
   total: 10,
   skip: 0,
@@ -93,28 +95,49 @@ const dataWithAllLocales: EntryCollection<
   ],
 }
 
-expectType<EntryCollection<Fields, undefined>>(await client.parseEntries<Fields>(data))
+expectType<EntryCollection<Fields, undefined>>(client.parseEntries(data))
+expectType<EntryCollection<Fields, undefined>>(client.parseEntries<Fields>(data))
 
 expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.parseEntries<Fields>(data)
+  client.withoutUnresolvableLinks.parseEntries(data)
+)
+expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  client.withoutUnresolvableLinks.parseEntries<Fields>(data)
 )
 
 expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.parseEntries<Fields>(data)
+  client.withoutLinkResolution.parseEntries(data)
+)
+expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
+  client.withoutLinkResolution.parseEntries<Fields>(data)
 )
 
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', LocaleCode>>(
-  await client.withAllLocales.parseEntries<Fields, LocaleCode>(dataWithAllLocales)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>(
+  client.withAllLocales.parseEntries(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES'>>(
+  client.withAllLocales.parseEntries<Fields>(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>(
+  client.withAllLocales.parseEntries<Fields, Locales>(dataWithAllLocales)
 )
 
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', LocaleCode>>(
-  await client.withAllLocales.withoutUnresolvableLinks.parseEntries<Fields, LocaleCode>(
-    dataWithAllLocales
-  )
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<Fields>(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<Fields, Locales>(dataWithAllLocales)
 )
 
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', LocaleCode>>(
-  await client.withAllLocales.withoutLinkResolution.parseEntries<Fields, LocaleCode>(
-    dataWithAllLocales
-  )
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<Fields>(dataWithAllLocales)
+)
+expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<Fields, Locales>(dataWithAllLocales)
 )


### PR DESCRIPTION
## Summary

Replace existing client types (`ClientWith…`) with one generic client type (`Client<ChainModifiers>`). With this change the client and entry types follow the same format which should make it easier to read and understand.

