### PR TITLE
fix: disallow objects as query parameter values

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -44,6 +44,7 @@ import {
   validateRemoveUnresolvedParam,
   validateResolveLinksParam,
 } from './utils/validate-params'
+import validateSearchParameters from './utils/validate-search-parameters'
 
 const ASSET_KEY_MAX_LIFETIME = 48 * 60 * 60
 
@@ -394,6 +395,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     validateLocaleParam(query, withAllLocales as boolean)
     validateResolveLinksParam(query)
     validateRemoveUnresolvedParam(query)
+    validateSearchParameters(query)
 
     return internalGetEntry<Fields, any, Extract<ChainOptions, typeof options>>(
       id,
@@ -438,6 +440,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     validateLocaleParam(query, withAllLocales)
     validateResolveLinksParam(query)
     validateRemoveUnresolvedParam(query)
+    validateSearchParameters(query)
 
     return internalGetEntries<Fields, any, Extract<ChainOptions, typeof options>>(
       withAllLocales
@@ -495,6 +498,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     const { withAllLocales } = options
 
     validateLocaleParam(query, withAllLocales)
+    validateSearchParameters(query)
 
     const localeSpecificQuery = withAllLocales ? { ...query, locale: '*' } : query
 
@@ -528,6 +532,7 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     const { withAllLocales } = options
 
     validateLocaleParam(query, withAllLocales)
+    validateSearchParameters(query)
 
     const localeSpecificQuery = withAllLocales ? { ...query, locale: '*' } : query
 
@@ -556,6 +561,8 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   }
 
   async function getTags(query = {}): Promise<TagCollection> {
+    validateSearchParameters(query)
+
     return get<TagCollection>({
       context: 'environment',
       path: 'tags',
@@ -580,6 +587,8 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   }
 
   async function getLocales(query = {}): Promise<LocaleCollection> {
+    validateSearchParameters(query)
+
     return get<LocaleCollection>({
       context: 'environment',
       path: 'locales',

--- a/lib/utils/validate-search-parameters.ts
+++ b/lib/utils/validate-search-parameters.ts
@@ -1,0 +1,9 @@
+export default function validateSearchParameters(query: Record<string, any>): void {
+  for (const key in query) {
+    const value = query[key]
+    // We don’t allow any objects as values for query parameters
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      throw new Error(`Objects are not supported as value for the "${key}" query parameter.`)
+    }
+  }
+}

--- a/test/unit/utils/validate-search-parameters.test.ts
+++ b/test/unit/utils/validate-search-parameters.test.ts
@@ -1,0 +1,38 @@
+import validateSearchParameters from '../../../lib/utils/validate-search-parameters'
+
+describe('validateSearchParameters', () => {
+  test('does nothing if no values are objects', () => {
+    const query = {
+      booleanValue: true,
+      stringValue: 'string',
+      numberValue: 3,
+      nullValue: null,
+      undefinedValue: undefined,
+      arrayValue: ['string'],
+    }
+
+    validateSearchParameters(query)
+  })
+
+  test('throws if a value is an object', () => {
+    const query = {
+      booleanValue: true,
+      stringValue: 'string',
+      objectValue: {},
+    }
+    const expectedErrorMessage =
+      'Objects are not supported as value for the "objectValue" query parameter'
+
+    expect(() => validateSearchParameters(query)).toThrow(expectedErrorMessage)
+  })
+
+  test('adds the affected parameter to the error', () => {
+    const query = {
+      affectedParameter: { key: 'value' },
+    }
+    const expectedErrorMessage =
+      'Objects are not supported as value for the "affectedParameter" query parameter'
+
+    expect(() => validateSearchParameters(query)).toThrow(expectedErrorMessage)
+  })
+})


### PR DESCRIPTION
## Summary

Disallow objects as query parameters at runtime. This check is in addition to type checks as object parameters are otherwise silently hidden leading to unexpected results and hard to find errors for users.