### PR TITLE
feat: add types for metadata.tags query parameters

### DIFF
--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -7,9 +7,11 @@ import { RangeFilters } from './range'
 import { FullTextSearchFilters } from './search'
 import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
 import { SubsetFilters } from './subset'
-import { FieldsType } from './util'
+import { ConditionalFixedQueries, ConditionalListQueries, FieldsType } from './util'
 import { ReferenceSearchFilters } from './reference'
 import { TagSys } from '../sys'
+import { Metadata } from '../metadata'
+import { TagLink } from '../link'
 
 type FixedPagedOptions = {
   skip?: number
@@ -36,6 +38,11 @@ export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   SubsetFilters<Sys, 'sys'> &
   RangeFilters<Sys, 'sys'>
 
+export type MetadataTagsQueries =
+  | ConditionalFixedQueries<Pick<Metadata, 'tags'>, any, boolean, 'metadata', '[exists]'>
+  | ConditionalListQueries<Pick<TagLink, 'id'>, any, 'metadata.tags.sys', '[all]'>
+  | ConditionalListQueries<Pick<TagLink, 'id'>, any, 'metadata.tags.sys', '[in]'>
+
 export type EntryFieldsQueries<Fields extends FieldsType> =
   | EntrySelectFilterWithFields<Fields>
   | ExistenceFilter<Fields, 'fields'>
@@ -50,6 +57,7 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
 export type EntriesQueries<Fields extends FieldsType> =
   | (EntryFieldsQueries<Fields> & { content_type: string })
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+      MetadataTagsQueries &
       EntrySelectFilter &
       FixedQueryOptions &
       FixedPagedOptions &
@@ -67,6 +75,7 @@ export type AssetFieldsQueries<Fields extends FieldsType> = ExistenceFilter<Fiel
 
 export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields> &
   SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+  MetadataTagsQueries &
   FixedQueryOptions &
   FixedPagedOptions & { mimetype_group?: AssetMimeType } & { order?: string }
 

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -5,6 +5,12 @@ import * as mocks from '../mocks'
 
 type DefaultAssetQueries = AssetQueries<AssetFields>
 
+// all operator
+
+expectAssignable<DefaultAssetQueries>({
+  'metadata.tags.sys.id[all]': mocks.stringArrayValue,
+})
+
 // equality operator
 
 expectAssignable<DefaultAssetQueries>({
@@ -22,6 +28,7 @@ expectNotAssignable<DefaultAssetQueries>({
 
 expectAssignable<DefaultAssetQueries>({
   'fields.title[exists]': mocks.booleanValue,
+  'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -53,6 +60,7 @@ expectNotAssignable<DefaultAssetQueries>({
 
 expectAssignable<DefaultAssetQueries>({
   'fields.title[in]': mocks.stringArrayValue,
+  'metadata.tags.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
 expectNotAssignable<DefaultAssetQueries>({

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -3,6 +3,12 @@ import { EntryFields, EntriesQueries } from '../../../lib'
 // @ts-ignore
 import * as mocks from '../mocks'
 
+// all operator
+
+expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+  'metadata.tags.sys.id[all]': mocks.stringArrayValue,
+})
+
 // equality
 
 expectAssignable<EntriesQueries<{ someField: string }>>({
@@ -27,6 +33,7 @@ expectNotAssignable<EntriesQueries<{ someField: string }>>({
 // exists operator (field is present)
 
 expectAssignable<EntriesQueries<{ someField: string }>>({
+  'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
 expectNotAssignable<EntriesQueries<{ someField: string }>>({
@@ -90,6 +97,7 @@ expectNotAssignable<EntriesQueries<{ numberField: number }>>({
 // in operator
 
 expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+  'metadata.tags.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
 expectNotAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({


### PR DESCRIPTION
## Summary

Add supported query parameters for `metadata.tags` to query types.
