### PR TITLE
fix: limit select operator to allowed values

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -47,7 +47,7 @@ type ClientMethodsWithAllLocales<Modifiers extends ChainModifiers> = {
   ): Promise<Entry<Fields, Modifiers, Locales>>
 
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
-    query?: Omit<EntriesQueries, 'locale'>
+    query?: EntriesQueries // TODO: omit locale if possible
   ): Promise<EntryCollection<Fields, Modifiers, Locales>>
 
   parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -40,7 +40,7 @@ export type EntriesQueries<Fields extends FieldsType = FieldsType> = Partial<
   EntryFieldsQueries<Fields> &
     SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
     FixedQueryOptions &
-    FixedPagedOptions & { content_type?: string } & Record<string, any> & {
+    FixedPagedOptions & { content_type?: string } & {
       resolveLinks?: never
     }
 >
@@ -60,5 +60,5 @@ export type AssetQueries<Fields extends FieldsType = FieldsType> = Partial<
   AssetFieldsQueries<Fields> &
     SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
     FixedQueryOptions &
-    FixedPagedOptions & { mimetype_group?: AssetMimeType } & Record<string, any>
+    FixedPagedOptions & { mimetype_group?: AssetMimeType }
 >

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from './existence'
 import { LocationSearchFilters } from './location'
 import { RangeFilters } from './range'
 import { FullTextSearchFilters } from './search'
-import { SelectFilter } from './select'
+import { AssetSelectFilter, EntrySelectFilter } from './select'
 import { SubsetFilters } from './subset'
 import { FieldsType } from './util'
 
@@ -24,11 +24,11 @@ export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   EqualityFilter<Sys, 'sys'> &
   InequalityFilter<Sys, 'sys'> &
   SubsetFilters<Sys, 'sys'> &
-  RangeFilters<Sys, 'sys'> &
-  SelectFilter<Sys, 'sys'>
+  RangeFilters<Sys, 'sys'>
 
 export type EntryFieldsQueries<Fields extends FieldsType = FieldsType> =
-  | (ExistenceFilter<Fields, 'fields'> & SelectFilter<Fields, 'fields'>)
+  | EntrySelectFilter<Fields>
+  | ExistenceFilter<Fields, 'fields'>
   | (EqualityFilter<Fields, 'fields'> & InequalityFilter<Fields, 'fields'>)
   | FullTextSearchFilters<Fields, 'fields'>
   | SubsetFilters<Fields, 'fields'>
@@ -36,14 +36,12 @@ export type EntryFieldsQueries<Fields extends FieldsType = FieldsType> =
   | RangeFilters<Fields, 'fields'>
 
 // TODO: create-contentful-api complained about non-optional fields when initialized with {}
-export type EntriesQueries<Fields extends FieldsType = FieldsType> = Partial<
-  EntryFieldsQueries<Fields> &
-    SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
-    FixedQueryOptions &
-    FixedPagedOptions & { content_type?: string } & {
-      resolveLinks?: never
-    }
->
+export type EntriesQueries<Fields extends FieldsType = FieldsType> = EntryFieldsQueries<Fields> &
+  SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+  FixedQueryOptions &
+  FixedPagedOptions & { content_type?: string } & {
+    resolveLinks?: never
+  } & { order?: string }
 
 export type EntryQueries = Omit<FixedQueryOptions, 'query'>
 
@@ -52,13 +50,11 @@ export type AssetFieldsQueries<Fields extends FieldsType = FieldsType> =
       EqualityFilter<Fields, 'fields'> &
       InequalityFilter<Fields, 'fields'> &
       FullTextSearchFilters<Fields, 'fields'> &
-      SelectFilter<Fields, 'fields'>)
+      AssetSelectFilter<Fields>)
   | RangeFilters<Fields, 'fields'>
   | SubsetFilters<Fields, 'fields'>
 
-export type AssetQueries<Fields extends FieldsType = FieldsType> = Partial<
-  AssetFieldsQueries<Fields> &
-    SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
-    FixedQueryOptions &
-    FixedPagedOptions & { mimetype_group?: AssetMimeType }
->
+export type AssetQueries<Fields extends FieldsType = FieldsType> = AssetFieldsQueries<Fields> &
+  SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+  FixedQueryOptions &
+  FixedPagedOptions & { mimetype_group?: AssetMimeType } & { order?: string }

--- a/lib/types/query/select.ts
+++ b/lib/types/query/select.ts
@@ -1,13 +1,39 @@
 import { FieldsType } from './util'
+import { EntrySys } from '../entry'
+import { AssetSys } from '../asset'
+
+export type SelectFilterPaths<
+  Fields extends FieldsType,
+  Prefix extends string
+> = `${Prefix}.${keyof Fields & string}`
 
 /**
- * @desc select
+ * @desc select for entries
  * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator}
  */
-export type SelectFilter<Fields extends FieldsType, Prefix extends string> = {
+export type EntrySelectFilter<Fields extends FieldsType> =
+  | {
+      select?: ('sys' | 'fields' | SelectFilterPaths<EntrySys, 'sys'>)[]
+    }
+  | {
+      content_type: string
+      select?: (
+        | 'sys'
+        | 'fields'
+        | SelectFilterPaths<EntrySys, 'sys'>
+        | SelectFilterPaths<Fields, 'fields'>
+      )[]
+    }
+
+/**
+ * @desc select for assets
+ * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator}
+ */
+export type AssetSelectFilter<Fields extends FieldsType> = {
   select?: (
-    | `${string}.${string}`
-    | `${Prefix}.${keyof Fields & string}`
-    | `${Prefix}.${keyof Fields & string}.${string}`
+    | 'sys'
+    | SelectFilterPaths<AssetSys, 'sys'>
+    | 'fields'
+    | SelectFilterPaths<Fields, 'fields'>
   )[]
 }

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -1,0 +1,23 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { AssetQueries } from '../../../lib'
+
+// select operator
+
+expectAssignable<AssetQueries>({ select: ['sys'] })
+expectAssignable<AssetQueries>({ select: ['sys.createdAt'] })
+expectNotAssignable<AssetQueries>({ select: ['sys.unknownProperty'] })
+
+expectAssignable<AssetQueries>({ select: ['fields'] })
+expectNotAssignable<AssetQueries>({ select: ['fields.unknownField'] })
+
+expectAssignable<AssetQueries<{ someField: string }>>({ select: ['sys'] })
+expectAssignable<AssetQueries<{ someField: string }>>({ select: ['sys.createdAt'] })
+expectNotAssignable<AssetQueries<{ someField: string }>>({ select: ['sys.unknownProperty'] })
+
+expectAssignable<AssetQueries<{ someField: string }>>({ select: ['fields'] })
+expectAssignable<AssetQueries<{ someField: string }>>({
+  select: ['fields.someField'],
+})
+expectNotAssignable<AssetQueries<{ someField: string }>>({
+  select: ['fields.unknownField'],
+})

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -1,0 +1,26 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { EntriesQueries } from '../../../lib'
+
+// select operator
+
+expectAssignable<EntriesQueries>({ select: ['sys'] })
+expectAssignable<EntriesQueries>({ select: ['sys.createdAt'] })
+expectNotAssignable<EntriesQueries>({ select: ['sys.unknownProperty'] })
+
+expectAssignable<EntriesQueries>({ select: ['fields'] })
+expectNotAssignable<EntriesQueries>({ select: ['fields.unknownField'] })
+
+expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys'] })
+expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys.createdAt'] })
+expectNotAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys.unknownProperty'] })
+
+expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['fields'] })
+expectNotAssignable<EntriesQueries<{ someField: string }>>({ select: ['fields.someField'] })
+expectAssignable<EntriesQueries<{ someField: string }>>({
+  content_type: 'id',
+  select: ['fields.someField'],
+})
+expectNotAssignable<EntriesQueries<{ someField: string }>>({
+  content_type: 'id',
+  select: ['fields.unknownField'],
+})

--- a/test/types/query-integer.test-d.ts
+++ b/test/types/query-integer.test-d.ts
@@ -4,7 +4,7 @@ import { EqualityFilter, InequalityFilter } from '../../lib/types/query/equality
 import { ExistenceFilter } from '../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../lib/types/query/location'
 import { RangeFilters } from '../../lib/types/query/range'
-import { SelectFilter } from '../../lib/types/query/select'
+import { EntrySelectFilter } from '../../lib/types/query/select'
 import { SubsetFilters } from '../../lib/types/query/subset'
 
 const numberValue = 1
@@ -42,7 +42,8 @@ expectAssignable<RangeFilters<{ testField: EntryFields.Integer }, 'fields'>>({
 //   'fields.testField[match]': stringValue,
 // })
 
-expectAssignable<SelectFilter<{ testField: EntryFields.Integer }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Integer }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Integer }, 'fields'>>({

--- a/test/types/query-types/boolean.test-d.ts
+++ b/test/types/query-types/boolean.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,7 +40,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Boolean }, 'fields'>>(
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Boolean }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Boolean }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Boolean }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Boolean }, 'fields'>>({

--- a/test/types/query-types/date.test-d.ts
+++ b/test/types/query-types/date.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 export const dateValue: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -44,7 +44,8 @@ expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Date }, 'fields'
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Date }, 'fields'>>({
   'fields.testField[match]': dateValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Date }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Date }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Date }, 'fields'>>({

--- a/test/types/query-types/integer.test-d.ts
+++ b/test/types/query-types/integer.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const numberValue = 1
@@ -43,7 +43,8 @@ expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Integer }, 'f
   'fields.testField[match]': stringValue,
 })
 
-expectAssignable<SelectFilter<{ testField: EntryFields.Integer }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Integer }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Integer }, 'fields'>>({

--- a/test/types/query-types/location.test-d.ts
+++ b/test/types/query-types/location.test-d.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -99,7 +99,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Location }, 'fields'>>
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Location }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Location }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Location }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.Location }, 'fields'>>({

--- a/test/types/query-types/number.test-d.ts
+++ b/test/types/query-types/number.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const numberValue = 1
@@ -41,7 +41,8 @@ expectAssignable<RangeFilters<{ testField: EntryFields.Number }, 'fields'>>({
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Number }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Number }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Number }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Number }, 'fields'>>({

--- a/test/types/query-types/object.test-d.ts
+++ b/test/types/query-types/object.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -41,7 +41,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Object }, 'fields'>>({
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Object }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Object }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Object }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.Object }, 'fields'>>({

--- a/test/types/query-types/richtext.test-d.ts
+++ b/test/types/query-types/richtext.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -41,7 +41,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.RichText }, 'fields'>>
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.RichText }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.RichText }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.RichText }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.RichText }, 'fields'>>({

--- a/test/types/query-types/symbol.test-d.ts
+++ b/test/types/query-types/symbol.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,7 +40,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Symbol }, 'fields'>>({
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Symbol }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Symbol }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Symbol }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Symbol }, 'fields'>>({

--- a/test/types/query-types/text.test-d.ts
+++ b/test/types/query-types/text.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { SelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,7 +40,8 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Text }, 'fields'>>({
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Text }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<SelectFilter<{ testField: EntryFields.Text }, 'fields'>>({
+expectAssignable<EntrySelectFilter<{ testField: EntryFields.Text }>>({
+  content_type: 'id',
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Text }, 'fields'>>({

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -1,5 +1,5 @@
-import { expectAssignable } from 'tsd'
-import { EntriesQueries, EntryFields } from '../../lib'
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { EntriesQueries, EntryFields, FieldsType } from '../../lib'
 import { EntryFieldsQueries } from '../../lib/types/query/query'
 import { BLOCKS } from '@contentful/rich-text-types'
 


### PR DESCRIPTION
## Summary

Update select operator type to match the API.

## Description

* Split select filter into variations for assets and entries
* Require `content_type` when selecting for entry fields
* Remove `Partial` around `EntriesQueries` and `AssetQueries` because it makes required properties impossible
* Remove wildcard types from `EntriesQueries` and `AssetQueries` because it makes forbidden properties impossible
* Add simple `order` parameter type as stand in until we have a proper type for it

## Motivation and Context

We want to guide users more when using queries. Currently it’s only possible to get some autocomplete support but the types don’t give hints as to what’s required for certain operators or which properties are not allowed. This PR lays the groundwork to add more helpful query types.