### PR TITLE
fix: move getEntry tests from tests.test.ts to getEntry.test.ts [DANTE-867]

### DIFF
--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -1,5 +1,7 @@
 import * as contentful from '../../lib/contentful'
+// @ts-ignore
 import { localeSpaceParams, params, previewParams } from './utils'
+import { EntryFields } from '../../lib'
 
 if (process.env.API_INTEGRATION_TESTS) {
   params.host = '127.0.0.1:5000'
@@ -10,14 +12,12 @@ const client = contentful.createClient(params)
 const previewClient = contentful.createClient(previewParams)
 const localeClient = contentful.createClient(localeSpaceParams)
 
-// TODO:
-// expand to cover also previewClient and localeClient
 describe('getEntry via chained clients', () => {
   const entryWithUnresolvableLink = '4SEhTg8sYJ1H3wDAinzhTp'
   const entryWithResolvableLink = 'nyancat'
 
   describe('default client', () => {
-    test('client', async () => {
+    test('Gets an entry with the correct ID', async () => {
       const response = await client.getEntry(entryWithResolvableLink, {
         include: 2,
       })
@@ -26,17 +26,89 @@ describe('getEntry via chained clients', () => {
       expect(response.fields.color).toBe('rainbow')
       expect(response.fields.color['en-US']).not.toBeDefined()
     })
+
+    test('Gets an entry with a specific locale', async () => {
+      const entry = await client.getEntry<{ test: EntryFields.Symbol }>(entryWithResolvableLink, {
+        locale: 'tlh',
+      })
+      expect(entry.sys.locale).toBe('tlh')
+    })
+
+    test('Get entry fails if entryId does not exist', async () => {
+      await expect(client.getEntry('nyancatblah')).rejects.toThrow()
+    })
+
+    test('Get entry fails if an entryId is not passed', async () => {
+      // @ts-ignore
+      await expect(client.getEntry()).rejects.toThrow()
+    })
+
+    test('Gets entry with link resolution', async () => {
+      const response = await client.getEntry(entryWithResolvableLink, { include: 2 })
+
+      expect(response.fields.bestFriend.sys.type).toEqual('Entry')
+      expect(response.fields.bestFriend.fields).toBeDefined()
+    })
+
+    test('Gets entry with link resolution and includes, does not consider global `removeUnresolved` option', async () => {
+      const removeUnresolvedClient = contentful.createClient({
+        ...params,
+        removeUnresolved: true,
+      })
+      const response = await removeUnresolvedClient.getEntry(entryWithUnresolvableLink, {
+        include: 2,
+      })
+      expect(response.fields).toBeDefined()
+      expect(response.fields.bestFriend).toMatchObject({
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '6SiPbntBPYYjnVHmipxJBF',
+        },
+      })
+    })
+
+    test('Gets an entry that has resource links', async () => {
+      const response = await client.getEntry('xspaceEntry')
+
+      expect(response.sys).toBeDefined()
+      expect(response.fields).toBeDefined()
+      expect(response.fields).toEqual({
+        items: [
+          {
+            sys: {
+              type: 'ResourceLink',
+              linkType: 'Contentful:Entry',
+              urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL',
+            },
+          },
+          {
+            sys: {
+              type: 'ResourceLink',
+              linkType: 'Contentful:Entry',
+              urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ',
+            },
+          },
+        ],
+      })
+    })
+
+    test('Gets entry with link resolution, and includes, keeping unresolvable links', async () => {
+      const response = await client.getEntry(entryWithUnresolvableLink, {
+        include: 2,
+      })
+      expect(response.fields).toBeDefined()
+      expect(response.fields.bestFriend).toMatchObject({
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '6SiPbntBPYYjnVHmipxJBF',
+        },
+      })
+    })
   })
 
   describe('client has withoutUnresolvableLinks modifier', () => {
-    test('client.withoutUnresolvableLinks', async () => {
-      const response = await client.withoutUnresolvableLinks.getEntry(entryWithUnresolvableLink, {
-        include: 2,
-      })
-
-      expect(response.fields.bestFriend).toBeUndefined()
-    })
-
     test('client.withoutUnresolvableLinks.withAllLocales', async () => {
       const response = await client.withoutUnresolvableLinks.withAllLocales.getEntry(
         entryWithUnresolvableLink,
@@ -47,6 +119,27 @@ describe('getEntry via chained clients', () => {
 
       expect(response.fields.color).toHaveProperty('en-US')
       expect(response.fields.bestFriend).toEqual({})
+    })
+
+    test('Gets entry with link resolution and includes, removing unresolvable links via client chain', async () => {
+      const response = await client.withoutUnresolvableLinks.getEntry(entryWithUnresolvableLink, {
+        include: 2,
+      })
+      expect(response.fields).toBeDefined()
+      expect(response.fields.bestFriend).toBeUndefined()
+    })
+
+    test('Gets entry with link resolution and includes, removing unresolvable links, overriding client config with client chain', async () => {
+      const keepUnresolvedClient = contentful.createClient({
+        ...params,
+        removeUnresolved: false,
+      })
+      const response = await keepUnresolvedClient.withoutUnresolvableLinks.getEntry(
+        entryWithUnresolvableLink,
+        { include: 2 }
+      )
+      expect(response.fields).toBeDefined()
+      expect(response.fields.bestFriend).toBeUndefined()
     })
   })
 
@@ -99,5 +192,46 @@ describe('getEntry via chained clients', () => {
       expect(response.fields.color).toHaveProperty('en-US')
       expect(response.fields.bestFriend['en-US'].sys.type).toBe('Link')
     })
+
+    test('Gets entry with without link resolution but with includes', async () => {
+      const response = await client.withoutLinkResolution.getEntry(entryWithUnresolvableLink, {
+        include: 2,
+      })
+      expect(response.fields).toBeDefined()
+      expect(response.fields.bestFriend).toMatchObject({
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '6SiPbntBPYYjnVHmipxJBF',
+        },
+      })
+    })
   })
+})
+
+test('Get entry with fallback locale', async () => {
+  type Fields = { title: string }
+
+  const entries = await Promise.all([
+    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'af' }),
+    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
+    localeClient.getEntry<Fields>('no-zu-ZA', { locale: 'zu-ZA' }),
+    localeClient.getEntry<Fields>('no-ne-NP', { locale: 'ne-NP' }),
+    localeClient.getEntry<Fields>('no-af', { locale: 'af' }),
+  ])
+
+  expect(entries[0].fields.title).not.toBe('')
+  expect(entries[1].fields.title).not.toBe('')
+  expect(entries[2].fields.title).not.toBe('')
+  expect(entries[3].fields.title).not.toBe('')
+  expect(entries[4].fields.title).not.toBe('')
+})
+
+test('Gets entry with attached metadata and field called "metadata" on preview', async () => {
+  const entryWithMetadataFieldAndMetadata = '1NnAC4eF9IRMpHtFB1NleW'
+  const response = await previewClient.getEntry(entryWithMetadataFieldAndMetadata)
+  expect(response.sys).toBeDefined()
+  expect(response.fields).toBeDefined()
+  expect(response.fields.metadata).toBeDefined()
+  expect(response.metadata).toBeDefined()
 })

--- a/test/integration/tests.test.ts
+++ b/test/integration/tests.test.ts
@@ -1,4 +1,3 @@
-import { EntryFields } from '../../lib'
 import * as contentful from '../../lib/contentful'
 import { ValidationError } from '../../lib/utils/validation-error'
 import { localeSpaceParams, params, previewParams } from './utils'
@@ -25,7 +24,7 @@ const clientWithLoggers = contentful.createClient({
 })
 
 const now = () => Math.floor(Date.now() / 1000)
-const withExpiryIn1Hour = () => now() + 1 * 60 * 60
+const withExpiryIn1Hour = () => now() + 60 * 60
 const withExpiryIn48Hours = () => now() + 48 * 60 * 60
 
 test('Gets space', async () => {
@@ -95,46 +94,6 @@ test('Gets content types with search query', async () => {
   expect(response.items).toHaveLength(2)
 })
 
-test('Gets entry', async () => {
-  const response = await client.getEntry('nyancat')
-  expect(response.sys).toBeDefined()
-  expect(response.fields).toBeDefined()
-})
-
-test('Gets an entry with a specific locale', async () => {
-  const entry = await client.getEntry<{ test: EntryFields.Symbol }>('nyancat', {
-    locale: 'tlh',
-  })
-  expect(entry.sys.locale).toBe('tlh')
-})
-
-test('Get entry fails if entryId does not exist', async () => {
-  await expect(client.getEntry('nyancatblah')).rejects.toThrow()
-})
-
-test('Get entry fails if an entryId is not passed', async () => {
-  // @ts-ignore
-  await expect(client.getEntry()).rejects.toThrow()
-})
-
-test('Get entry with fallback locale', async () => {
-  type Fields = { title: string }
-
-  const entries = await Promise.all([
-    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'af' }),
-    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
-    localeClient.getEntry<Fields>('no-zu-ZA', { locale: 'zu-ZA' }),
-    localeClient.getEntry<Fields>('no-ne-NP', { locale: 'ne-NP' }),
-    localeClient.getEntry<Fields>('no-af', { locale: 'af' }),
-  ])
-
-  expect(entries[0].fields.title).not.toBe('')
-  expect(entries[1].fields.title).not.toBe('')
-  expect(entries[2].fields.title).not.toBe('')
-  expect(entries[3].fields.title).not.toBe('')
-  expect(entries[4].fields.title).not.toBe('')
-})
-
 test('Gets entries', async () => {
   const response = await client.getEntries()
 
@@ -193,27 +152,6 @@ test('Gets entries with linked includes', async () => {
   expect(response.items[0].fields.bestFriend.fields).toBeDefined()
 })
 
-test('Gets entry with link resolution', async () => {
-  const response = await client.getEntry('nyancat', { include: 2 })
-
-  expect(response.fields.bestFriend.sys.type).toEqual('Entry')
-  expect(response.fields.bestFriend.fields).toBeDefined()
-})
-
-test('Gets entry with without link resolution but with includes', async () => {
-  const response = await client.withoutLinkResolution.getEntry('4SEhTg8sYJ1H3wDAinzhTp', {
-    include: 2,
-  })
-  expect(response.fields).toBeDefined()
-  expect(response.fields.bestFriend).toMatchObject({
-    sys: {
-      type: 'Link',
-      linkType: 'Entry',
-      id: '6SiPbntBPYYjnVHmipxJBF',
-    },
-  })
-})
-
 test('Gets entries with link resolution and includes, does not consider global `removeUnresolved` option', async () => {
   const removeUnresolvedClient = contentful.createClient({
     ...params,
@@ -225,58 +163,6 @@ test('Gets entries with link resolution and includes, does not consider global `
   })
   expect(response.items[0].fields).toBeDefined()
   expect(response.items[0].fields.bestFriend).toMatchObject({
-    sys: {
-      type: 'Link',
-      linkType: 'Entry',
-      id: '6SiPbntBPYYjnVHmipxJBF',
-    },
-  })
-})
-test('Gets entry with link resolution and includes, does not consider global `removeUnresolved` option', async () => {
-  const removeUnresolvedClient = contentful.createClient({
-    ...params,
-    removeUnresolved: true,
-  })
-  const response = await removeUnresolvedClient.getEntry('4SEhTg8sYJ1H3wDAinzhTp', { include: 2 })
-  expect(response.fields).toBeDefined()
-  expect(response.fields.bestFriend).toMatchObject({
-    sys: {
-      type: 'Link',
-      linkType: 'Entry',
-      id: '6SiPbntBPYYjnVHmipxJBF',
-    },
-  })
-})
-
-// TODO move tests with client.withoutUnresolvableLinks to getEntries/getEntry integration test files
-// TODO add localized
-test('Gets entry with link resolution and includes, removing unresolvable links via client chain', async () => {
-  const response = await client.withoutUnresolvableLinks.getEntry('4SEhTg8sYJ1H3wDAinzhTp', {
-    include: 2,
-  })
-  expect(response.fields).toBeDefined()
-  expect(response.fields.bestFriend).toBeUndefined()
-})
-
-test('Gets entry with link resolution and includes, removing unresolvable links, overriding client config with client chain', async () => {
-  const keepUnresolvedClient = contentful.createClient({
-    ...params,
-    removeUnresolved: false,
-  })
-  const response = await keepUnresolvedClient.withoutUnresolvableLinks.getEntry(
-    '4SEhTg8sYJ1H3wDAinzhTp',
-    { include: 2 }
-  )
-  expect(response.fields).toBeDefined()
-  expect(response.fields.bestFriend).toBeUndefined()
-})
-
-test('Gets entry with link resolution, and includes, keeping unresolvable links', async () => {
-  const response = await client.getEntry('4SEhTg8sYJ1H3wDAinzhTp', {
-    include: 2,
-  })
-  expect(response.fields).toBeDefined()
-  expect(response.fields.bestFriend).toMatchObject({
     sys: {
       type: 'Link',
       linkType: 'Entry',
@@ -486,31 +372,6 @@ test('Gets entries by creation order and id order', async () => {
   expect(response.items[0].sys.id < response.items[1].sys.id).toBeTruthy()
 })
 
-test('Gets an entry that has resource links', async () => {
-  const response = await client.getEntry('xspaceEntry')
-
-  expect(response.sys).toBeDefined()
-  expect(response.fields).toBeDefined()
-  expect(response.fields).toEqual({
-    items: [
-      {
-        sys: {
-          type: 'ResourceLink',
-          linkType: 'Contentful:Entry',
-          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/1hTi7NUq74QfA8DI8rF8gL',
-        },
-      },
-      {
-        sys: {
-          type: 'ResourceLink',
-          linkType: 'Contentful:Entry',
-          urn: 'crn:contentful:::content:spaces/ocrd5ofpzqgz/entries/3V5lyzzmJ2vH5f8kTmLtuZ',
-        },
-      },
-    ],
-  })
-})
-
 test('Gets assets with only images', async () => {
   const response = await client.getAssets({
     mimetype_group: 'image',
@@ -580,15 +441,6 @@ describe('Metadata', () => {
     expect(response.items).toBeDefined()
     expect(response.items.filter(({ fields }) => fields.metadata).length).toBeGreaterThan(0)
     expect(response.items.filter(({ fields }) => fields.metadata)[0].metadata).toBeDefined()
-  })
-
-  test('Gets entry with attached metadata and field called "metadata"on preview', async () => {
-    const entryWithMetadataFieldAndMetadata = '1NnAC4eF9IRMpHtFB1NleW'
-    const response = await previewClient.getEntry(entryWithMetadataFieldAndMetadata)
-    expect(response.sys).toBeDefined()
-    expect(response.fields).toBeDefined()
-    expect(response.fields.metadata).toBeDefined()
-    expect(response.metadata).toBeDefined()
   })
 })
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Fixing getEntry test TODOs.