### PR TITLE
chore: chain-specific behavior in sync [DANTE-870]

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,7 @@ The configuration options belong to two categories: request config and response 
 ##### Response configuration options
 
 > :warning: **Response config options** are in the process of being **deprecated** (`v10.0.0`).
-> They still work for the `sync` method.
-> The `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset` methods already use the new [Chained Clients](#chained-clients) approach.
+> The `sync`, `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset` methods already use the new [Chained Clients](#chained-clients) approach.
 
 | Name                          | Default | Description                                         |
 | ----------------------------- | ------- | --------------------------------------------------- |
@@ -262,7 +261,7 @@ The configuration options belong to two categories: request config and response 
 
 > Introduced in `v10.0.0`.
 
-The contentful.js library returns calls to `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset` in different shapes, depending on the configurations listed in the respective sections below.
+The contentful.js library returns calls to `sync`, `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset` in different shapes, depending on the configurations listed in the respective sections below.
 
 In order to provide type support for each configuration, we provide the possibility to chain modifiers to the Contentful client, providing the correct return types corresponding to the used modifiers.
 
@@ -277,7 +276,7 @@ When initialising a client, you will receive an instance of the [`DefaultClient`
 | _none (default)_           | Returns entries in a single locale. Resolvable linked entries will be inlined while unresolvable links will be kept as link objects. [Read more on link resolution](ADVANCED.md#link-resolution) |
 | `withAllLocales`           | Returns entries in all locales.                                                                                                                                                                  |
 | `withoutLinkResolution`    | All linked entries will be rendered as link objects. [Read more on link resolution](ADVANCED.md#link-resolution)                                                                                 |
-| `withoutUnresolvableLinks` | If linked entries are not resolvalbe, the corresponding link objects are removed from the response.                                                                                              |
+| `withoutUnresolvableLinks` | If linked entries are not resolvable, the corresponding link objects are removed from the response.                                                                                              |
 
 ##### Example
 
@@ -453,6 +452,26 @@ The default behaviour doesn't change, you can still do:
 // returns assets in one locale
 const assets = await client.getAssets()
 ```
+
+#### Sync
+
+The Sync API always retrieves all localized content, therefore `withAllLocales` is accepted, but ignored.
+
+| Chain                      | Modifier                                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| _none (default)_           | Returns content in all locales.                                                                              |
+| `withoutLinkResolution`    | Linked content will be rendered as link objects. [Read more on link resolution](ADVANCED.md#link-resolution) |
+| `withoutUnresolvableLinks` | If linked content is not resolvable, the corresponding link objects are removed from the response.           |
+
+##### Example
+
+```js
+// returns content in all locales, resolves linked entries, removing unresolvable links
+const { entries, assets, deletedEntries, deletedAssets } =
+  await client.withoutUnresolvableLinks.sync({ initial: true })
+```
+
+More information on behavior of the Sync API can be found in [the sync section in ADVANCED.md](ADVANCED.md#sync)
 
 ### Reference documentation
 

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -241,7 +241,7 @@ The return type of `getEntry` is matching the `fields` shape
 
 #### Limitation
 
-The different response types are determined based on [client chains](./README.md#chained-clients). So far, these are implemented for `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset`. Other methods returning entries (e.g. `sync`) or methods that can have localized responses still rely on the previous implementation, and might not always have correct response types.
+The different response types are determined based on [client chains](./README.md#chained-clients). So far, these are implemented for `sync`, `parseEntries`, `getEntries`, `getEntry`, `getAssets` and `getAsset`. Other methods returning entries or methods that can have localized responses still rely on the previous implementation, and might not always have correct response types.
 
 ## Generating type definitions for content types
 

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -25,6 +25,7 @@ import {
   Entry,
   EntryCollection,
   SyncQuery,
+  SyncOptions,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
@@ -575,10 +576,9 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     })
   }
 
-  async function sync(query = {}, options = { paginate: true }) {
-    const { resolveLinks, removeUnresolved } = getGlobalOptions(query)
+  async function sync(query: SyncQuery, options: SyncOptions = { paginate: true }) {
     switchToEnvironment(http)
-    return pagedSync(http, query, { resolveLinks, removeUnresolved, ...options })
+    return pagedSync(http, query, options)
   }
 
   function parseEntries<Fields extends FieldsType = FieldsType>(data) {

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -24,13 +24,14 @@ import {
   TagCollection,
   Entry,
   EntryCollection,
+  SyncQuery,
 } from './types'
 import { EntryQueries } from './types/query/query'
 import { FieldsType } from './types/query/util'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
 import validateTimestamp from './utils/validate-timestamp'
-import { ChainOption, ChainOptions } from './utils/client-helpers'
+import { ChainModifiers, ChainOption, ChainOptions } from './utils/client-helpers'
 import { validateLocaleParam, validateResolveLinksParam } from './utils/validate-params'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
@@ -245,7 +246,13 @@ interface BaseClient {
    * })
    * ```
    */
-  sync(query: any): Promise<SyncCollection>
+  sync<
+    Fields extends FieldsType = FieldsType,
+    Modifiers extends ChainModifiers = ChainModifiers,
+    Locales extends LocaleCode = LocaleCode
+  >(
+    query: SyncQuery
+  ): Promise<SyncCollection<Fields, Modifiers, Locales>>
 
   /**
    * Gets a Tag

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -576,9 +576,32 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     })
   }
 
-  async function sync(query: SyncQuery, options: SyncOptions = { paginate: true }) {
+  async function sync<Fields extends FieldsType = FieldsType>(
+    query: SyncQuery,
+    syncOptions: SyncOptions = { paginate: true }
+  ) {
+    return makePagedSync<Fields>(query, syncOptions, options)
+  }
+
+  async function makePagedSync<Fields extends FieldsType = FieldsType>(
+    query: SyncQuery,
+    syncOptions: SyncOptions,
+    options: ChainOptions = {
+      withAllLocales: false,
+      withoutLinkResolution: false,
+      withoutUnresolvableLinks: false,
+    }
+  ) {
+    const combinedOptions = {
+      ...syncOptions,
+      ...options,
+    }
     switchToEnvironment(http)
-    return pagedSync(http, query, options)
+    return pagedSync<Fields, any, Extract<ChainOptions, typeof options>>(
+      http,
+      query,
+      combinedOptions
+    )
   }
 
   function parseEntries<Fields extends FieldsType = FieldsType>(data) {

--- a/lib/paged-sync.ts
+++ b/lib/paged-sync.ts
@@ -34,7 +34,7 @@ export default async function pagedSync<
 >(
   http: AxiosInstance,
   query: SyncQuery,
-  options: SyncOptions & ChainOptions
+  options?: SyncOptions | ChainOptions
 ): Promise<SyncCollection<Fields, ModifiersFromOptions<Options>, Locales>> {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error(
@@ -55,6 +55,7 @@ export default async function pagedSync<
     withoutUnresolvableLinks: false,
     paginate: true,
   }
+
   const { withoutLinkResolution, withoutUnresolvableLinks, paginate } = {
     ...defaultOptions,
     ...options,

--- a/lib/paged-sync.ts
+++ b/lib/paged-sync.ts
@@ -5,55 +5,39 @@
 import resolveResponse from 'contentful-resolve-response'
 import { AxiosInstance, createRequestConfig, freezeSys, toPlainObject } from 'contentful-sdk-core'
 import mixinStringifySafe from './mixins/stringify-safe'
-import { SyncCollection } from './types'
-
-/**
- * @memberof Sync
- * @typedef SyncCollection
- * @prop {Array<Entities.Entry>} entries - All existing entries on first sync. New and updated entries on subsequent syncs.
- * @prop {Array<Entities.Asset>} assets - All existing assets on first sync. New and updated assets on subsequent syncs.
- * @prop {Array<Sync.DeletedEntry>} deletedEntries - List of deleted Entries since last sync
- * @prop {Array<Sync.DeletedAsset>} deletedAssets - List of deleted Assets since last sync
- * @prop {string} nextSyncToken - Token to be sent to the next sync call
- * @prop {function(): Object} toPlainObject() - Returns this Sync collection as a plain JS object
- * @prop {function(?function=, space=): Object} stringifySafe(replacer,space) - Stringifies the Sync collection, accounting for circular references. Circular references will be replaced with just a Link object, with a <code>circular</code> property set to <code>true</code>. See <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify">MDN</a> and <a href="https://www.npmjs.com/package/json-stringify-safe">json-stringify-safe</a> for more details on the arguments this method can take.
- */
-
-/**
- * Deleted Entries are the same as Entries, but only appear on the sync API.
- * @memberof Sync
- * @typedef DeletedEntry
- * @type Entities.Entry
- */
-
-/**
- * Deleted Assets are the same as Assets, but only appear on the sync API.
- * @memberof Sync
- * @typedef DeletedAsset
- * @type Entities.Asset
- */
+import {
+  SyncPageQuery,
+  SyncResponse,
+  SyncPageResponse,
+  SyncCollection,
+  SyncOptions,
+  SyncEntities,
+  SyncQuery,
+} from './types'
 
 /**
  * This module retrieves all the available pages for a sync operation
  * @private
- * @param {Object} http - HTTP client
- * @param {Object} query - Query object
- * @param {Object} options - Sync options object
- * @param {boolean} [options.resolveLinks = true] - If links should be resolved
- * @param {boolean} [options.removeUnresolved = false] - If unresolvable links should get removed
+ * @param {AxiosInstance} http - HTTP client
+ * @param {SyncQuery} query - Query object
+ * @param {SyncOptions} options - Sync options object
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
  * @return {Promise<SyncCollection>}
  */
-export default async function pagedSync(http: AxiosInstance, query, options = {}) {
+export default async function pagedSync(
+  http: AxiosInstance,
+  query: SyncQuery,
+  options: SyncOptions
+): Promise<SyncCollection> {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error(
       'Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing'
     )
   }
 
-  if (query && query.content_type && !query.type) {
+  if (query['content_type'] && !query.type) {
     query.type = 'Entry'
-  } else if (query && query.content_type && query.type && query.type !== 'Entry') {
+  } else if (query['content_type'] && query.type && query.type !== 'Entry') {
     throw new Error(
       'When using the `content_type` filter your `type` parameter cannot be different from `Entry`.'
     )
@@ -90,7 +74,7 @@ export default async function pagedSync(http: AxiosInstance, query, options = {}
 
 /**
  * @private
- * @param {Array<Entities.Entry|Entities.Array|Sync.DeletedEntry|Sync.DeletedAsset>} items
+ * @param {Array<Entry|Array|DeletedEntry|DeletedAsset>} items
  * @return {Object} Entities mapped to an object for each entity type
  */
 function mapResponseItems(items): any {
@@ -111,6 +95,22 @@ function mapResponseItems(items): any {
   }
 }
 
+function createRequestQuery(originalQuery: SyncPageQuery): SyncPageQuery {
+  if (originalQuery.nextPageToken) {
+    return { sync_token: originalQuery.nextPageToken }
+  }
+
+  if (originalQuery.nextSyncToken) {
+    return { sync_token: originalQuery.nextSyncToken }
+  }
+
+  if (originalQuery.sync_token) {
+    return { sync_token: originalQuery.sync_token }
+  }
+
+  return originalQuery
+}
+
 /**
  * If the response contains a nextPageUrl, extracts the sync token to get the
  * next page and calls itself again with that token.
@@ -119,48 +119,41 @@ function mapResponseItems(items): any {
  * On each call of this function, any retrieved items are collected in the
  * supplied items array, which gets returned in the end
  * @private
- * @param {Object} http
- * @param {Array<Entities.Entry|Entities.Array|Sync.DeletedEntry|Sync.DeletedAsset>} items
- * @param {Object} query
- * @param {Object} options - Sync page options object
+ * @param {AxiosInstance} http
+ * @param {Array<Entry|Asset|DeletedEntry|DeletedAsset>} items
+ * @param {SyncPageQuery} query
+ * @param {SyncOptions} options - Sync page options object
  * @param {boolean} [options.paginate = true] - If further sync pages should automatically be crawled
- * @return {Promise<{items: Array, nextSyncToken: string}>}
+ * @return {Promise<SyncPageResponse>}
  */
-async function getSyncPage(http: AxiosInstance, items, query, { paginate }) {
-  if (query.nextSyncToken) {
-    query.sync_token = query.nextSyncToken
-    delete query.nextSyncToken
-  }
+async function getSyncPage(
+  http: AxiosInstance,
+  items: SyncEntities[],
+  query: SyncPageQuery,
+  { paginate }: SyncOptions
+): Promise<SyncPageResponse> {
+  const requestQuery = createRequestQuery(query)
 
-  if (query.nextPageToken) {
-    query.sync_token = query.nextPageToken
-    delete query.nextPageToken
-  }
+  const response = await http.get<SyncResponse>(
+    'sync',
+    createRequestConfig({ query: requestQuery })
+  )
 
-  if (query.sync_token) {
-    delete query.initial
-    delete query.type
-    delete query.content_type
-    delete query.limit
-  }
-
-  // Todo: better type sync response (SyncCollection)
-  const response = await http.get<any>('sync', createRequestConfig({ query: query }))
   const data = response.data || {}
   items = items.concat(data.items || [])
   if (data.nextPageUrl) {
     if (paginate) {
-      delete query.initial
-      query.sync_token = getToken(data.nextPageUrl)
-      return getSyncPage(http, items, query, { paginate })
+      delete requestQuery.initial
+      requestQuery.sync_token = getToken(data.nextPageUrl)
+      return getSyncPage(http, items, requestQuery, { paginate })
     }
     return {
-      items: items,
+      items,
       nextPageToken: getToken(data.nextPageUrl),
     }
   } else if (data.nextSyncUrl) {
     return {
-      items: items,
+      items,
       nextSyncToken: getToken(data.nextSyncUrl),
     }
   } else {
@@ -172,7 +165,7 @@ async function getSyncPage(http: AxiosInstance, items, query, { paginate }) {
  * Extracts token out of an url
  * @private
  */
-function getToken(url) {
+function getToken(url: string) {
   const urlParts = url.split('?')
   return urlParts.length > 0 ? urlParts[1].replace('sync_token=', '') : ''
 }

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -6,7 +6,7 @@ import { LocaleCode } from './locale'
 import { ChainModifiers } from '../utils/client-helpers'
 
 export type SyncOptions = {
-  paginate: boolean
+  paginate?: boolean
 }
 
 export type SyncQuery = {

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -67,5 +67,6 @@ export interface SyncCollection<
   >
   deletedEntries: Array<DeletedEntry>
   deletedAssets: Array<DeletedAsset>
-  nextSyncToken: string
+  nextSyncToken?: string
+  nextPageToken?: string
 }

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -5,18 +5,33 @@ import { FieldsType } from './query'
 import { LocaleCode } from './locale'
 import { ChainModifiers } from '../utils/client-helpers'
 
-export type SyncQuery =
-  | ({ initial: true; limit?: number } & (
-      | {
-          type?: 'Asset' | 'Entry' | 'Deletion' | 'DeletedAsset' | 'DeletedEntry'
-        }
-      | {
-          content_type: string
-          type?: 'Entry'
-        }
-    ))
-  | { nextSyncToken: string }
-  | { nextPageToken: string }
+export type SyncOptions = {
+  paginate: boolean
+}
+
+export type SyncQuery = {
+  initial?: true
+  limit?: number
+  nextSyncToken?: string
+  nextPageToken?: string
+} & (
+  | { type: 'Entry'; content_type: string }
+  | { type?: 'Asset' | 'Entry' | 'Deletion' | 'DeletedAsset' | 'DeletedEntry' }
+)
+
+export type SyncPageQuery = SyncQuery & { sync_token?: string }
+
+export type SyncResponse = {
+  nextPageUrl?: string
+  nextSyncUrl?: string
+  items: SyncEntities[]
+}
+
+export type SyncPageResponse = {
+  nextPageToken?: string
+  nextSyncToken?: string
+  items: SyncEntities[]
+}
 
 export type DeletedEntry = {
   sys: EntitySys & { type: 'DeletedEntry' }
@@ -25,6 +40,8 @@ export type DeletedEntry = {
 export type DeletedAsset = {
   sys: EntitySys & { type: 'DeletedAsset' }
 }
+
+export type SyncEntities = Entry | Asset | DeletedEntry | DeletedAsset
 
 export interface SyncCollection<
   Fields extends FieldsType = FieldsType,

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -1,10 +1,54 @@
 import { Asset } from './asset'
 import { Entry } from './entry'
+import { EntitySys } from './sys'
+import { FieldsType } from './query'
+import { LocaleCode } from './locale'
+import { ChainModifiers } from '../utils/client-helpers'
 
-export interface SyncCollection {
-  entries: Array<Entry>
-  assets: Array<Asset>
-  deletedEntries: Array<Entry>
-  deletedAssets: Array<Asset>
+export type SyncQuery =
+  | ({ initial: true; limit?: number } & (
+      | {
+          type?: 'Asset' | 'Entry' | 'Deletion' | 'DeletedAsset' | 'DeletedEntry'
+        }
+      | {
+          content_type: string
+          type?: 'Entry'
+        }
+    ))
+  | { nextSyncToken: string }
+  | { nextPageToken: string }
+
+export type DeletedEntry = {
+  sys: EntitySys & { type: 'DeletedEntry' }
+}
+
+export type DeletedAsset = {
+  sys: EntitySys & { type: 'DeletedAsset' }
+}
+
+export interface SyncCollection<
+  Fields extends FieldsType = FieldsType,
+  Modifiers extends ChainModifiers = ChainModifiers,
+  Locales extends LocaleCode = LocaleCode
+> {
+  entries: Array<
+    Entry<
+      Fields,
+      ChainModifiers extends Modifiers
+        ? ChainModifiers
+        : Exclude<Modifiers, undefined> | 'WITH_ALL_LOCALES',
+      Locales
+    >
+  >
+  assets: Array<
+    Asset<
+      ChainModifiers extends Modifiers
+        ? ChainModifiers
+        : Exclude<Modifiers, undefined> | 'WITH_ALL_LOCALES',
+      Locales
+    >
+  >
+  deletedEntries: Array<DeletedEntry>
+  deletedAssets: Array<DeletedAsset>
   nextSyncToken: string
 }

--- a/test/integration/sync.test.ts
+++ b/test/integration/sync.test.ts
@@ -1,0 +1,97 @@
+import * as contentful from '../../lib/contentful'
+import { TypeCatFields } from './parseEntries.test'
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe('Sync API', () => {
+  test('Sync space', async () => {
+    const response = await client.sync({ initial: true })
+    expect(response.entries).toBeDefined()
+    expect(response.assets).toBeDefined()
+    expect(response.deletedEntries).toBeDefined()
+    expect(response.deletedAssets).toBeDefined()
+    expect(response.nextSyncToken).toBeDefined()
+  })
+
+  test('Sync space asset links are resolved', async () => {
+    const response = await client.sync({ initial: true })
+    expect(response.entries).toBeDefined()
+
+    const entryWithImageLink = response.entries.find((entry) => entry.fields && entry.fields.image)
+    expect(entryWithImageLink?.fields?.image['en-US']?.sys?.type).toEqual('Asset')
+  })
+
+  test('Sync space with token', async () => {
+    const response = await client.sync({
+      nextSyncToken:
+        'w5ZGw6JFwqZmVcKsE8Kow4grw45QdybDsm4DWMK6OVYsSsOJwqPDksOVFXUFw54Hw65Tw6MAwqlWw5QkdcKjwqrDlsOiw4zDolvDq8KRRwUVBn3CusK6wpB3w690w6vDtMKkwrHDmsKSwobCuMKww57Cl8OGwp_Dq1QZCA',
+    })
+    expect(response.entries).toBeDefined()
+    expect(response.assets).toBeDefined()
+    expect(response.deletedEntries).toBeDefined()
+    expect(response.deletedAssets).toBeDefined()
+    expect(response.nextSyncToken).toBeDefined()
+  })
+
+  test('Sync spaces assets', async () => {
+    const response = await client.sync({ initial: true, type: 'Asset' })
+    expect(response.assets).toBeDefined()
+    expect(response.deletedAssets).toBeDefined()
+    expect(response.nextSyncToken).toBeDefined()
+  })
+
+  test('Sync space entries by content type', async () => {
+    const response = await client.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'dog',
+    })
+    expect(response.entries).toBeDefined()
+    expect(response.deletedEntries).toBeDefined()
+    expect(response.nextSyncToken).toBeDefined()
+  })
+
+  test('Sync has withoutUnresolvableLinks modifier', async () => {
+    const response = await client.withoutUnresolvableLinks.sync<TypeCatFields>({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    expect(response.entries[0].fields).toBeDefined()
+    expect(response.entries[0].fields.bestFriend).toEqual({})
+  })
+
+  test('Sync ignores withAllLocales modifier', async () => {
+    const responseWithLocales = await client.withAllLocales.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    const responseWithoutLocales = await client.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    expect(responseWithLocales).toStrictEqual(responseWithoutLocales)
+  })
+
+  test('Sync has withoutLinkResolution modifier', async () => {
+    const response = await client.withoutLinkResolution.sync<TypeCatFields>({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    expect(response.entries[0].fields).toBeDefined()
+    expect(response.entries[0].fields.bestFriend?.['en-US']?.sys.type).toEqual('Link')
+  })
+})

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -1,7 +1,7 @@
 import { EntryFields } from '../../lib'
 import * as contentful from '../../lib/contentful'
 import { ValidationError } from '../../lib/utils/validation-error'
-// @ts-ignore
+import { TypeCatFields } from './parseEntries.test'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -599,6 +599,44 @@ describe('Sync API', () => {
     expect(response.deletedEntries).toBeDefined()
     expect(response.nextSyncToken).toBeDefined()
   })
+
+  test('Sync has withoutUnresolvableLinks modifier', async () => {
+    const response = await client.withoutUnresolvableLinks.sync<TypeCatFields>({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    expect(response.entries[0].fields).toBeDefined()
+    expect(response.entries[0].fields.bestFriend).toEqual({})
+  })
+
+  test('Sync ignores withAllLocales modifier', async () => {
+    const responseWithLocales = await client.withAllLocales.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    const responseWithoutLocales = await client.sync({
+      initial: true,
+      type: 'Entry',
+      content_type: 'cat',
+    })
+
+    expect(responseWithLocales).toStrictEqual(responseWithoutLocales)
+  })
+})
+
+test('Sync has withoutLinkResolution modifier', async () => {
+  const response = await client.withoutLinkResolution.sync<TypeCatFields>({
+    initial: true,
+    type: 'Entry',
+    content_type: 'cat',
+  })
+
+  expect(response.entries[0].fields).toBeDefined()
+  expect(response.entries[0].fields.bestFriend?.['en-US']?.sys.type).toEqual('Link')
 })
 
 test('Gets entries with linked includes with all locales using the withAllLocales client chain modifier', async () => {

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -1,7 +1,6 @@
 import { EntryFields } from '../../lib'
 import * as contentful from '../../lib/contentful'
 import { ValidationError } from '../../lib/utils/validation-error'
-import { TypeCatFields } from './parseEntries.test'
 import { localeSpaceParams, params, previewParams } from './utils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -550,93 +549,6 @@ test('Gets tags', async () => {
   const publicTag = response.items.find((tag) => tag.sys.id === 'publicTag1')
   expect(publicTag).toBeDefined()
   expect(publicTag?.name).toEqual('public tag 1')
-})
-
-describe('Sync API', () => {
-  test('Sync space', async () => {
-    const response = await client.sync({ initial: true })
-    expect(response.entries).toBeDefined()
-    expect(response.assets).toBeDefined()
-    expect(response.deletedEntries).toBeDefined()
-    expect(response.deletedAssets).toBeDefined()
-    expect(response.nextSyncToken).toBeDefined()
-  })
-
-  test('Sync space asset links are resolved', async () => {
-    const response = await client.sync({ initial: true })
-    expect(response.entries).toBeDefined()
-
-    const entryWithImageLink = response.entries.find((entry) => entry.fields && entry.fields.image)
-    expect(entryWithImageLink?.fields?.image['en-US']?.sys?.type).toEqual('Asset')
-  })
-
-  test('Sync space with token', async () => {
-    const response = await client.sync({
-      nextSyncToken:
-        'w5ZGw6JFwqZmVcKsE8Kow4grw45QdybDsm4DWMK6OVYsSsOJwqPDksOVFXUFw54Hw65Tw6MAwqlWw5QkdcKjwqrDlsOiw4zDolvDq8KRRwUVBn3CusK6wpB3w690w6vDtMKkwrHDmsKSwobCuMKww57Cl8OGwp_Dq1QZCA',
-    })
-    expect(response.entries).toBeDefined()
-    expect(response.assets).toBeDefined()
-    expect(response.deletedEntries).toBeDefined()
-    expect(response.deletedAssets).toBeDefined()
-    expect(response.nextSyncToken).toBeDefined()
-  })
-
-  test('Sync spaces assets', async () => {
-    const response = await client.sync({ initial: true, type: 'Asset' })
-    expect(response.assets).toBeDefined()
-    expect(response.deletedAssets).toBeDefined()
-    expect(response.nextSyncToken).toBeDefined()
-  })
-
-  test('Sync space entries by content type', async () => {
-    const response = await client.sync({
-      initial: true,
-      type: 'Entry',
-      content_type: 'dog',
-    })
-    expect(response.entries).toBeDefined()
-    expect(response.deletedEntries).toBeDefined()
-    expect(response.nextSyncToken).toBeDefined()
-  })
-
-  test('Sync has withoutUnresolvableLinks modifier', async () => {
-    const response = await client.withoutUnresolvableLinks.sync<TypeCatFields>({
-      initial: true,
-      type: 'Entry',
-      content_type: 'cat',
-    })
-
-    expect(response.entries[0].fields).toBeDefined()
-    expect(response.entries[0].fields.bestFriend).toEqual({})
-  })
-
-  test('Sync ignores withAllLocales modifier', async () => {
-    const responseWithLocales = await client.withAllLocales.sync({
-      initial: true,
-      type: 'Entry',
-      content_type: 'cat',
-    })
-
-    const responseWithoutLocales = await client.sync({
-      initial: true,
-      type: 'Entry',
-      content_type: 'cat',
-    })
-
-    expect(responseWithLocales).toStrictEqual(responseWithoutLocales)
-  })
-})
-
-test('Sync has withoutLinkResolution modifier', async () => {
-  const response = await client.withoutLinkResolution.sync<TypeCatFields>({
-    initial: true,
-    type: 'Entry',
-    content_type: 'cat',
-  })
-
-  expect(response.entries[0].fields).toBeDefined()
-  expect(response.entries[0].fields.bestFriend?.['en-US']?.sys.type).toEqual('Link')
 })
 
 test('Gets entries with linked includes with all locales using the withAllLocales client chain modifier', async () => {

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -1,5 +1,5 @@
 import { AssetKey } from './../../lib/types/asset-key'
-import { TagLink, UserLink } from './../../lib/types/link'
+import { EntryLink, TagLink, UserLink } from './../../lib/types/link'
 import copy from 'fast-copy'
 import {
   Asset,
@@ -45,6 +45,12 @@ const userLinkMock: UserLink = {
   type: 'Link',
   linkType: 'User',
   id: 'myUser',
+}
+
+const entryLinkMock: EntryLink = {
+  type: 'Link',
+  linkType: 'Entry',
+  id: 'myLink',
 }
 
 const tagSysMock: TagSys = {
@@ -205,6 +211,20 @@ const assetKeyMock: AssetKey = {
   secret: '-jE6hqytutc_dygbjShVq0PijvDn80SdT0EWD1mNHgc',
 }
 
+const entryWithLinkMock = {
+  sys: Object.assign(copy(sysMock), {
+    type: 'Entry',
+    contentType: Object.assign(copy(spaceLinkMock), { linkType: 'ContentType' }),
+    locale: 'locale',
+  }),
+  fields: {
+    linked: { sys: entryLinkMock },
+  },
+  metadata: {
+    tags: [],
+  },
+}
+
 const entryWithResourceLinksMock = {
   sys: Object.assign(copy(sysMock), {
     type: 'Entry',
@@ -268,4 +288,5 @@ export {
   tagMock,
   assetKeyMock,
   entryWithResourceLinksMock,
+  entryWithLinkMock,
 }

--- a/test/unit/paged-sync.test.ts
+++ b/test/unit/paged-sync.test.ts
@@ -22,7 +22,7 @@ function createAsset(id, deleted = false): any {
   return asset
 }
 
-describe('paged-sync', () => {
+describe.only('paged-sync', () => {
   let http
 
   beforeEach(() => {
@@ -34,6 +34,7 @@ describe('paged-sync', () => {
   })
 
   test('Rejects with no parameters', async () => {
+    // @ts-ignore
     await expect(pagedSync(http, {}, { resolveLinks: true })).rejects.toEqual(
       new Error(
         'Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing'
@@ -48,6 +49,7 @@ describe('paged-sync', () => {
         {
           initial: true,
           content_type: 'id',
+          // @ts-ignore
           type: 'ContentType',
         },
         { resolveLinks: true }
@@ -65,7 +67,7 @@ describe('paged-sync', () => {
         nextSyncUrl: 'http://nextsyncurl?sync_token=nextsynctoken',
       },
     })
-
+    // @ts-ignore
     const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
     expect(response).toEqual({
       entries: [],
@@ -82,6 +84,7 @@ describe('paged-sync', () => {
   })
   test('Returns empty response if response is empty', async () => {
     http.get.mockResolvedValue({})
+    // @ts-ignore
     const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
     expect(response).toEqual({
       entries: [],
@@ -118,6 +121,7 @@ describe('paged-sync', () => {
       },
     })
 
+    // @ts-ignore
     const response = await pagedSync(http, { initial: true }, { resolveLinks: true })
     expect(http.get.mock.calls[0][1].params.initial).toBeTruthy()
     expect(response.entries).toHaveLength(3)
@@ -139,6 +143,7 @@ describe('paged-sync', () => {
     const response = await pagedSync(
       http,
       { initial: true, content_type: 'cat' },
+      // @ts-ignore
       { resolveLinks: true }
     )
 
@@ -165,6 +170,7 @@ describe('paged-sync', () => {
       },
     })
 
+    // @ts-ignore
     const response = await pagedSync(http, { initial: true, limit: 10 }, { resolveLinks: true })
 
     expect(http.get).toBeCalledWith('sync', {
@@ -219,6 +225,7 @@ describe('paged-sync', () => {
 
     const response = await pagedSync(
       http,
+      // @ts-ignore
       { initial: true, type: 'Entries' },
       { resolveLinks: true }
     )
@@ -275,6 +282,7 @@ describe('paged-sync', () => {
 
     const response = await pagedSync(
       http,
+      // @ts-ignore
       { initial: true, limit: 10, type: 'Entries' },
       { resolveLinks: true }
     )
@@ -313,6 +321,7 @@ describe('paged-sync', () => {
     const response = await pagedSync(
       http,
       { nextSyncToken: 'nextsynctoken' },
+      // @ts-ignore
       { resolveLinks: true }
     )
     expect(http.get.mock.calls[0][1].params.sync_token).toEqual('nextsynctoken')
@@ -360,6 +369,7 @@ describe('paged-sync', () => {
         })
       )
 
+    // @ts-ignore
     const response = await pagedSync(http, { initial: true, type: 'Entries' }, { paginate: false })
     expect(http.get).toHaveBeenCalledTimes(1)
     expect(http.get.mock.calls[0][1].params.initial).toBeDefined()
@@ -368,28 +378,33 @@ describe('paged-sync', () => {
     expect(response.deletedEntries).toHaveLength(0)
     expect(response.assets).toHaveLength(0)
     expect(response.deletedAssets).toHaveLength(0)
+    // @ts-ignore
     expect(response.nextPageToken).toEqual('nextpage1')
     expect(response.nextSyncToken).toBeUndefined()
 
     // Manually sync next page
     const response2 = await pagedSync(
       http,
+      // @ts-ignore
       { nextPageToken: response.nextPageToken },
       { paginate: false }
     )
     expect(http.get).toHaveBeenCalledTimes(2)
     expect(http.get.mock.calls[1][1].params.initial).toBeUndefined()
+    // @ts-ignore
     expect(response2.nextPageToken).toEqual('nextpage2')
     expect(response2.nextSyncToken).toBeUndefined()
 
     // Manually sync next (last) page
     const response3 = await pagedSync(
       http,
+      // @ts-ignore
       { nextPageToken: response2.nextPageToken },
       { paginate: false }
     )
     expect(http.get).toHaveBeenCalledTimes(3)
     expect(http.get.mock.calls[2][1].params.initial).toBeUndefined()
+    // @ts-ignore
     expect(response3.nextPageToken).toBeUndefined()
     expect(response3.nextSyncToken).toEqual('nextsynctoken')
   })


### PR DESCRIPTION
The `sync` method no longer uses global options, but now accepts client chains of `withoutLinkResolution` and `withoutUnresolvableLinks` to get different return shape from the API depending on `resolveLinks` and `removeUnresolved`, similar to `getEntry` and `getEntries`. Tests and documentation have been updated to reflect the changes.