### PR TITLE
fix: location filter type

### DIFF
--- a/lib/types/query/location.ts
+++ b/lib/types/query/location.ts
@@ -2,7 +2,7 @@ import { ConditionalPick } from 'type-fest'
 import { EntryFields } from '../entry'
 import { NonEmpty } from './util'
 
-type Types = EntryFields.Location
+type Types = EntryFields.Location | undefined
 
 export type ProximitySearchFilterInput = [number, number] | undefined
 export type BoundingBoxSearchFilterInput = [number, number, number, number] | undefined


### PR DESCRIPTION
## Summary

2 of my 3 TypeScript contexts don’t accept the location filter type without this change despite all 3 using the same TypeScript version.