### PR TITLE
chore: add more asset file query parameters

### DIFF
--- a/lib/types/query/existence.ts
+++ b/lib/types/query/existence.ts
@@ -1,5 +1,6 @@
 import { EntryField } from '../entry'
 import { ConditionalFixedQueries, FieldsType } from './util'
+import { AssetDetails, AssetFile } from '../asset'
 
 /**
  * @name exists
@@ -9,4 +10,10 @@ import { ConditionalFixedQueries, FieldsType } from './util'
 export type ExistenceFilter<
   Fields extends FieldsType,
   Prefix extends string
-> = ConditionalFixedQueries<Fields, EntryField<Fields> | undefined, boolean, Prefix, '[exists]'>
+> = ConditionalFixedQueries<
+  Fields,
+  EntryField<Fields> | AssetFile | AssetDetails | undefined,
+  boolean,
+  Prefix,
+  '[exists]'
+>

--- a/lib/types/query/order.ts
+++ b/lib/types/query/order.ts
@@ -56,6 +56,10 @@ export type AssetOrderFilter = {
     | '-fields.file.contentType'
     | 'fields.file.fileName'
     | '-fields.file.fileName'
+    | 'fields.file.url'
+    | '-fields.file.url'
+    | 'fields.file.details.size'
+    | '-fields.file.details.size'
   )[]
 }
 

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -1,4 +1,4 @@
-import { AssetMimeType, AssetSys } from '../asset'
+import { AssetDetails, AssetFields, AssetFile, AssetMimeType, AssetSys } from '../asset'
 import { EntrySys } from '../entry'
 import { EqualityFilter, InequalityFilter } from './equality'
 import { ExistenceFilter } from './existence'
@@ -84,7 +84,25 @@ export type AssetFieldsQueries<Fields extends FieldsType> = ExistenceFilter<Fiel
   RangeFilters<Fields, 'fields'> &
   SubsetFilters<Fields, 'fields'>
 
+export type AssetFieldsFileQueries = ExistenceFilter<AssetFile, 'fields.file'> &
+  EqualityFilter<AssetFile, 'fields.file'> &
+  InequalityFilter<AssetFile, 'fields.file'> &
+  FullTextSearchFilters<AssetFile, 'fields.file'> &
+  RangeFilters<AssetFile, 'fields.file'> &
+  SubsetFilters<AssetFile, 'fields.file'>
+
+export type AssetFieldsFileDetailsQueries = ExistenceFilter<
+  Pick<AssetDetails, 'size'>,
+  'fields.file.details'
+> &
+  EqualityFilter<Pick<AssetDetails, 'size'>, 'fields.file.details'> &
+  InequalityFilter<Pick<AssetDetails, 'size'>, 'fields.file.details'> &
+  RangeFilters<Pick<AssetDetails, 'size'>, 'fields.file.details'> &
+  SubsetFilters<Pick<AssetDetails, 'size'>, 'fields.file.details'>
+
 export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields> &
+  AssetFieldsFileQueries &
+  AssetFieldsFileDetailsQueries &
   SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
   MetadataTagsQueries &
   FixedQueryOptions &

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -169,6 +169,10 @@ expectAssignable<DefaultAssetQueries>({
     '-fields.file.contentType',
     'fields.file.fileName',
     '-fields.file.fileName',
+    'fields.file.url',
+    '-fields.file.url',
+    'fields.file.details.size',
+    '-fields.file.details.size',
   ],
 })
 expectNotAssignable<DefaultAssetQueries>({ order: ['fields.unknownField'] })

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -14,6 +14,11 @@ expectAssignable<DefaultAssetQueries>({
 // equality operator
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description': mocks.stringValue,
+  'fields.file.contentType': mocks.stringValue,
+  'fields.file.details.size': mocks.numberValue,
+  'fields.file.fileName': mocks.stringValue,
+  'fields.file.url': mocks.stringValue,
   'fields.title': mocks.stringValue,
   'sys.updatedAt': mocks.dateValue,
 })
@@ -27,6 +32,13 @@ expectNotAssignable<DefaultAssetQueries>({
 // exists operator (field is present)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description[exists]': mocks.booleanValue,
+  'fields.file[exists]': mocks.booleanValue,
+  'fields.file.contentType[exists]': mocks.booleanValue,
+  'fields.file.details[exists]': mocks.booleanValue,
+  'fields.file.details.size[exists]': mocks.booleanValue,
+  'fields.file.fileName[exists]': mocks.booleanValue,
+  'fields.file.url[exists]': mocks.booleanValue,
   'fields.title[exists]': mocks.booleanValue,
   'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
@@ -41,6 +53,7 @@ expectNotAssignable<DefaultAssetQueries>({
 // gt operator (range)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.file.details.size[gt]': mocks.numberValue,
   'sys.updatedAt[gt]': mocks.dateValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -50,6 +63,7 @@ expectNotAssignable<DefaultAssetQueries>({
 // gte operator (range)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.file.details.size[gte]': mocks.numberValue,
   'sys.updatedAt[gte]': mocks.dateValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -59,6 +73,11 @@ expectNotAssignable<DefaultAssetQueries>({
 // in operator
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description[in]': mocks.stringArrayValue,
+  'fields.file.contentType[in]': mocks.stringArrayValue,
+  'fields.file.details.size[in]': mocks.numberArrayValue,
+  'fields.file.fileName[in]': mocks.stringArrayValue,
+  'fields.file.url[in]': mocks.stringArrayValue,
   'fields.title[in]': mocks.stringArrayValue,
   'metadata.tags.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
@@ -73,6 +92,7 @@ expectNotAssignable<DefaultAssetQueries>({
 // lt operator (range)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.file.details.size[lt]': mocks.numberValue,
   'sys.updatedAt[lt]': mocks.dateValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -82,6 +102,7 @@ expectNotAssignable<DefaultAssetQueries>({
 // lte operator (range)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.file.details.size[lte]': mocks.numberValue,
   'sys.updatedAt[lte]': mocks.dateValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -91,6 +112,10 @@ expectNotAssignable<DefaultAssetQueries>({
 // match operator (full-text search)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description[match]': mocks.stringValue,
+  'fields.file.contentType[match]': mocks.stringValue,
+  'fields.file.fileName[match]': mocks.stringValue,
+  'fields.file.url[match]': mocks.stringValue,
   'fields.title[match]': mocks.stringValue,
 })
 expectNotAssignable<DefaultAssetQueries>({
@@ -100,6 +125,11 @@ expectNotAssignable<DefaultAssetQueries>({
 // ne operator (inequality)
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description[ne]': mocks.stringValue,
+  'fields.file.contentType[ne]': mocks.stringValue,
+  'fields.file.details.size[ne]': mocks.numberValue,
+  'fields.file.fileName[ne]': mocks.stringValue,
+  'fields.file.url[ne]': mocks.stringValue,
   'fields.title[ne]': mocks.stringValue,
   'sys.updatedAt[ne]': mocks.dateValue,
 })
@@ -113,6 +143,11 @@ expectNotAssignable<DefaultAssetQueries>({
 // nin operator
 
 expectAssignable<DefaultAssetQueries>({
+  'fields.description[nin]': mocks.stringArrayValue,
+  'fields.file.contentType[nin]': mocks.stringArrayValue,
+  'fields.file.details.size[nin]': mocks.numberArrayValue,
+  'fields.file.fileName[nin]': mocks.stringArrayValue,
+  'fields.file.url[nin]': mocks.stringArrayValue,
   'fields.title[nin]': mocks.stringArrayValue,
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })


### PR DESCRIPTION
## Summary

Some query parameters for `getAssets` where related to the asset file where still missing.

## Description

* Add operators for file properties and file size
* Add file URL and file size to `order` parameter values
