### PR TITLE
feat: require content type when it’s needed in API

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -47,7 +47,7 @@ type ClientMethodsWithAllLocales<Modifiers extends ChainModifiers> = {
   ): Promise<Entry<Fields, Modifiers, Locales>>
 
   getEntries<Fields extends FieldsType, Locales extends LocaleCode = LocaleCode>(
-    query?: EntriesQueries // TODO: omit locale if possible
+    query?: EntriesQueries<Fields> // TODO: omit locale if possible
   ): Promise<EntryCollection<Fields, Modifiers, Locales>>
 
   parseEntries<Fields extends FieldsType = FieldsType, Locales extends LocaleCode = LocaleCode>(

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from './existence'
 import { LocationSearchFilters } from './location'
 import { RangeFilters } from './range'
 import { FullTextSearchFilters } from './search'
-import { AssetSelectFilter, EntrySelectFilter } from './select'
+import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
 import { SubsetFilters } from './subset'
 import { FieldsType } from './util'
 
@@ -26,26 +26,27 @@ export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   SubsetFilters<Sys, 'sys'> &
   RangeFilters<Sys, 'sys'>
 
-export type EntryFieldsQueries<Fields extends FieldsType = FieldsType> =
-  | EntrySelectFilter<Fields>
+export type EntryFieldsQueries<Fields extends FieldsType> =
+  | EntrySelectFilterWithFields<Fields>
   | ExistenceFilter<Fields, 'fields'>
-  | (EqualityFilter<Fields, 'fields'> & InequalityFilter<Fields, 'fields'>)
+  | EqualityFilter<Fields, 'fields'>
+  | InequalityFilter<Fields, 'fields'>
   | FullTextSearchFilters<Fields, 'fields'>
   | SubsetFilters<Fields, 'fields'>
   | LocationSearchFilters<Fields, 'fields'>
   | RangeFilters<Fields, 'fields'>
 
 // TODO: create-contentful-api complained about non-optional fields when initialized with {}
-export type EntriesQueries<Fields extends FieldsType = FieldsType> = EntryFieldsQueries<Fields> &
-  SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
-  FixedQueryOptions &
-  FixedPagedOptions & { content_type?: string } & {
-    resolveLinks?: never
-  } & { order?: string }
+export type EntriesQueries<Fields extends FieldsType> =
+  | (EntryFieldsQueries<Fields> & { content_type: string })
+  | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+      EntrySelectFilter &
+      FixedQueryOptions &
+      FixedPagedOptions & { order?: string })
 
 export type EntryQueries = Omit<FixedQueryOptions, 'query'>
 
-export type AssetFieldsQueries<Fields extends FieldsType = FieldsType> =
+export type AssetFieldsQueries<Fields extends FieldsType> =
   | (ExistenceFilter<Fields, 'fields'> &
       EqualityFilter<Fields, 'fields'> &
       InequalityFilter<Fields, 'fields'> &
@@ -54,7 +55,7 @@ export type AssetFieldsQueries<Fields extends FieldsType = FieldsType> =
   | RangeFilters<Fields, 'fields'>
   | SubsetFilters<Fields, 'fields'>
 
-export type AssetQueries<Fields extends FieldsType = FieldsType> = AssetFieldsQueries<Fields> &
+export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields> &
   SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
   FixedQueryOptions &
   FixedPagedOptions & { mimetype_group?: AssetMimeType } & { order?: string }

--- a/lib/types/query/select.ts
+++ b/lib/types/query/select.ts
@@ -11,19 +11,22 @@ export type SelectFilterPaths<
  * @desc select for entries
  * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator}
  */
-export type EntrySelectFilter<Fields extends FieldsType> =
-  | {
-      select?: ('sys' | 'fields' | SelectFilterPaths<EntrySys, 'sys'>)[]
-    }
-  | {
-      content_type: string
-      select?: (
-        | 'sys'
-        | 'fields'
-        | SelectFilterPaths<EntrySys, 'sys'>
-        | SelectFilterPaths<Fields, 'fields'>
-      )[]
-    }
+export type EntrySelectFilterWithFields<Fields extends FieldsType> = {
+  select?: (
+    | 'sys'
+    | 'fields'
+    | SelectFilterPaths<EntrySys, 'sys'>
+    | SelectFilterPaths<Fields, 'fields'>
+  )[]
+}
+
+/**
+ * @desc select for entries
+ * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/select-operator}
+ */
+export type EntrySelectFilter = {
+  select?: ('sys' | 'fields' | SelectFilterPaths<EntrySys, 'sys'>)[]
+}
 
 /**
  * @desc select for assets

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -3,13 +3,6 @@ import { AssetQueries } from '../../../lib'
 
 // select operator
 
-expectAssignable<AssetQueries>({ select: ['sys'] })
-expectAssignable<AssetQueries>({ select: ['sys.createdAt'] })
-expectNotAssignable<AssetQueries>({ select: ['sys.unknownProperty'] })
-
-expectAssignable<AssetQueries>({ select: ['fields'] })
-expectNotAssignable<AssetQueries>({ select: ['fields.unknownField'] })
-
 expectAssignable<AssetQueries<{ someField: string }>>({ select: ['sys'] })
 expectAssignable<AssetQueries<{ someField: string }>>({ select: ['sys.createdAt'] })
 expectNotAssignable<AssetQueries<{ someField: string }>>({ select: ['sys.unknownProperty'] })

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -1,14 +1,105 @@
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntriesQueries } from '../../../lib'
+import { EntryFields, EntriesQueries } from '../../../lib'
+
+// exists operator (field is present)
+
+expectNotAssignable<EntriesQueries<{ someField: string }>>({
+  'fields.numberField[exists]': true,
+})
+expectAssignable<EntriesQueries<{ someField: string }>>({
+  content_type: 'id',
+  'fields.someField[exists]': true,
+})
+expectNotAssignable<EntriesQueries<{ someField: string }>>({
+  content_type: 'id',
+  'fields.unknownField[exists]': true,
+})
+
+// gt operator (range)
+
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  'fields.numberField[gt]': 3,
+})
+expectAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.numberField[gt]': 3,
+})
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.unknownField[gt]': 3,
+})
+
+// gte operator (range)
+
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  'fields.numberField[gte]': 3,
+})
+expectAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.numberField[gte]': 3,
+})
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.unknownField[gte]': 3,
+})
+
+// lt operator (range)
+
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  'fields.numberField[lt]': 3,
+})
+expectAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.numberField[lt]': 3,
+})
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.unknownField[lt]': 3,
+})
+
+// lte operator (range)
+
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  'fields.numberField[lte]': 3,
+})
+expectAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.numberField[lte]': 3,
+})
+expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+  content_type: 'id',
+  'fields.unknownField[lte]': 3,
+})
+
+// match operator (full-text search)
+
+expectNotAssignable<EntriesQueries<{ textField: string }>>({
+  'fields.textField[match]': 'value',
+})
+expectAssignable<EntriesQueries<{ textField: string }>>({
+  content_type: 'id',
+  'fields.textField[match]': 'value',
+})
+expectNotAssignable<EntriesQueries<{ textField: string }>>({
+  content_type: 'id',
+  'fields.unknownField[match]': 'value',
+})
+
+// near operator (full-text search)
+
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  'fields.locationField[near]': [0, 1],
+})
+expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  'fields.locationField[near]': [0, 1],
+})
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  'fields.unknownField[near]': [0, 1],
+})
 
 // select operator
-
-expectAssignable<EntriesQueries>({ select: ['sys'] })
-expectAssignable<EntriesQueries>({ select: ['sys.createdAt'] })
-expectNotAssignable<EntriesQueries>({ select: ['sys.unknownProperty'] })
-
-expectAssignable<EntriesQueries>({ select: ['fields'] })
-expectNotAssignable<EntriesQueries>({ select: ['fields.unknownField'] })
 
 expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys'] })
 expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys.createdAt'] })
@@ -23,4 +114,32 @@ expectAssignable<EntriesQueries<{ someField: string }>>({
 expectNotAssignable<EntriesQueries<{ someField: string }>>({
   content_type: 'id',
   select: ['fields.unknownField'],
+})
+
+// within operator (bounding circle)
+
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  'fields.locationField[within]': [0, 1, 2],
+})
+expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  'fields.locationField[within]': [0, 1, 2],
+})
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  ['fields.unknownField[within]']: [0, 1, 2],
+})
+
+// within operator (bounding rectangle)
+
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  'fields.locationField[within]': [0, 1, 2, 3],
+})
+expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  'fields.locationField[within]': [0, 1, 2, 3],
+})
+expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+  content_type: 'id',
+  'fields.unknownField[within]': [0, 1, 2, 3],
 })

--- a/test/types/query-integer.test-d.ts
+++ b/test/types/query-integer.test-d.ts
@@ -4,7 +4,7 @@ import { EqualityFilter, InequalityFilter } from '../../lib/types/query/equality
 import { ExistenceFilter } from '../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../lib/types/query/location'
 import { RangeFilters } from '../../lib/types/query/range'
-import { EntrySelectFilter } from '../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../lib/types/query/select'
 import { SubsetFilters } from '../../lib/types/query/subset'
 
 const numberValue = 1
@@ -42,8 +42,7 @@ expectAssignable<RangeFilters<{ testField: EntryFields.Integer }, 'fields'>>({
 //   'fields.testField[match]': stringValue,
 // })
 
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Integer }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Integer }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Integer }, 'fields'>>({

--- a/test/types/query-types/boolean.test-d.ts
+++ b/test/types/query-types/boolean.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,8 +40,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Boolean }, 'fields'>>(
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Boolean }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Boolean }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Boolean }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Boolean }, 'fields'>>({

--- a/test/types/query-types/date.test-d.ts
+++ b/test/types/query-types/date.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 export const dateValue: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -44,8 +44,7 @@ expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Date }, 'fields'
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Date }, 'fields'>>({
   'fields.testField[match]': dateValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Date }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Date }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Date }, 'fields'>>({

--- a/test/types/query-types/integer.test-d.ts
+++ b/test/types/query-types/integer.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilter, EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const numberValue = 1
@@ -43,8 +43,7 @@ expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Integer }, 'f
   'fields.testField[match]': stringValue,
 })
 
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Integer }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Integer }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Integer }, 'fields'>>({

--- a/test/types/query-types/location.test-d.ts
+++ b/test/types/query-types/location.test-d.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -99,8 +99,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Location }, 'fields'>>
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Location }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Location }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Location }>>({
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.Location }, 'fields'>>({

--- a/test/types/query-types/number.test-d.ts
+++ b/test/types/query-types/number.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const numberValue = 1
@@ -41,8 +41,7 @@ expectAssignable<RangeFilters<{ testField: EntryFields.Number }, 'fields'>>({
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Number }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Number }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Number }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Number }, 'fields'>>({

--- a/test/types/query-types/object.test-d.ts
+++ b/test/types/query-types/object.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -41,8 +41,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Object }, 'fields'>>({
 expectNotAssignable<FullTextSearchFilters<{ testField: EntryFields.Object }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Object }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Object }>>({
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.Object }, 'fields'>>({

--- a/test/types/query-types/richtext.test-d.ts
+++ b/test/types/query-types/richtext.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -41,8 +41,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.RichText }, 'fields'>>
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.RichText }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.RichText }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.RichText }>>({
   select: ['fields.testField'],
 })
 expectNotAssignable<SubsetFilters<{ testField: EntryFields.RichText }, 'fields'>>({

--- a/test/types/query-types/symbol.test-d.ts
+++ b/test/types/query-types/symbol.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,8 +40,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Symbol }, 'fields'>>({
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Symbol }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Symbol }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Symbol }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Symbol }, 'fields'>>({

--- a/test/types/query-types/text.test-d.ts
+++ b/test/types/query-types/text.test-d.ts
@@ -5,7 +5,7 @@ import { ExistenceFilter } from '../../../lib/types/query/existence'
 import { LocationSearchFilters } from '../../../lib/types/query/location'
 import { RangeFilters } from '../../../lib/types/query/range'
 import { FullTextSearchFilters } from '../../../lib/types/query/search'
-import { EntrySelectFilter } from '../../../lib/types/query/select'
+import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 
 const stringValue = ''
@@ -40,8 +40,7 @@ expectNotAssignable<RangeFilters<{ testField: EntryFields.Text }, 'fields'>>({
 expectAssignable<FullTextSearchFilters<{ testField: EntryFields.Text }, 'fields'>>({
   'fields.testField[match]': stringValue,
 })
-expectAssignable<EntrySelectFilter<{ testField: EntryFields.Text }>>({
-  content_type: 'id',
+expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Text }>>({
   select: ['fields.testField'],
 })
 expectAssignable<SubsetFilters<{ testField: EntryFields.Text }, 'fields'>>({

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -1,5 +1,5 @@
-import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntriesQueries, EntryFields, FieldsType } from '../../lib'
+import { expectAssignable } from 'tsd'
+import { EntriesQueries, EntryFields } from '../../lib'
 import { EntryFieldsQueries } from '../../lib/types/query/query'
 import { BLOCKS } from '@contentful/rich-text-types'
 
@@ -132,6 +132,7 @@ expectAssignable<
     numberField: EntryFields.Number
   }>
 >({
+  content_type: 'id',
   'fields.stringField[exists]': booleanValue,
   'fields.stringField[match]': stringValue,
   'fields.numberField[gte]': numberValue,


### PR DESCRIPTION
## Summary

Require `content_type` in query for all operations on fields.

## Description

* Require `content_type` directly in `EntriesQueries` to keep types simple
* Remove defaults for the generic in `EntriesQueries` and `AssetQueries` as they’re always called with a value.
* Add tests for several operator types that focus on the `content_type` requirement.