### PR TITLE
feat: add all query parameter

### DIFF
--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -18,6 +18,7 @@ import {
   EntryOrderFilterWithFields,
   TagOrderFilter,
 } from './order'
+import { SetFilter } from './set'
 
 type FixedPagedOptions = {
   skip?: number
@@ -57,6 +58,7 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
   | InequalityFilter<Fields, 'fields'>
   | FullTextSearchFilters<Fields, 'fields'>
   | SubsetFilters<Fields, 'fields'>
+  | SetFilter<Fields, 'fields'>
   | LocationSearchFilters<Fields, 'fields'>
   | RangeFilters<Fields, 'fields'>
   | ReferenceSearchFilters<Fields, 'fields'>

--- a/lib/types/query/set.ts
+++ b/lib/types/query/set.ts
@@ -1,0 +1,15 @@
+import { EntryFields } from '..'
+import { ConditionalListQueries } from './util'
+
+type SupportedTypes = EntryFields.Symbol | EntryFields.Symbol[] | EntryFields.Text | undefined
+
+/**
+ * @desc match multiple values
+ * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/array-with-multiple-values}
+ */
+export type SetFilter<Fields, Prefix extends string> = ConditionalListQueries<
+  Fields,
+  SupportedTypes,
+  Prefix,
+  `[all]`
+>

--- a/lib/types/query/subset.ts
+++ b/lib/types/query/subset.ts
@@ -16,9 +16,6 @@ type SupportedTypes =
  * @desc inclusion & exclusion
  * @see [inclusion documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/inclusion}
  * @see [exclusion documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/exclusion}
- * @example
- * // {'fields.myField', 'singleValue'}
- * // {'fields.myField', 'firstValue,secondValue'}
  */
 export type SubsetFilters<Fields, Prefix extends string> = ConditionalListQueries<
   Fields,

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -5,8 +5,20 @@ import * as mocks from '../mocks'
 
 // all operator
 
-expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
+})
+expectNotAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+  'fields.stringField[all]': mocks.anyValue,
+})
+expectAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+  content_type: 'id',
+  'fields.stringField[all]': mocks.stringArrayValue,
+  'fields.stringArrayField[all]': mocks.stringArrayValue,
+})
+expectNotAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+  content_type: 'id',
+  'fields.unknownField[all]': mocks.anyValue,
 })
 
 // equality

--- a/test/types/query-types/boolean.test-d.ts
+++ b/test/types/query-types/boolean.test-d.ts
@@ -10,6 +10,9 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.Boolean }, 'fields'>>>({})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Boolean }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Boolean }, 'fields'>>>({

--- a/test/types/query-types/date.test-d.ts
+++ b/test/types/query-types/date.test-d.ts
@@ -10,6 +10,13 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+// we can’t tell dates from text fields so the [all] operator is included here
+expectAssignable<SetFilter<{ testField: EntryFields.Symbol }, 'fields'>>({})
+expectType<Required<SetFilter<{ testField: EntryFields.Symbol }, 'fields'>>>({
+  'fields.testField[all]': mocks.stringArrayValue,
+})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Date }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Date }, 'fields'>>>({

--- a/test/types/query-types/integer.test-d.ts
+++ b/test/types/query-types/integer.test-d.ts
@@ -10,6 +10,9 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.Integer }, 'fields'>>>({})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Integer }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Integer }, 'fields'>>>({

--- a/test/types/query-types/location.test-d.ts
+++ b/test/types/query-types/location.test-d.ts
@@ -10,6 +10,9 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.Location }, 'fields'>>>({})
 
 expectAssignable<Required<EqualityFilter<{ testField: EntryFields.Location }, 'fields'>>>({})
 

--- a/test/types/query-types/number.test-d.ts
+++ b/test/types/query-types/number.test-d.ts
@@ -10,6 +10,9 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.Number }, 'fields'>>>({})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Number }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Number }, 'fields'>>>({

--- a/test/types/query-types/object.test-d.ts
+++ b/test/types/query-types/object.test-d.ts
@@ -8,8 +8,11 @@ import { FullTextSearchFilters } from '../../../lib/types/query/search'
 import { EntrySelectFilterWithFields } from '../../../lib/types/query/select'
 import { SubsetFilters } from '../../../lib/types/query/subset'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
 // @ts-ignore
 import * as mocks from '../mocks'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.Object }, 'fields'>>>({})
 
 expectAssignable<Required<EqualityFilter<{ testField: EntryFields.Object }, 'fields'>>>({})
 

--- a/test/types/query-types/richtext.test-d.ts
+++ b/test/types/query-types/richtext.test-d.ts
@@ -10,6 +10,9 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<Required<SetFilter<{ testField: EntryFields.RichText }, 'fields'>>>({})
 
 expectAssignable<Required<EqualityFilter<{ testField: EntryFields.RichText }, 'fields'>>>({})
 

--- a/test/types/query-types/symbol.test-d.ts
+++ b/test/types/query-types/symbol.test-d.ts
@@ -10,6 +10,12 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<SetFilter<{ testField: EntryFields.Symbol }, 'fields'>>({})
+expectType<Required<SetFilter<{ testField: EntryFields.Symbol }, 'fields'>>>({
+  'fields.testField[all]': mocks.stringArrayValue,
+})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Symbol }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Symbol }, 'fields'>>>({

--- a/test/types/query-types/text.test-d.ts
+++ b/test/types/query-types/text.test-d.ts
@@ -10,6 +10,12 @@ import { SubsetFilters } from '../../../lib/types/query/subset'
 // @ts-ignore
 import * as mocks from '../mocks'
 import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
+import { SetFilter } from '../../../lib/types/query/set'
+
+expectAssignable<SetFilter<{ testField: EntryFields.Text }, 'fields'>>({})
+expectType<Required<SetFilter<{ testField: EntryFields.Text }, 'fields'>>>({
+  'fields.testField[all]': mocks.stringArrayValue,
+})
 
 expectAssignable<EqualityFilter<{ testField: EntryFields.Text }, 'fields'>>({})
 expectType<Required<EqualityFilter<{ testField: EntryFields.Text }, 'fields'>>>({


### PR DESCRIPTION
## Summary

Add support for the `[all]` operator in `getEntries` query types.
