### PR TITLE
chore: throw error when using old parameters

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -9,6 +9,7 @@ import { ContentfulClientApi } from './create-contentful-api'
 import createGlobalOptions from './create-global-options'
 import { makeClient } from './make-client'
 import type { AxiosRequestConfig } from 'axios'
+import { validateRemoveUnresolvedParam, validateResolveLinksParam } from './utils/validate-params'
 
 export type ClientLogLevel = 'error' | 'warning' | 'info' | string
 
@@ -40,6 +41,9 @@ export function createClient(params: CreateClientParams): ContentfulClientApi {
   if (!params.space) {
     throw new TypeError('Expected parameter space')
   }
+
+  validateResolveLinksParam(params)
+  validateRemoveUnresolvedParam(params)
 
   const defaultConfig = {
     resolveLinks: true,

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -76,9 +76,7 @@ export function createClient(params: CreateClientParams): ContentfulClientApi {
 
   const getGlobalOptions = createGlobalOptions({
     space: config.space,
-    resolveLinks: config.resolveLinks,
     environment: config.environment,
-    removeUnresolved: config.removeUnresolved,
     spaceBaseUrl: http.defaults.baseURL,
     environmentBaseUrl: `${http.defaults.baseURL}environments/${config.environment}`,
   })

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -39,7 +39,11 @@ import {
   ChainOptions,
   ModifiersFromOptions,
 } from './utils/client-helpers'
-import { validateLocaleParam, validateResolveLinksParam } from './utils/validate-params'
+import {
+  validateLocaleParam,
+  validateRemoveUnresolvedParam,
+  validateResolveLinksParam,
+} from './utils/validate-params'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
 
@@ -389,6 +393,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
 
     validateLocaleParam(query, withAllLocales as boolean)
     validateResolveLinksParam(query)
+    validateRemoveUnresolvedParam(query)
 
     return internalGetEntry<Fields, any, Extract<ChainOptions, typeof options>>(
       id,
@@ -432,6 +437,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
 
     validateLocaleParam(query, withAllLocales)
     validateResolveLinksParam(query)
+    validateRemoveUnresolvedParam(query)
 
     return internalGetEntries<Fields, any, Extract<ChainOptions, typeof options>>(
       withAllLocales
@@ -597,6 +603,9 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
       withoutUnresolvableLinks: false,
     }
   ) {
+    validateResolveLinksParam(query)
+    validateRemoveUnresolvedParam(query)
+
     const combinedOptions = {
       ...syncOptions,
       ...options,

--- a/lib/create-global-options.ts
+++ b/lib/create-global-options.ts
@@ -7,9 +7,7 @@
  */
 
 export interface GlobalOptionsParams {
-  resolveLinks?: boolean
   environment?: string
-  removeUnresolved?: boolean
   space?: string
   spaceBaseUrl?: string
   environmentBaseUrl?: string

--- a/lib/utils/validate-params.ts
+++ b/lib/utils/validate-params.ts
@@ -35,3 +35,14 @@ export function validateResolveLinksParam(query) {
   }
   return
 }
+
+export function validateRemoveUnresolvedParam(query) {
+  if ('removeUnresolved' in query) {
+    throw new ValidationError(
+      'removeUnresolved',
+      `The use of the 'removeUnresolved' parameter is no longer supported. By default, unresolved links are kept as link objects.
+      If you do not want to include unresolved links, use client.withoutUnresolvableLinks.`
+    )
+  }
+  return
+}

--- a/test/unit/contentful.test.ts
+++ b/test/unit/contentful.test.ts
@@ -93,16 +93,6 @@ describe('contentful', () => {
     expect(client.getAssets).toBeDefined()
   })
 
-  test('Initializes API with link resolution turned on by default', () => {
-    createClient({
-      accessToken: 'accessToken',
-      space: 'spaceId',
-    })
-    const callConfig = createContentfulApiMock.mock.calls[0]
-    expect(callConfig[0].getGlobalOptions().resolveLinks).toBeTruthy()
-    expect(callConfig[0].getGlobalOptions({ resolveLinks: false }).resolveLinks).toBeFalsy()
-  })
-
   test('Initializes API and attaches default environment', () => {
     createClient({
       accessToken: 'accessToken',

--- a/test/unit/make-contentful-api-client.test.ts
+++ b/test/unit/make-contentful-api-client.test.ts
@@ -182,9 +182,10 @@ describe('make Contentful API client', () => {
       promise: Promise.resolve({ data: data }),
     })
     await expect(api.getEntries()).resolves.toEqual(data)
+    expect(resolveCircularMock.mock.calls[0][1].resolveLinks).toBeTruthy()
   })
 
-  test('API call getEntries with global resolveLinks overridden by chained modifier', async () => {
+  test('API call getEntries with link resolution disabled', async () => {
     const data = { sys: { id: 'id' } }
     const { api } = setupWithData({
       promise: Promise.resolve({ data: data }),
@@ -197,23 +198,6 @@ describe('make Contentful API client', () => {
 
     await expect(api.withoutLinkResolution.getEntries()).resolves.toEqual(data)
     expect(resolveCircularMock.mock.calls[0][1].resolveLinks).toBeFalsy()
-  })
-
-  test('API call getEntries with global resolveLinks turned on', async () => {
-    const data = { sys: { id: 'id' } }
-
-    const { api } = setupWithData({
-      promise: Promise.resolve({ data: data }),
-      getGlobalOptions: jest.fn().mockReturnValue({
-        environment: 'master',
-        environmentBaseUrl: 'environmentUrl',
-        resolveLinks: true,
-        removeUnresolved: false,
-      }),
-    })
-
-    await expect(api.getEntries()).resolves.toEqual(data)
-    expect(resolveCircularMock.mock.calls[0][1].resolveLinks).toBeTruthy()
   })
 
   test('API call getEntries fails', async () => {


### PR DESCRIPTION
## Summary

Follow-up for https://github.com/contentful/contentful.js/pull/1783 to remove the old `resolveLinks` and `removeUnresolved` parameters on the JS level.

## Description

* Throw error when `resolveLinks` or `removeUnresolved` are used in query to alert JS users to new API.
* Throw error when `resolveLinks` or `removeUnresolved` are used in client creation to alert JS users to new API.
* Remove old parameters from global options.