### PR TITLE
fix: add proper type for TagQueries [DANTE-867]

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -25,7 +25,7 @@ import {
   Entry,
   EntryCollection,
 } from './types'
-import { EntryQueries } from './types/query/query'
+import { EntryQueries, TagQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
@@ -234,8 +234,7 @@ interface BaseClient {
    * const response = await client.getTags()
    * console.log(response.items)
    */
-  // TODO type query
-  getTags(query?: any): Promise<TagCollection>
+  getTags(query?: TagQueries): Promise<TagCollection>
 
   /**
    * Creates an asset key for signing asset URLs (Embargoed Assets)

--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,2 +1,2 @@
-export { type AssetQueries, type EntriesQueries } from './query'
+export { type AssetQueries, type EntriesQueries, type TagQueries } from './query'
 export { type FieldsType } from './util'

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -9,6 +9,7 @@ import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } fro
 import { SubsetFilters } from './subset'
 import { FieldsType } from './util'
 import { ReferenceSearchFilters } from './reference'
+import { TagSys } from '../sys'
 
 type FixedPagedOptions = {
   skip?: number
@@ -43,7 +44,6 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
   | RangeFilters<Fields, 'fields'>
   | ReferenceSearchFilters<Fields, 'fields'>
 
-// TODO: create-contentful-api complained about non-optional fields when initialized with {}
 export type EntriesQueries<Fields extends FieldsType> =
   | (EntryFieldsQueries<Fields> & { content_type: string })
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
@@ -67,3 +67,14 @@ export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields>
   SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
   FixedQueryOptions &
   FixedPagedOptions & { mimetype_group?: AssetMimeType } & { order?: string }
+
+type TagName = { name: string }
+
+export type TagQueries =
+  | ExistenceFilter<TagName, ''>
+  | EqualityFilter<TagName, ''>
+  | InequalityFilter<TagName, ''>
+  | FullTextSearchFilters<TagName, ''>
+  | SubsetFilters<TagName, ''>
+  | (SysQueries<Pick<TagSys, 'createdAt' | 'updatedAt' | 'visibility' | 'id' | 'type'>> &
+      FixedPagedOptions & { order?: string })

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -68,13 +68,15 @@ export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields>
   FixedQueryOptions &
   FixedPagedOptions & { mimetype_group?: AssetMimeType } & { order?: string }
 
-type TagName = { name: string }
+export type TagNameFilters = {
+  'name[exists]'?: boolean
+  name?: string
+  'name[ne]'?: string
+  'name[match]'?: string
+  'name[in]'?: string
+  'name[nin]'?: string
+}
 
-export type TagQueries =
-  | ExistenceFilter<TagName, ''>
-  | EqualityFilter<TagName, ''>
-  | InequalityFilter<TagName, ''>
-  | FullTextSearchFilters<TagName, ''>
-  | SubsetFilters<TagName, ''>
-  | (SysQueries<Pick<TagSys, 'createdAt' | 'updatedAt' | 'visibility' | 'id' | 'type'>> &
-      FixedPagedOptions & { order?: string })
+export type TagQueries = TagNameFilters &
+  SysQueries<Pick<TagSys, 'createdAt' | 'updatedAt' | 'visibility' | 'id' | 'type'>> &
+  FixedPagedOptions & { order?: string }

--- a/lib/types/sys.ts
+++ b/lib/types/sys.ts
@@ -1,5 +1,5 @@
 import { EntryFields } from './entry'
-import { SpaceLink, EnvironmentLink } from './link'
+import { SpaceLink, EnvironmentLink, UserLink } from './link'
 
 export interface BaseSys {
   type: string
@@ -13,4 +13,15 @@ export interface EntitySys extends BaseSys {
   space: { sys: SpaceLink }
   environment: { sys: EnvironmentLink }
   locale?: string
+}
+
+export interface TagSys extends BaseSys {
+  createdAt: EntryFields.Date
+  updatedAt: EntryFields.Date
+  version: number
+  space: { sys: SpaceLink }
+  environment: { sys: EnvironmentLink }
+  createdBy: { sys: UserLink }
+  updatedBy: { sys: UserLink }
+  visibility: string
 }

--- a/test/integration/getTags.test.ts
+++ b/test/integration/getTags.test.ts
@@ -8,11 +8,9 @@ if (process.env.API_INTEGRATION_TESTS) {
 
 const client = contentful.createClient(params)
 
-describe.only('getTags', () => {
+describe('getTags', () => {
   it('returns all tags when no filters are available', async () => {
     const response = await client.getTags()
-
-    console.dir(response, { depth: null })
 
     expect(response.items[0].sys.type).toBe('Tag')
   })
@@ -21,42 +19,42 @@ describe.only('getTags', () => {
     it('gets the tag with the name equals to the provided value', async () => {
       const response = await client.getTags({ name: 'public tag 1' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].name).toEqual('public tag 1')
     })
 
     it('gets the tag with the name not equals to the provided value', async () => {
       const response = await client.getTags({ 'name[ne]': 'public tag 1' })
 
-      expect(response.items.length).toBe(0)
+      expect(response.items).toHaveLength(0)
       expect(response.items).toEqual([])
     })
 
     it('gets the tags with the name matching to the provided value', async () => {
       const response = await client.getTags({ 'name[match]': 'public tag' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].name).toEqual('public tag 1')
     })
 
     it('gets the tags with the name in the list of the provided value', async () => {
       const response = await client.getTags({ 'name[in]': 'public tag,public tag 1' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].name).toEqual('public tag 1')
     })
 
     it('gets the tags with the name not in the list of the provided value', async () => {
       const response = await client.getTags({ 'name[nin]': 'public tag,public tag 1' })
 
-      expect(response.items.length).toBe(0)
+      expect(response.items).toHaveLength(0)
       expect(response.items).toEqual([])
     })
 
     it('gets the tags with the name exists', async () => {
       const response = await client.getTags({ 'name[exists]': true })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].name).toEqual('public tag 1')
     })
   })
@@ -65,35 +63,35 @@ describe.only('getTags', () => {
     it('can filter by id', async () => {
       const response = await client.getTags({ 'sys.id': 'publicTag1' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].sys.id).toEqual('publicTag1')
     })
 
     it('can filter by createdAt', async () => {
       const response = await client.getTags({ 'sys.createdAt': '2021-02-11T14:44:48.594Z' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].sys.id).toEqual('publicTag1')
     })
 
     it('can filter by updateAt', async () => {
       const response = await client.getTags({ 'sys.updatedAt': '2021-02-11T14:44:48.594Z' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].sys.id).toEqual('publicTag1')
     })
 
     it('can filter by visibility', async () => {
       const response = await client.getTags({ 'sys.visibility': 'private' })
 
-      expect(response.items.length).toBe(0)
+      expect(response.items).toHaveLength(0)
       expect(response.items).toEqual([])
     })
 
     it('can filter by type', async () => {
       const response = await client.getTags({ 'sys.type': 'Tag' })
 
-      expect(response.items.length).toBe(1)
+      expect(response.items).toHaveLength(1)
       expect(response.items[0].sys.id).toEqual('publicTag1')
     })
   })

--- a/test/integration/getTags.test.ts
+++ b/test/integration/getTags.test.ts
@@ -1,0 +1,100 @@
+import * as contentful from '../../lib/contentful'
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe.only('getTags', () => {
+  it('returns all tags when no filters are available', async () => {
+    const response = await client.getTags()
+
+    console.dir(response, { depth: null })
+
+    expect(response.items[0].sys.type).toBe('Tag')
+  })
+
+  describe('tagName filters', () => {
+    it('gets the tag with the name equals to the provided value', async () => {
+      const response = await client.getTags({ name: 'public tag 1' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].name).toEqual('public tag 1')
+    })
+
+    it('gets the tag with the name not equals to the provided value', async () => {
+      const response = await client.getTags({ 'name[ne]': 'public tag 1' })
+
+      expect(response.items.length).toBe(0)
+      expect(response.items).toEqual([])
+    })
+
+    it('gets the tags with the name matching to the provided value', async () => {
+      const response = await client.getTags({ 'name[match]': 'public tag' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].name).toEqual('public tag 1')
+    })
+
+    it('gets the tags with the name in the list of the provided value', async () => {
+      const response = await client.getTags({ 'name[in]': 'public tag,public tag 1' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].name).toEqual('public tag 1')
+    })
+
+    it('gets the tags with the name not in the list of the provided value', async () => {
+      const response = await client.getTags({ 'name[nin]': 'public tag,public tag 1' })
+
+      expect(response.items.length).toBe(0)
+      expect(response.items).toEqual([])
+    })
+
+    it('gets the tags with the name exists', async () => {
+      const response = await client.getTags({ 'name[exists]': true })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].name).toEqual('public tag 1')
+    })
+  })
+
+  describe('sys filters', () => {
+    it('can filter by id', async () => {
+      const response = await client.getTags({ 'sys.id': 'publicTag1' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].sys.id).toEqual('publicTag1')
+    })
+
+    it('can filter by createdAt', async () => {
+      const response = await client.getTags({ 'sys.createdAt': '2021-02-11T14:44:48.594Z' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].sys.id).toEqual('publicTag1')
+    })
+
+    it('can filter by updateAt', async () => {
+      const response = await client.getTags({ 'sys.updatedAt': '2021-02-11T14:44:48.594Z' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].sys.id).toEqual('publicTag1')
+    })
+
+    it('can filter by visibility', async () => {
+      const response = await client.getTags({ 'sys.visibility': 'private' })
+
+      expect(response.items.length).toBe(0)
+      expect(response.items).toEqual([])
+    })
+
+    it('can filter by type', async () => {
+      const response = await client.getTags({ 'sys.type': 'Tag' })
+
+      expect(response.items.length).toBe(1)
+      expect(response.items[0].sys.id).toEqual('publicTag1')
+    })
+  })
+})

--- a/test/types/queries/tag-queries.test-d.ts
+++ b/test/types/queries/tag-queries.test-d.ts
@@ -1,0 +1,35 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { TagQueries } from '../../../lib'
+
+const dateFilter = '2023-03-03T09:18:16.329Z'
+const tagId = 'tagId'
+const userId = 'userId'
+
+// Tag sys queries
+expectAssignable<TagQueries>({ 'sys.id': tagId })
+
+expectAssignable<TagQueries>({ 'sys.createdAt': dateFilter })
+
+expectAssignable<TagQueries>({ 'sys.updatedAt': dateFilter })
+
+expectAssignable<TagQueries>({ 'sys.visibility': 'private' })
+
+expectAssignable<TagQueries>({ 'sys.type': 'Tag' })
+
+expectNotAssignable<TagQueries>({ 'sys.createdBy': userId })
+
+expectNotAssignable<TagQueries>({ 'sys.updatedBy': userId })
+
+expectNotAssignable<TagQueries>({ 'sys.version': 2 })
+
+expectNotAssignable<TagQueries>({ 'sys.revision': 2 })
+
+// Tag fixed Query filters
+
+expectAssignable<TagQueries>({ skip: 1 })
+
+expectAssignable<TagQueries>({ limit: 1 })
+
+expectAssignable<TagQueries>({ order: 'sys.updatedAt' })
+
+expectNotAssignable<TagQueries>({ locale: 'en' })

--- a/test/types/query-types/tagName.test-d.ts
+++ b/test/types/query-types/tagName.test-d.ts
@@ -1,0 +1,49 @@
+import { expectAssignable, expectNotAssignable } from 'tsd'
+import { TagNameFilters } from '../../../lib/types/query/query'
+
+const booleanValue = false
+const stringValue = ''
+const rangeString = 'test1,test2'
+
+expectAssignable<TagNameFilters>({
+  'name[exists]': booleanValue,
+})
+
+expectAssignable<TagNameFilters>({
+  name: stringValue,
+})
+
+expectAssignable<TagNameFilters>({
+  'name[match]': stringValue,
+})
+
+expectAssignable<TagNameFilters>({
+  'name[ne]': stringValue,
+})
+
+expectAssignable<TagNameFilters>({
+  'name[in]': rangeString,
+})
+
+expectAssignable<TagNameFilters>({
+  'name[nin]': rangeString,
+})
+
+expectNotAssignable<TagNameFilters>({
+  'name[near]': rangeString,
+})
+
+expectNotAssignable<TagNameFilters>({
+  'name[within]': rangeString,
+})
+
+expectNotAssignable<TagNameFilters>({
+  select: ['name'],
+})
+
+expectNotAssignable<TagNameFilters>({
+  'name[lt]': stringValue,
+  'name[lte]': stringValue,
+  'name[gt]': stringValue,
+  'name[gte]': stringValue,
+})


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

One of the TODOS is to properly type the tagQuery filters, this PR addresses that.
