### PR TITLE
fix: improve query types for getEntries

### DIFF
--- a/lib/types/query/equality.ts
+++ b/lib/types/query/equality.ts
@@ -3,6 +3,7 @@ import { ConditionalQueries, NonEmpty } from './util'
 
 type SupportedTypes =
   | EntryFields.Symbol
+  | EntryFields.Symbol[]
   | EntryFields.Text
   | EntryFields.Integer
   | EntryFields.Number

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -20,6 +20,11 @@ type FixedQueryOptions = {
   query?: string
 }
 
+type FixedLinkOptions = {
+  links_to_asset?: string
+  links_to_entry?: string
+}
+
 export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   EqualityFilter<Sys, 'sys'> &
   InequalityFilter<Sys, 'sys'> &
@@ -42,7 +47,8 @@ export type EntriesQueries<Fields extends FieldsType> =
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       EntrySelectFilter &
       FixedQueryOptions &
-      FixedPagedOptions & { order?: string })
+      FixedPagedOptions &
+      FixedLinkOptions & { order?: string })
 
 export type EntryQueries = Omit<FixedQueryOptions, 'query'>
 

--- a/lib/types/query/search.ts
+++ b/lib/types/query/search.ts
@@ -1,7 +1,12 @@
 import { EntryFields } from '../entry'
 import { ConditionalFixedQueries, NonEmpty } from './util'
 
-type SupportedTypes = EntryFields.Text | EntryFields.RichText | EntryFields.Symbol | undefined
+type SupportedTypes =
+  | EntryFields.Text
+  | EntryFields.RichText
+  | EntryFields.Symbol
+  | EntryFields.Symbol[]
+  | undefined
 
 /**
  * @desc match - full text search

--- a/lib/types/query/util.ts
+++ b/lib/types/query/util.ts
@@ -25,5 +25,5 @@ export type ConditionalQueries<
   QueryFilter extends string = ''
 > = {
   [FieldName in keyof ConditionalPick<Fields, SupportedTypes> as `${Prefix}.${string &
-    FieldName}${QueryFilter}`]?: Fields[FieldName] extends Array<infer T> ? T[] : Fields[FieldName]
+    FieldName}${QueryFilter}`]?: Fields[FieldName] extends Array<infer T> ? T : Fields[FieldName]
 }

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -121,6 +121,9 @@ expectAssignable<Required<EntryFieldsQueries<{ richTextField: EntryFields.RichTe
 expectAssignable<Required<EntryFieldsQueries<{ arrayStringField: EntryFields.Array<string> }>>>({
   select: ['fields.arrayStringField'],
   'fields.arrayStringField[exists]': booleanValue,
+  'fields.arrayStringField': stringValue,
+  'fields.arrayStringField[ne]': stringValue,
+  'fields.arrayStringField[match]': stringValue,
 })
 
 /*

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -141,4 +141,7 @@ expectAssignable<
   'fields.numberField[gte]': numberValue,
   select: ['fields.stringField', 'fields.numberField'],
   limit: numberValue,
+  order: stringValue,
+  links_to_asset: stringValue,
+  links_to_entry: stringValue,
 })


### PR DESCRIPTION
## Summary

Improve query types to better match API.

## Description

* add `links_to_asset` and `links_to_entry`
* enable equality, inequality, and full text search operators for symbol list fields
