### PR TITLE
feat: add reference search to query types

### DIFF
--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -8,6 +8,7 @@ import { FullTextSearchFilters } from './search'
 import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
 import { SubsetFilters } from './subset'
 import { FieldsType } from './util'
+import { ReferenceSearchFilters } from './reference'
 
 type FixedPagedOptions = {
   skip?: number
@@ -40,6 +41,7 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
   | SubsetFilters<Fields, 'fields'>
   | LocationSearchFilters<Fields, 'fields'>
   | RangeFilters<Fields, 'fields'>
+  | ReferenceSearchFilters<Fields, 'fields'>
 
 // TODO: create-contentful-api complained about non-optional fields when initialized with {}
 export type EntriesQueries<Fields extends FieldsType> =

--- a/lib/types/query/reference.ts
+++ b/lib/types/query/reference.ts
@@ -1,0 +1,13 @@
+import { EntryFields } from '../entry'
+import { ConditionalPick } from 'type-fest'
+
+type SupportedTypes = EntryFields.EntryLink<any>
+
+/**
+ * @desc search on references
+ * @see [Documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/search-on-references}
+ */
+export type ReferenceSearchFilters<Fields, Prefix extends string> = {
+  [FieldName in keyof ConditionalPick<Fields, SupportedTypes> as `${Prefix}.${string &
+    FieldName}.${string}`]?: any
+}

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -143,3 +143,17 @@ expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
   content_type: 'id',
   'fields.unknownField[within]': [0, 1, 2, 3],
 })
+
+// search on references
+
+expectNotAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+  'fields.referenceField.sys.contentType.sys.id': 'id',
+})
+expectAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+  content_type: 'id',
+  'fields.referenceField.sys.contentType.sys.id': 'id',
+})
+expectNotAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+  content_type: 'id',
+  'fields.unknownField.sys.contentType.sys.id': 'id',
+})

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { EntriesQueries, EntryFields } from '../../lib'
+import { EntriesQueries, EntryFields, EntryLink, FieldsType } from '../../lib'
 import { EntryFieldsQueries } from '../../lib/types/query/query'
 import { BLOCKS } from '@contentful/rich-text-types'
 
@@ -124,6 +124,18 @@ expectAssignable<Required<EntryFieldsQueries<{ arrayStringField: EntryFields.Arr
   'fields.arrayStringField': stringValue,
   'fields.arrayStringField[ne]': stringValue,
   'fields.arrayStringField[match]': stringValue,
+})
+
+/*
+ * EntryFields: Type Reference
+ */
+expectAssignable<
+  Required<EntryFieldsQueries<{ referenceField: EntryFields.EntryLink<FieldsType> }>>
+>({
+  select: ['fields.referenceField'],
+  'fields.referenceField[exists]': booleanValue,
+  'fields.referenceField.sys.contentType.sys.id': stringValue,
+  'fields.referenceField.fields.numberField': numberValue,
 })
 
 /*


### PR DESCRIPTION
## Summary

Add [search on references](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/search-on-references) to the query types. To not completely overload TypeScript with filters for nested entries, the specific paths are not checked in detail.
