### PR TITLE
feat: add EntrySkeletonType combining fields with content type id [DANTE-946]

### DIFF
--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -78,7 +78,7 @@ Static query keys are not influenced by the shape of the entries or assets you'r
 
 ![](images/static-query-keys.png)
 
-```
+```js
 getEntries({
     'skip': 10,
     'limit': 20,
@@ -92,23 +92,26 @@ Dynamic query keys are based on the given shape of the expected entries' content
 
 ![](images/dynamic-query-keys.png)
 
-To calculate dynamic keys, we have to define the shape of the fields of the entries' content type:
+To calculate dynamic keys, we have to define the shape the entries' content type:
 
 ```typescript
 import * as contentful from 'contentful'
 
-type ExampleEntryFields = {
-  productName: contentful.EntryFields.Text
-  image: contentful.Asset
-  price: contentful.EntryFields.Number
-  categories: contentful.Entry<CategoryEntryFields>[]
+type ExampleEntryFieldsWithContentTypeId = {
+  contentTypeId: 'product',
+  fields: {
+    productName: contentful.EntryFields.Text
+    image: contentful.Asset
+    price: contentful.EntryFields.Number
+    categories: contentful.Entry<CategoryEntryFields>[]
+  }
 }
 ```
 
 We can then pass this shape to our `getEntries` call. This gives us the relevant information needed to calculate the dynamic keys and their possible value types.
 
 ```typescript
-getEntries<ExampleEntryFields>({
+getEntries<ExampleEntryFieldsWithContentTypeId>({
   'fields.price[gt]': 100,
 })
 ```
@@ -136,9 +139,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type Fields = { productName: contentful.EntryFields.Text }
+type FieldsWithContentTypeId = {
+  fields: { productName: contentful.EntryFields.Text },
+  contentTypeId: 'product'
+}
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withAllLocales.getEntry<Fields, Locales>('some-entry-id')
+const entry = client.withAllLocales.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
 ```
 
 The return type of the `getEntry` is matching the `fields` shape
@@ -191,11 +197,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type Fields = {
-  relatedProduct: contentful.EntryFields.Entry,
+type FieldsWithContentTypeId = {
+  fields: { relatedProduct: contentful.EntryFields.Entry },
+  contentTypeId: 'product'
 }
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withoutLinkResolution.getEntry<Fields, Locales>('some-entry-id')
+const entry = client.withoutLinkResolution.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
 ```
 
 The return type of `getEntry` is matching the `fields` shape
@@ -226,11 +233,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type Fields = {
-  relatedProduct: contentful.EntryFields.Entry,
+type FieldsWithContentTypeId = {
+  fields: { relatedProduct: contentful.EntryFields.Entry },
+  contentTypeId: 'product'
 }
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withoutUnresolvableLinks.getEntry<Fields, Locales>('some-entry-id')
+const entry = client.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
 ```
 
 The return type of `getEntry` is matching the `fields` shape

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -92,7 +92,7 @@ Dynamic query keys are based on the given shape of the expected entries' content
 
 ![](images/dynamic-query-keys.png)
 
-To calculate dynamic keys, we have to define the shape the entries' content type:
+To calculate dynamic keys, we have to provide the shape of the entries:
 
 ```typescript
 import * as contentful from 'contentful'

--- a/TYPESCRIPT.md
+++ b/TYPESCRIPT.md
@@ -97,7 +97,7 @@ To calculate dynamic keys, we have to define the shape the entries' content type
 ```typescript
 import * as contentful from 'contentful'
 
-type ExampleEntryFieldsWithContentTypeId = {
+type ExampleEntrySkeleton = {
   contentTypeId: 'product',
   fields: {
     productName: contentful.EntryFields.Text
@@ -111,7 +111,7 @@ type ExampleEntryFieldsWithContentTypeId = {
 We can then pass this shape to our `getEntries` call. This gives us the relevant information needed to calculate the dynamic keys and their possible value types.
 
 ```typescript
-getEntries<ExampleEntryFieldsWithContentTypeId>({
+getEntries<ExampleEntrySkeleton>({
   'fields.price[gt]': 100,
 })
 ```
@@ -139,12 +139,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type FieldsWithContentTypeId = {
+type ProductSkeleton = {
   fields: { productName: contentful.EntryFields.Text },
   contentTypeId: 'product'
 }
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withAllLocales.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
+const entry = client.withAllLocales.getEntry<ProductSkeleton, Locales>('some-entry-id')
 ```
 
 The return type of the `getEntry` is matching the `fields` shape
@@ -197,12 +197,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type FieldsWithContentTypeId = {
+type ProductSkeleton = {
   fields: { relatedProduct: contentful.EntryFields.Entry },
   contentTypeId: 'product'
 }
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withoutLinkResolution.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
+const entry = client.withoutLinkResolution.getEntry<ProductSkeleton, Locales>('some-entry-id')
 ```
 
 The return type of `getEntry` is matching the `fields` shape
@@ -233,12 +233,12 @@ const client = contentful.createClient({
   accessToken: '<content-delivery-token>',
 })
 
-type FieldsWithContentTypeId = {
+type ProductSkeleton = {
   fields: { relatedProduct: contentful.EntryFields.Entry },
   contentTypeId: 'product'
 }
 type Locales = 'en-US' | 'de-DE'
-const entry = client.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId, Locales>('some-entry-id')
+const entry = client.withoutUnresolvableLinks.getEntry<ProductSkeleton, Locales>('some-entry-id')
 ```
 
 The return type of `getEntry` is matching the `fields` shape

--- a/lib/paged-sync.ts
+++ b/lib/paged-sync.ts
@@ -13,7 +13,7 @@ import {
   SyncOptions,
   SyncEntities,
   SyncQuery,
-  FieldsType,
+  FieldsWithContentTypeIdType,
   LocaleCode,
 } from './types'
 import { ChainOptions, ModifiersFromOptions } from './utils/client-helpers'
@@ -28,14 +28,14 @@ import { ChainOptions, ModifiersFromOptions } from './utils/client-helpers'
  * @return {Promise<SyncCollection>}
  */
 export default async function pagedSync<
-  Fields extends FieldsType,
+  FieldsWithContentTypeId extends FieldsWithContentTypeIdType,
   Locales extends LocaleCode,
   Options extends ChainOptions
 >(
   http: AxiosInstance,
   query: SyncQuery,
   options?: SyncOptions | ChainOptions
-): Promise<SyncCollection<Fields, ModifiersFromOptions<Options>, Locales>> {
+): Promise<SyncCollection<FieldsWithContentTypeId, ModifiersFromOptions<Options>, Locales>> {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error(
       'Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing'

--- a/lib/paged-sync.ts
+++ b/lib/paged-sync.ts
@@ -13,8 +13,8 @@ import {
   SyncOptions,
   SyncEntities,
   SyncQuery,
-  FieldsWithContentTypeIdType,
   LocaleCode,
+  EntrySkeletonType,
 } from './types'
 import { ChainOptions, ModifiersFromOptions } from './utils/client-helpers'
 
@@ -28,14 +28,14 @@ import { ChainOptions, ModifiersFromOptions } from './utils/client-helpers'
  * @return {Promise<SyncCollection>}
  */
 export default async function pagedSync<
-  FieldsWithContentTypeId extends FieldsWithContentTypeIdType,
+  EntrySkeleton extends EntrySkeletonType,
   Locales extends LocaleCode,
   Options extends ChainOptions
 >(
   http: AxiosInstance,
   query: SyncQuery,
   options?: SyncOptions | ChainOptions
-): Promise<SyncCollection<FieldsWithContentTypeId, ModifiersFromOptions<Options>, Locales>> {
+): Promise<SyncCollection<EntrySkeleton, ModifiersFromOptions<Options>, Locales>> {
   if (!query || (!query.initial && !query.nextSyncToken && !query.nextPageToken)) {
     throw new Error(
       'Please provide one of `initial`, `nextSyncToken` or `nextPageToken` parameters for syncing'

--- a/lib/types/query/existence.ts
+++ b/lib/types/query/existence.ts
@@ -1,5 +1,5 @@
 import { EntryField } from '../entry'
-import { ConditionalFixedQueries, FieldsType } from './util'
+import { ConditionalFixedQueries, FieldsType, FieldsWithContentTypeIdType } from './util'
 import { AssetDetails, AssetFile } from '../asset'
 
 /**
@@ -12,7 +12,7 @@ export type ExistenceFilter<
   Prefix extends string
 > = ConditionalFixedQueries<
   Fields,
-  EntryField<Fields> | AssetFile | AssetDetails | undefined,
+  EntryField<FieldsWithContentTypeIdType<Fields>> | AssetFile | AssetDetails | undefined,
   boolean,
   Prefix,
   '[exists]'

--- a/lib/types/query/existence.ts
+++ b/lib/types/query/existence.ts
@@ -1,5 +1,5 @@
 import { EntryField } from '../entry'
-import { ConditionalFixedQueries, FieldsType, FieldsWithContentTypeIdType } from './util'
+import { ConditionalFixedQueries, FieldsType, EntrySkeletonType } from './util'
 import { AssetDetails, AssetFile } from '../asset'
 
 /**
@@ -12,7 +12,7 @@ export type ExistenceFilter<
   Prefix extends string
 > = ConditionalFixedQueries<
   Fields,
-  EntryField<FieldsWithContentTypeIdType<Fields>> | AssetFile | AssetDetails | undefined,
+  EntryField<EntrySkeletonType<Fields>> | AssetFile | AssetDetails | undefined,
   boolean,
   Prefix,
   '[exists]'

--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,2 +1,2 @@
 export { type AssetQueries, type EntriesQueries, type TagQueries } from './query'
-export { type FieldsType } from './util'
+export { type FieldsType, FieldsWithContentTypeIdType } from './util'

--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,2 +1,2 @@
 export { type AssetQueries, type EntriesQueries, type TagQueries } from './query'
-export { type FieldsType, FieldsWithContentTypeIdType } from './util'
+export { type FieldsType, EntrySkeletonType } from './util'

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -68,10 +68,13 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
   | RangeFilters<Fields, 'fields'>
   | ReferenceSearchFilters<Fields, 'fields'>
 
+export type EntryContentTypeQuery<T extends string> = {
+  content_type: T
+}
+
 export type EntriesQueries<FieldsWithContentTypeId extends FieldsWithContentTypeIdType> =
-  | (EntryFieldsQueries<FieldsWithContentTypeId['fields']> & {
-      content_type: FieldsWithContentTypeId['contentTypeId']
-    })
+  | (EntryFieldsQueries<FieldsWithContentTypeId['fields']> &
+      EntryContentTypeQuery<FieldsWithContentTypeId['contentTypeId']>)
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       MetadataTagsQueries &
       EntrySelectFilter &

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -7,7 +7,12 @@ import { RangeFilters } from './range'
 import { FullTextSearchFilters } from './search'
 import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
 import { SubsetFilters } from './subset'
-import { ConditionalFixedQueries, ConditionalListQueries, FieldsType } from './util'
+import {
+  ConditionalFixedQueries,
+  ConditionalListQueries,
+  FieldsType,
+  FieldsWithContentTypeIdType,
+} from './util'
 import { ReferenceSearchFilters } from './reference'
 import { TagSys } from '../sys'
 import { Metadata } from '../metadata'
@@ -63,8 +68,10 @@ export type EntryFieldsQueries<Fields extends FieldsType> =
   | RangeFilters<Fields, 'fields'>
   | ReferenceSearchFilters<Fields, 'fields'>
 
-export type EntriesQueries<Fields extends FieldsType> =
-  | (EntryFieldsQueries<Fields> & { content_type: string })
+export type EntriesQueries<FieldsWithContentTypeId extends FieldsWithContentTypeIdType> =
+  | (EntryFieldsQueries<FieldsWithContentTypeId['fields']> & {
+      content_type: FieldsWithContentTypeId['contentTypeId']
+    })
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       MetadataTagsQueries &
       EntrySelectFilter &

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -11,7 +11,7 @@ import {
   ConditionalFixedQueries,
   ConditionalListQueries,
   FieldsType,
-  FieldsWithContentTypeIdType,
+  EntrySkeletonType,
 } from './util'
 import { ReferenceSearchFilters } from './reference'
 import { TagSys } from '../sys'
@@ -72,9 +72,9 @@ export type EntryContentTypeQuery<T extends string> = {
   content_type: T
 }
 
-export type EntriesQueries<FieldsWithContentTypeId extends FieldsWithContentTypeIdType> =
-  | (EntryFieldsQueries<FieldsWithContentTypeId['fields']> &
-      EntryContentTypeQuery<FieldsWithContentTypeId['contentTypeId']>)
+export type EntriesQueries<EntrySkeleton extends EntrySkeletonType> =
+  | (EntryFieldsQueries<EntrySkeleton['fields']> &
+      EntryContentTypeQuery<EntrySkeleton['contentTypeId']>)
   | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       MetadataTagsQueries &
       EntrySelectFilter &

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -1,4 +1,4 @@
-import { AssetDetails, AssetFields, AssetFile, AssetMimeType, AssetSys } from '../asset'
+import { AssetDetails, AssetFile, AssetMimeType, AssetSys } from '../asset'
 import { EntrySys } from '../entry'
 import { EqualityFilter, InequalityFilter } from './equality'
 import { ExistenceFilter } from './existence'

--- a/lib/types/query/search.ts
+++ b/lib/types/query/search.ts
@@ -1,5 +1,5 @@
 import { EntryFields } from '../entry'
-import { ConditionalFixedQueries } from './util'
+import { ConditionalFixedQueries, FieldsType } from './util'
 
 type SupportedTypes =
   | EntryFields.Text
@@ -12,10 +12,7 @@ type SupportedTypes =
  * @desc match - full text search
  * @see [documentation]{@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/full-text-search}
  */
-export type FullTextSearchFilters<Fields, Prefix extends string> = ConditionalFixedQueries<
-  Fields,
-  SupportedTypes,
-  string,
-  Prefix,
-  '[match]'
->
+export type FullTextSearchFilters<
+  Fields extends FieldsType,
+  Prefix extends string
+> = ConditionalFixedQueries<Fields, SupportedTypes, string, Prefix, '[match]'>

--- a/lib/types/query/util.ts
+++ b/lib/types/query/util.ts
@@ -2,7 +2,7 @@ import { ConditionalPick } from 'type-fest'
 
 export type FieldsType = Record<string, any>
 
-export type FieldsWithContentTypeIdType<Fields extends FieldsType = FieldsType, Id = string> = {
+export type EntrySkeletonType<Fields extends FieldsType = FieldsType, Id = string> = {
   fields: Fields
   contentTypeId: Id
 }

--- a/lib/types/query/util.ts
+++ b/lib/types/query/util.ts
@@ -2,12 +2,17 @@ import { ConditionalPick } from 'type-fest'
 
 export type FieldsType = Record<string, any>
 
+export type FieldsWithContentTypeIdType<Fields extends FieldsType = FieldsType, Id = string> = {
+  fields: Fields
+  contentTypeId: Id
+}
+
 export type BaseOrArrayType<T> = T extends Array<infer U> ? U : T
 
 export type NonEmpty<T> = T extends Record<string, never> ? never : T
 
 export type ConditionalFixedQueries<
-  Fields,
+  Fields extends FieldsType,
   SupportedTypes,
   ValueType,
   Prefix extends string,

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -1,7 +1,7 @@
 import { Asset } from './asset'
 import { Entry } from './entry'
 import { EntitySys } from './sys'
-import { FieldsWithContentTypeIdType } from './query'
+import { EntrySkeletonType } from './query'
 import { LocaleCode } from './locale'
 import { ChainModifiers } from '../utils/client-helpers'
 
@@ -41,16 +41,16 @@ export type DeletedAsset = {
   sys: EntitySys & { type: 'DeletedAsset' }
 }
 
-export type SyncEntities = Entry<FieldsWithContentTypeIdType> | Asset | DeletedEntry | DeletedAsset
+export type SyncEntities = Entry<EntrySkeletonType> | Asset | DeletedEntry | DeletedAsset
 
 export interface SyncCollection<
-  FieldsWithContentTypeId extends FieldsWithContentTypeIdType,
+  EntrySkeleton extends EntrySkeletonType,
   Modifiers extends ChainModifiers = ChainModifiers,
   Locales extends LocaleCode = LocaleCode
 > {
   entries: Array<
     Entry<
-      FieldsWithContentTypeId,
+      EntrySkeleton,
       ChainModifiers extends Modifiers
         ? ChainModifiers
         : Exclude<Modifiers, undefined> | 'WITH_ALL_LOCALES',

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -1,7 +1,7 @@
 import { Asset } from './asset'
 import { Entry } from './entry'
 import { EntitySys } from './sys'
-import { FieldsType } from './query'
+import { FieldsWithContentTypeIdType } from './query'
 import { LocaleCode } from './locale'
 import { ChainModifiers } from '../utils/client-helpers'
 
@@ -41,16 +41,16 @@ export type DeletedAsset = {
   sys: EntitySys & { type: 'DeletedAsset' }
 }
 
-export type SyncEntities = Entry | Asset | DeletedEntry | DeletedAsset
+export type SyncEntities = Entry<FieldsWithContentTypeIdType> | Asset | DeletedEntry | DeletedAsset
 
 export interface SyncCollection<
-  Fields extends FieldsType = FieldsType,
+  FieldsWithContentTypeId extends FieldsWithContentTypeIdType,
   Modifiers extends ChainModifiers = ChainModifiers,
   Locales extends LocaleCode = LocaleCode
 > {
   entries: Array<
     Entry<
-      Fields,
+      FieldsWithContentTypeId,
       ChainModifiers extends Modifiers
         ? ChainModifiers
         : Exclude<Modifiers, undefined> | 'WITH_ALL_LOCALES',

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,4 +1,4 @@
-import { FieldsWithContentTypeIdType } from '../../lib'
+import { EntrySkeletonType } from '../../lib'
 import * as contentful from '../../lib/contentful'
 import { params, previewParams } from './utils'
 
@@ -28,7 +28,7 @@ describe('getEntries via chained clients', () => {
     })
 
     test('Gets entries with select', async () => {
-      type FieldsWithContentTypeId = FieldsWithContentTypeIdType<
+      type TypeCatSkeleton = EntrySkeletonType<
         {
           name: string
           likes: string
@@ -37,7 +37,7 @@ describe('getEntries via chained clients', () => {
         'cat'
       >
 
-      const response = await client.getEntries<FieldsWithContentTypeId>({
+      const response = await client.getEntries<TypeCatSkeleton>({
         select: ['fields.name', 'fields.likes'],
         content_type: 'cat',
       })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,6 +1,5 @@
 import { FieldsWithContentTypeIdType } from '../../lib'
 import * as contentful from '../../lib/contentful'
-// @ts-ignore
 import { params, previewParams } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -1,3 +1,4 @@
+import { FieldsWithContentTypeIdType } from '../../lib'
 import * as contentful from '../../lib/contentful'
 // @ts-ignore
 import { params, previewParams } from './utils'
@@ -28,13 +29,16 @@ describe('getEntries via chained clients', () => {
     })
 
     test('Gets entries with select', async () => {
-      type Fields = {
-        name: string
-        likes: string
-        color: string
-      }
+      type FieldsWithContentTypeId = FieldsWithContentTypeIdType<
+        {
+          name: string
+          likes: string
+          color: string
+        },
+        'cat'
+      >
 
-      const response = await client.getEntries<Fields>({
+      const response = await client.getEntries<FieldsWithContentTypeId>({
         select: ['fields.name', 'fields.likes'],
         content_type: 'cat',
       })

--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -1,7 +1,6 @@
 import * as contentful from '../../lib/contentful'
 import { localeSpaceParams, params, previewParams } from './utils'
-import { EntryFields } from '../../lib'
-import { FieldsWithContentTypeIdType } from '../../lib/types/query/util'
+import { EntryFields, EntrySkeletonType } from '../../lib'
 
 if (process.env.API_INTEGRATION_TESTS) {
   params.host = '127.0.0.1:5000'
@@ -28,11 +27,12 @@ describe('getEntry via chained clients', () => {
     })
 
     test('Gets an entry with a specific locale', async () => {
-      const entry = await client.getEntry<
-        FieldsWithContentTypeIdType<{ test: EntryFields.Symbol }>
-      >(entryWithResolvableLink, {
-        locale: 'tlh',
-      })
+      const entry = await client.getEntry<EntrySkeletonType<{ test: EntryFields.Symbol }>>(
+        entryWithResolvableLink,
+        {
+          locale: 'tlh',
+        }
+      )
       expect(entry.sys.locale).toBe('tlh')
     })
 
@@ -181,14 +181,14 @@ describe('getEntry via chained clients', () => {
 })
 
 test('Get entry with fallback locale', async () => {
-  type FieldsWithContentTypeId = FieldsWithContentTypeIdType<{ title: string }>
+  type EntrySkeleton = EntrySkeletonType<{ title: string }>
 
   const entries = await Promise.all([
-    localeClient.getEntry<FieldsWithContentTypeId>('no-af-and-no-zu-za', { locale: 'af' }),
-    localeClient.getEntry<FieldsWithContentTypeId>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
-    localeClient.getEntry<FieldsWithContentTypeId>('no-zu-ZA', { locale: 'zu-ZA' }),
-    localeClient.getEntry<FieldsWithContentTypeId>('no-ne-NP', { locale: 'ne-NP' }),
-    localeClient.getEntry<FieldsWithContentTypeId>('no-af', { locale: 'af' }),
+    localeClient.getEntry<EntrySkeleton>('no-af-and-no-zu-za', { locale: 'af' }),
+    localeClient.getEntry<EntrySkeleton>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
+    localeClient.getEntry<EntrySkeleton>('no-zu-ZA', { locale: 'zu-ZA' }),
+    localeClient.getEntry<EntrySkeleton>('no-ne-NP', { locale: 'ne-NP' }),
+    localeClient.getEntry<EntrySkeleton>('no-af', { locale: 'af' }),
   ])
 
   expect(entries[0].fields.title).not.toBe('')

--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -2,6 +2,7 @@ import * as contentful from '../../lib/contentful'
 // @ts-ignore
 import { localeSpaceParams, params, previewParams } from './utils'
 import { EntryFields } from '../../lib'
+import { FieldsWithContentTypeIdType } from '../../lib/types/query/util'
 
 if (process.env.API_INTEGRATION_TESTS) {
   params.host = '127.0.0.1:5000'
@@ -28,7 +29,9 @@ describe('getEntry via chained clients', () => {
     })
 
     test('Gets an entry with a specific locale', async () => {
-      const entry = await client.getEntry<{ test: EntryFields.Symbol }>(entryWithResolvableLink, {
+      const entry = await client.getEntry<
+        FieldsWithContentTypeIdType<{ test: EntryFields.Symbol }>
+      >(entryWithResolvableLink, {
         locale: 'tlh',
       })
       expect(entry.sys.locale).toBe('tlh')
@@ -179,14 +182,14 @@ describe('getEntry via chained clients', () => {
 })
 
 test('Get entry with fallback locale', async () => {
-  type Fields = { title: string }
+  type FieldsWithContentTypeId = FieldsWithContentTypeIdType<{ title: string }>
 
   const entries = await Promise.all([
-    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'af' }),
-    localeClient.getEntry<Fields>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
-    localeClient.getEntry<Fields>('no-zu-ZA', { locale: 'zu-ZA' }),
-    localeClient.getEntry<Fields>('no-ne-NP', { locale: 'ne-NP' }),
-    localeClient.getEntry<Fields>('no-af', { locale: 'af' }),
+    localeClient.getEntry<FieldsWithContentTypeId>('no-af-and-no-zu-za', { locale: 'af' }),
+    localeClient.getEntry<FieldsWithContentTypeId>('no-af-and-no-zu-za', { locale: 'zu-ZA' }),
+    localeClient.getEntry<FieldsWithContentTypeId>('no-zu-ZA', { locale: 'zu-ZA' }),
+    localeClient.getEntry<FieldsWithContentTypeId>('no-ne-NP', { locale: 'ne-NP' }),
+    localeClient.getEntry<FieldsWithContentTypeId>('no-af', { locale: 'af' }),
   ])
 
   expect(entries[0].fields.title).not.toBe('')

--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -1,5 +1,4 @@
 import * as contentful from '../../lib/contentful'
-// @ts-ignore
 import { localeSpaceParams, params, previewParams } from './utils'
 import { EntryFields } from '../../lib'
 import { FieldsWithContentTypeIdType } from '../../lib/types/query/util'

--- a/test/integration/parseEntries.test.ts
+++ b/test/integration/parseEntries.test.ts
@@ -1,5 +1,5 @@
 import * as contentful from '../../lib/contentful'
-import { FieldsWithContentTypeIdType, Link } from '../../lib/types'
+import { EntrySkeletonType, Link } from '../../lib/types'
 import { EntryFields, EntryCollection } from '../../lib/types/entry'
 import { params } from './utils'
 
@@ -14,7 +14,7 @@ interface TypeCatFields {
   image?: { sys: Link<'Asset'> }
 }
 
-export type TypeCatFieldsWithContentTypeId = FieldsWithContentTypeIdType<TypeCatFields, 'cat'>
+export type TypeCatSkeleton = EntrySkeletonType<TypeCatFields, 'cat'>
 
 if (process.env.API_INTEGRATION_TESTS) {
   params.host = '127.0.0.1:5000'
@@ -23,21 +23,15 @@ if (process.env.API_INTEGRATION_TESTS) {
 
 const client = contentful.createClient(params)
 
-let dataWithResolvableLink = {} as EntryCollection<
-  TypeCatFieldsWithContentTypeId,
-  'WITHOUT_LINK_RESOLUTION'
->
+let dataWithResolvableLink = {} as EntryCollection<TypeCatSkeleton, 'WITHOUT_LINK_RESOLUTION'>
 let dataWithResolvableLinkAndAllLocales = {} as EntryCollection<
-  TypeCatFieldsWithContentTypeId,
+  TypeCatSkeleton,
   'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
   'en-US' | 'tlh'
 >
-let dataWithUnresolvableLink = {} as EntryCollection<
-  TypeCatFieldsWithContentTypeId,
-  'WITHOUT_LINK_RESOLUTION'
->
+let dataWithUnresolvableLink = {} as EntryCollection<TypeCatSkeleton, 'WITHOUT_LINK_RESOLUTION'>
 let dataWithUnresolvableLinkAndAllLocales = {} as EntryCollection<
-  TypeCatFieldsWithContentTypeId,
+  TypeCatSkeleton,
   'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
   'en-US' | 'tlh'
 >

--- a/test/integration/parseEntries.test.ts
+++ b/test/integration/parseEntries.test.ts
@@ -1,8 +1,9 @@
 import * as contentful from '../../lib/contentful'
-import { Link } from '../../lib/types'
+import { FieldsWithContentTypeIdType, Link } from '../../lib/types'
 import { EntryFields, EntryCollection } from '../../lib/types/entry'
 import { params } from './utils'
-export interface TypeCatFields {
+
+interface TypeCatFields {
   name: EntryFields.Text
   likes?: EntryFields.Symbol[]
   color?: EntryFields.Symbol
@@ -13,6 +14,8 @@ export interface TypeCatFields {
   image?: { sys: Link<'Asset'> }
 }
 
+export type TypeCatFieldsWithContentTypeId = FieldsWithContentTypeIdType<TypeCatFields, 'cat'>
+
 if (process.env.API_INTEGRATION_TESTS) {
   params.host = '127.0.0.1:5000'
   params.insecure = true
@@ -20,15 +23,21 @@ if (process.env.API_INTEGRATION_TESTS) {
 
 const client = contentful.createClient(params)
 
-let dataWithResolvableLink = {} as EntryCollection<TypeCatFields, 'WITHOUT_LINK_RESOLUTION'>
+let dataWithResolvableLink = {} as EntryCollection<
+  TypeCatFieldsWithContentTypeId,
+  'WITHOUT_LINK_RESOLUTION'
+>
 let dataWithResolvableLinkAndAllLocales = {} as EntryCollection<
-  TypeCatFields,
+  TypeCatFieldsWithContentTypeId,
   'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
   'en-US' | 'tlh'
 >
-let dataWithUnresolvableLink = {} as EntryCollection<TypeCatFields, 'WITHOUT_LINK_RESOLUTION'>
+let dataWithUnresolvableLink = {} as EntryCollection<
+  TypeCatFieldsWithContentTypeId,
+  'WITHOUT_LINK_RESOLUTION'
+>
 let dataWithUnresolvableLinkAndAllLocales = {} as EntryCollection<
-  TypeCatFields,
+  TypeCatFieldsWithContentTypeId,
   'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
   'en-US' | 'tlh'
 >

--- a/test/integration/sync.test.ts
+++ b/test/integration/sync.test.ts
@@ -1,5 +1,5 @@
 import * as contentful from '../../lib/contentful'
-import { TypeCatFields } from './parseEntries.test'
+import { TypeCatFieldsWithContentTypeId } from './parseEntries.test'
 import { params } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {
@@ -58,7 +58,7 @@ describe('Sync API', () => {
   })
 
   test('Sync has withoutUnresolvableLinks modifier', async () => {
-    const response = await client.withoutUnresolvableLinks.sync<TypeCatFields>({
+    const response = await client.withoutUnresolvableLinks.sync<TypeCatFieldsWithContentTypeId>({
       initial: true,
       type: 'Entry',
       content_type: 'cat',
@@ -85,7 +85,7 @@ describe('Sync API', () => {
   })
 
   test('Sync has withoutLinkResolution modifier', async () => {
-    const response = await client.withoutLinkResolution.sync<TypeCatFields>({
+    const response = await client.withoutLinkResolution.sync<TypeCatFieldsWithContentTypeId>({
       initial: true,
       type: 'Entry',
       content_type: 'cat',

--- a/test/integration/sync.test.ts
+++ b/test/integration/sync.test.ts
@@ -1,5 +1,5 @@
 import * as contentful from '../../lib/contentful'
-import { TypeCatFieldsWithContentTypeId } from './parseEntries.test'
+import { TypeCatSkeleton } from './parseEntries.test'
 import { params } from './utils'
 
 if (process.env.API_INTEGRATION_TESTS) {
@@ -58,7 +58,7 @@ describe('Sync API', () => {
   })
 
   test('Sync has withoutUnresolvableLinks modifier', async () => {
-    const response = await client.withoutUnresolvableLinks.sync<TypeCatFieldsWithContentTypeId>({
+    const response = await client.withoutUnresolvableLinks.sync<TypeCatSkeleton>({
       initial: true,
       type: 'Entry',
       content_type: 'cat',
@@ -85,7 +85,7 @@ describe('Sync API', () => {
   })
 
   test('Sync has withoutLinkResolution modifier', async () => {
-    const response = await client.withoutLinkResolution.sync<TypeCatFieldsWithContentTypeId>({
+    const response = await client.withoutLinkResolution.sync<TypeCatSkeleton>({
       initial: true,
       type: 'Entry',
       content_type: 'cat',

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType, expectError } from 'tsd'
-import { createClient, EntryCollection, Entry, FieldsWithContentTypeIdType } from '../../../lib'
+import { createClient, EntryCollection, Entry, EntrySkeletonType } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -10,128 +10,112 @@ type LinkedFields = {
   name: string
 }
 
-type LinkedFieldsWithContentTypeId = FieldsWithContentTypeIdType<LinkedFields, 'linked-type-id'>
+type LinkedSkeleton = EntrySkeletonType<LinkedFields, 'linked-type-id'>
 
 type Fields = {
   title: string
-  link: Entry<LinkedFieldsWithContentTypeId>
-  moreLinks: Entry<LinkedFieldsWithContentTypeId>[]
+  link: Entry<LinkedSkeleton>
+  moreLinks: Entry<LinkedSkeleton>[]
 }
 
-type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields, 'content-type-id'>
+type EntrySkeleton = EntrySkeletonType<Fields, 'content-type-id'>
 
 type Locale = 'en'
 
-expectType<Entry<FieldsWithContentTypeIdType, undefined>>(await client.getEntry('entry-id'))
-expectType<Entry<FieldsWithContentTypeId, undefined>>(
-  await client.getEntry<FieldsWithContentTypeId>('entry-id')
-)
-expectType<EntryCollection<FieldsWithContentTypeIdType, undefined>>(await client.getEntries())
-expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
-  await client.getEntries<FieldsWithContentTypeId>()
-)
+expectType<Entry<EntrySkeleton, undefined>>(await client.getEntry('entry-id'))
+expectType<Entry<EntrySkeleton, undefined>>(await client.getEntry<EntrySkeleton>('entry-id'))
+expectType<EntryCollection<EntrySkeleton, undefined>>(await client.getEntries())
+expectType<EntryCollection<EntrySkeleton, undefined>>(await client.getEntries<EntrySkeleton>())
 
-expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
-  await client.getEntries<FieldsWithContentTypeId>({ content_type: 'content-type-id' })
+expectType<EntryCollection<EntrySkeleton, undefined>>(
+  await client.getEntries<EntrySkeleton>({ content_type: 'content-type-id' })
 )
-expectError(await client.getEntries<FieldsWithContentTypeId>({ content_type: 'unexpected' }))
-expectType<EntryCollection<FieldsWithContentTypeId | LinkedFieldsWithContentTypeId, undefined>>(
-  await client.getEntries<FieldsWithContentTypeId | LinkedFieldsWithContentTypeId>({
+expectError(await client.getEntries<EntrySkeleton>({ content_type: 'unexpected' }))
+expectType<EntryCollection<EntrySkeleton | LinkedSkeleton, undefined>>(
+  await client.getEntries<EntrySkeleton | LinkedSkeleton>({
     content_type: 'content-type-id',
   })
 )
 
-expectType<Entry<FieldsWithContentTypeIdType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<Entry<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntry<EntrySkeleton>('entry-id')
 )
-expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntries()
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId>()
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntries<EntrySkeleton>()
 )
 
-expectType<Entry<FieldsWithContentTypeIdType, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntry<FieldsWithContentTypeId>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntry<EntrySkeleton>('entry-id')
 )
-expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntries()
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntries<FieldsWithContentTypeId>()
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntries<EntrySkeleton>()
 )
 
-expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES'>>(
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntry('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntry<FieldsWithContentTypeId>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntry<EntrySkeleton>('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntry<FieldsWithContentTypeId, Locale>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntry<EntrySkeleton, Locale>('entry-id')
 )
-expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES'>>(
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntries()
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntries<FieldsWithContentTypeId>()
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntries<EntrySkeleton>()
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntries<FieldsWithContentTypeId, Locale>()
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntries<EntrySkeleton, Locale>()
 )
 
-expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntry('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<EntrySkeleton>('entry-id')
+)
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<EntrySkeleton, Locale>('entry-id')
+)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries()
+)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<EntrySkeleton>()
 )
 expectType<
-  Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>
->(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId, Locale>(
-    'entry-id'
-  )
-)
-expectType<
-  EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
->(await client.withAllLocales.withoutUnresolvableLinks.getEntries())
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
->(await client.withAllLocales.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId>())
-expectType<
-  EntryCollection<
-    FieldsWithContentTypeId,
-    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
-    Locale
-  >
->(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId, Locale>()
-)
+  EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>
+>(await client.withAllLocales.withoutUnresolvableLinks.getEntries<EntrySkeleton, Locale>())
 
-expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withAllLocales.withoutLinkResolution.getEntry('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<FieldsWithContentTypeId>('entry-id')
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<EntrySkeleton>('entry-id')
 )
-expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<FieldsWithContentTypeId, Locale>(
-    'entry-id'
-  )
+expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<EntrySkeleton, Locale>('entry-id')
 )
-expectType<
-  EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
->(await client.withAllLocales.withoutLinkResolution.getEntries())
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
->(await client.withAllLocales.withoutLinkResolution.getEntries<FieldsWithContentTypeId>())
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>
->(await client.withAllLocales.withoutLinkResolution.getEntries<FieldsWithContentTypeId, Locale>())
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries()
+)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries<EntrySkeleton>()
+)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries<EntrySkeleton, Locale>()
+)

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType } from 'tsd'
-import { createClient, EntryCollection, Entry, FieldsType } from '../../../lib'
+import { createClient, EntryCollection, Entry } from '../../../lib'
+import { FieldsWithContentTypeIdType } from '../../../dist/types/types/query/util'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -10,96 +11,118 @@ type LinkedFields = {
   name: string
 }
 
+type LinkedFieldsWithContentTypeId = FieldsWithContentTypeIdType<LinkedFields>
+
 type Fields = {
   title: string
-  link: Entry<LinkedFields>
-  moreLinks: Entry<LinkedFields>[]
+  link: Entry<LinkedFieldsWithContentTypeId>
+  moreLinks: Entry<LinkedFieldsWithContentTypeId>[]
 }
+
+type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields>
 
 type Locale = 'en'
 
-expectType<Entry<FieldsType, undefined>>(await client.getEntry('entry-id'))
-expectType<Entry<Fields, undefined>>(await client.getEntry<Fields>('entry-id'))
-expectType<EntryCollection<FieldsType, undefined>>(await client.getEntries())
-expectType<EntryCollection<Fields, undefined>>(await client.getEntries<Fields>())
+expectType<Entry<FieldsWithContentTypeIdType, undefined>>(await client.getEntry('entry-id'))
+expectType<Entry<FieldsWithContentTypeId, undefined>>(
+  await client.getEntry<FieldsWithContentTypeId>('entry-id')
+)
+expectType<EntryCollection<FieldsWithContentTypeIdType, undefined>>(await client.getEntries())
+expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
+  await client.getEntries<FieldsWithContentTypeId>()
+)
 
-expectType<Entry<FieldsType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<Entry<FieldsWithContentTypeIdType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry('entry-id')
 )
-expectType<Entry<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId>('entry-id')
 )
-expectType<EntryCollection<FieldsType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntries()
 )
-expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntries<Fields>()
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId>()
 )
 
-expectType<Entry<FieldsType, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<FieldsWithContentTypeIdType, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry('entry-id')
 )
-expectType<Entry<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntry<Fields>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntry<FieldsWithContentTypeId>('entry-id')
 )
-expectType<EntryCollection<FieldsType, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntries()
 )
-expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntries<Fields>()
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntries<FieldsWithContentTypeId>()
 )
 
-expectType<Entry<FieldsType, 'WITH_ALL_LOCALES'>>(await client.withAllLocales.getEntry('entry-id'))
-expectType<Entry<Fields, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntry<Fields>('entry-id')
+expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntry('entry-id')
 )
-expectType<Entry<Fields, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntry<Fields, Locale>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntry<FieldsWithContentTypeId>('entry-id')
 )
-expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES'>>(
+expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntry<FieldsWithContentTypeId, Locale>('entry-id')
+)
+expectType<EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntries()
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntries<Fields>()
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntries<FieldsWithContentTypeId>()
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntries<Fields, Locale>()
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntries<FieldsWithContentTypeId, Locale>()
 )
 
-expectType<Entry<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntry('entry-id')
 )
-expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId>('entry-id')
 )
-expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<Fields, Locale>('entry-id')
+expectType<
+  Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>
+>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<FieldsWithContentTypeId, Locale>(
+    'entry-id'
+  )
 )
-expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries()
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields>()
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries<Fields, Locale>()
+expectType<
+  EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+>(await client.withAllLocales.withoutUnresolvableLinks.getEntries())
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+>(await client.withAllLocales.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId>())
+expectType<
+  EntryCollection<
+    FieldsWithContentTypeId,
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
+    Locale
+  >
+>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<FieldsWithContentTypeId, Locale>()
 )
 
-expectType<Entry<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withAllLocales.withoutLinkResolution.getEntry('entry-id')
 )
-expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<Fields>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<FieldsWithContentTypeId>('entry-id')
 )
-expectType<Entry<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<Fields, Locale>('entry-id')
+expectType<Entry<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<FieldsWithContentTypeId, Locale>(
+    'entry-id'
+  )
 )
-expectType<EntryCollection<FieldsType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries()
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries<Fields>()
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries<Fields, Locale>()
-)
+expectType<
+  EntryCollection<FieldsWithContentTypeIdType, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+>(await client.withAllLocales.withoutLinkResolution.getEntries())
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+>(await client.withAllLocales.withoutLinkResolution.getEntries<FieldsWithContentTypeId>())
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>
+>(await client.withAllLocales.withoutLinkResolution.getEntries<FieldsWithContentTypeId, Locale>())

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -1,6 +1,5 @@
-import { expectType } from 'tsd'
-import { createClient, EntryCollection, Entry } from '../../../lib'
-import { FieldsWithContentTypeIdType } from '../../../dist/types/types/query/util'
+import { expectType, expectError } from 'tsd'
+import { createClient, EntryCollection, Entry, FieldsWithContentTypeIdType } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -11,7 +10,7 @@ type LinkedFields = {
   name: string
 }
 
-type LinkedFieldsWithContentTypeId = FieldsWithContentTypeIdType<LinkedFields>
+type LinkedFieldsWithContentTypeId = FieldsWithContentTypeIdType<LinkedFields, 'linked-type-id'>
 
 type Fields = {
   title: string
@@ -19,7 +18,7 @@ type Fields = {
   moreLinks: Entry<LinkedFieldsWithContentTypeId>[]
 }
 
-type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields>
+type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields, 'content-type-id'>
 
 type Locale = 'en'
 
@@ -30,6 +29,16 @@ expectType<Entry<FieldsWithContentTypeId, undefined>>(
 expectType<EntryCollection<FieldsWithContentTypeIdType, undefined>>(await client.getEntries())
 expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
   await client.getEntries<FieldsWithContentTypeId>()
+)
+
+expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
+  await client.getEntries<FieldsWithContentTypeId>({ content_type: 'content-type-id' })
+)
+expectError(await client.getEntries<FieldsWithContentTypeId>({ content_type: 'unexpected' }))
+expectType<EntryCollection<FieldsWithContentTypeId | LinkedFieldsWithContentTypeId, undefined>>(
+  await client.getEntries<FieldsWithContentTypeId | LinkedFieldsWithContentTypeId>({
+    content_type: 'content-type-id',
+  })
 )
 
 expectType<Entry<FieldsWithContentTypeIdType, 'WITHOUT_UNRESOLVABLE_LINKS'>>(

--- a/test/types/client/parseEntries.test-d.ts
+++ b/test/types/client/parseEntries.test-d.ts
@@ -1,5 +1,11 @@
 import { expectType } from 'tsd'
-import { createClient, EntryCollection, EntrySys, FieldsType, Link, LocaleCode } from '../../../lib'
+import {
+  createClient,
+  EntryCollection,
+  EntrySys,
+  FieldsWithContentTypeIdType,
+  Link,
+} from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -12,7 +18,9 @@ type Fields = {
   moreLinks: { sys: Link<'Entry'> }[]
 }
 
-const data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'> = {
+type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields>
+
+const data: EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
   total: 10,
   skip: 0,
   limit: 1,
@@ -50,7 +58,7 @@ const data: EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'> = {
 type Locales = 'en' | 'de'
 
 const dataWithAllLocales: EntryCollection<
-  Fields,
+  FieldsWithContentTypeId,
   'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES',
   Locales
 > = {
@@ -95,49 +103,75 @@ const dataWithAllLocales: EntryCollection<
   ],
 }
 
-expectType<EntryCollection<Fields, undefined>>(client.parseEntries(data))
-expectType<EntryCollection<Fields, undefined>>(client.parseEntries<Fields>(data))
+expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(client.parseEntries(data))
+expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
+  client.parseEntries<FieldsWithContentTypeId>(data)
+)
 
-expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   client.withoutUnresolvableLinks.parseEntries(data)
 )
-expectType<EntryCollection<Fields, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  client.withoutUnresolvableLinks.parseEntries<Fields>(data)
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  client.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId>(data)
 )
 
-expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
   client.withoutLinkResolution.parseEntries(data)
 )
-expectType<EntryCollection<Fields, 'WITHOUT_LINK_RESOLUTION'>>(
-  client.withoutLinkResolution.parseEntries<Fields>(data)
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
+  client.withoutLinkResolution.parseEntries<FieldsWithContentTypeId>(data)
 )
 
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>(
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locales>>(
   client.withAllLocales.parseEntries(dataWithAllLocales)
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES'>>(
-  client.withAllLocales.parseEntries<Fields>(dataWithAllLocales)
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
+  client.withAllLocales.parseEntries<FieldsWithContentTypeId>(dataWithAllLocales)
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES', Locales>>(
-  client.withAllLocales.parseEntries<Fields, Locales>(dataWithAllLocales)
-)
-
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>(
-  client.withAllLocales.withoutUnresolvableLinks.parseEntries(dataWithAllLocales)
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  client.withAllLocales.withoutUnresolvableLinks.parseEntries<Fields>(dataWithAllLocales)
-)
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>>(
-  client.withAllLocales.withoutUnresolvableLinks.parseEntries<Fields, Locales>(dataWithAllLocales)
+expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locales>>(
+  client.withAllLocales.parseEntries<FieldsWithContentTypeId, Locales>(dataWithAllLocales)
 )
 
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
-  client.withAllLocales.withoutLinkResolution.parseEntries(dataWithAllLocales)
+expectType<
+  EntryCollection<
+    FieldsWithContentTypeId,
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
+    Locales
+  >
+>(client.withAllLocales.withoutUnresolvableLinks.parseEntries(dataWithAllLocales))
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
+>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId>(
+    dataWithAllLocales
+  )
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  client.withAllLocales.withoutLinkResolution.parseEntries<Fields>(dataWithAllLocales)
+expectType<
+  EntryCollection<
+    FieldsWithContentTypeId,
+    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
+    Locales
+  >
+>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId, Locales>(
+    dataWithAllLocales
+  )
 )
-expectType<EntryCollection<Fields, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
-  client.withAllLocales.withoutLinkResolution.parseEntries<Fields, Locales>(dataWithAllLocales)
+
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
+>(client.withAllLocales.withoutLinkResolution.parseEntries(dataWithAllLocales))
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
+>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<FieldsWithContentTypeId>(
+    dataWithAllLocales
+  )
+)
+expectType<
+  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
+>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<FieldsWithContentTypeId, Locales>(
+    dataWithAllLocales
+  )
 )

--- a/test/types/client/parseEntries.test-d.ts
+++ b/test/types/client/parseEntries.test-d.ts
@@ -1,11 +1,5 @@
 import { expectType } from 'tsd'
-import {
-  createClient,
-  EntryCollection,
-  EntrySys,
-  FieldsWithContentTypeIdType,
-  Link,
-} from '../../../lib'
+import { createClient, EntryCollection, EntrySys, EntrySkeletonType, Link } from '../../../lib'
 
 const client = createClient({
   accessToken: 'accessToken',
@@ -18,9 +12,9 @@ type Fields = {
   moreLinks: { sys: Link<'Entry'> }[]
 }
 
-type FieldsWithContentTypeId = FieldsWithContentTypeIdType<Fields>
+type EntrySkeleton = EntrySkeletonType<Fields>
 
-const data: EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
+const data: EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'> = {
   total: 10,
   skip: 0,
   limit: 1,
@@ -58,7 +52,7 @@ const data: EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> 
 type Locales = 'en' | 'de'
 
 const dataWithAllLocales: EntryCollection<
-  FieldsWithContentTypeId,
+  EntrySkeleton,
   'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES',
   Locales
 > = {
@@ -103,75 +97,55 @@ const dataWithAllLocales: EntryCollection<
   ],
 }
 
-expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(client.parseEntries(data))
-expectType<EntryCollection<FieldsWithContentTypeId, undefined>>(
-  client.parseEntries<FieldsWithContentTypeId>(data)
-)
+expectType<EntryCollection<EntrySkeleton, undefined>>(client.parseEntries(data))
+expectType<EntryCollection<EntrySkeleton, undefined>>(client.parseEntries<EntrySkeleton>(data))
 
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   client.withoutUnresolvableLinks.parseEntries(data)
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  client.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId>(data)
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  client.withoutUnresolvableLinks.parseEntries<EntrySkeleton>(data)
 )
 
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
   client.withoutLinkResolution.parseEntries(data)
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'>>(
-  client.withoutLinkResolution.parseEntries<FieldsWithContentTypeId>(data)
+expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  client.withoutLinkResolution.parseEntries<EntrySkeleton>(data)
 )
 
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locales>>(
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES', Locales>>(
   client.withAllLocales.parseEntries(dataWithAllLocales)
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES'>>(
-  client.withAllLocales.parseEntries<FieldsWithContentTypeId>(dataWithAllLocales)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  client.withAllLocales.parseEntries<EntrySkeleton>(dataWithAllLocales)
 )
-expectType<EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES', Locales>>(
-  client.withAllLocales.parseEntries<FieldsWithContentTypeId, Locales>(dataWithAllLocales)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES', Locales>>(
+  client.withAllLocales.parseEntries<EntrySkeleton, Locales>(dataWithAllLocales)
 )
 
 expectType<
-  EntryCollection<
-    FieldsWithContentTypeId,
-    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
-    Locales
-  >
+  EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
 >(client.withAllLocales.withoutUnresolvableLinks.parseEntries(dataWithAllLocales))
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>
->(
-  client.withAllLocales.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId>(
-    dataWithAllLocales
-  )
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<EntrySkeleton>(dataWithAllLocales)
 )
 expectType<
-  EntryCollection<
-    FieldsWithContentTypeId,
-    'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
-    Locales
-  >
+  EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locales>
 >(
-  client.withAllLocales.withoutUnresolvableLinks.parseEntries<FieldsWithContentTypeId, Locales>(
+  client.withAllLocales.withoutUnresolvableLinks.parseEntries<EntrySkeleton, Locales>(
     dataWithAllLocales
   )
 )
 
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
->(client.withAllLocales.withoutLinkResolution.parseEntries(dataWithAllLocales))
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>
->(
-  client.withAllLocales.withoutLinkResolution.parseEntries<FieldsWithContentTypeId>(
-    dataWithAllLocales
-  )
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries(dataWithAllLocales)
 )
-expectType<
-  EntryCollection<FieldsWithContentTypeId, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
->(
-  client.withAllLocales.withoutLinkResolution.parseEntries<FieldsWithContentTypeId, Locales>(
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<EntrySkeleton>(dataWithAllLocales)
+)
+expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>>(
+  client.withAllLocales.withoutLinkResolution.parseEntries<EntrySkeleton, Locales>(
     dataWithAllLocales
   )
 )

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, Entry } from '../../lib'
+import { EntryFields, Entry, FieldsWithContentTypeIdType } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
 
@@ -11,7 +11,7 @@ import * as mocks from './mocks'
  * @namespace: Typescript - type test
  * @description: A simple Entry with generic fields
  */
-expectAssignable<Entry<Record<string, any>>>({
+expectAssignable<Entry<FieldsWithContentTypeIdType<Record<string, any>>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -23,7 +23,7 @@ expectAssignable<Entry<Record<string, any>>>({
  * @namespace: Typescript - type test
  * @description: A simple Entry generic
  */
-expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
+expectAssignable<Entry<FieldsWithContentTypeIdType<{ stringField: EntryFields.Text }>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -35,10 +35,12 @@ expectAssignable<Entry<{ stringField: EntryFields.Text }>>({
  * @description: A simple Entry generic with a referenced fields wildcard
  */
 expectAssignable<
-  Entry<{
-    stringField: EntryFields.Text
-    referenceField: EntryFields.Link<Record<string, any>>
-  }>
+  Entry<
+    FieldsWithContentTypeIdType<{
+      stringField: EntryFields.Text
+      referenceField: EntryFields.Link<FieldsWithContentTypeIdType<Record<string, any>>>
+    }>
+  >
 >({
   ...mocks.entryBasics,
   fields: {
@@ -56,13 +58,13 @@ expectAssignable<
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       assetReferenceField: EntryFields.AssetLink
       multiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     'WITHOUT_LINK_RESOLUTION'
   >
 >(
@@ -77,41 +79,75 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
     'WITHOUT_LINK_RESOLUTION'
   >
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields> }, 'WITHOUT_LINK_RESOLUTION'>
+  Entry<
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.Link<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(mocks.getEntry({ referenceField: mocks.entry }))
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITHOUT_LINK_RESOLUTION'
   >
 >(mocks.getEntry({ referenceField: [undefined] }))
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.Link<mocks.SimpleEntryFields>[] }, 'WITHOUT_LINK_RESOLUTION'>
+  Entry<
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.Link<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
+    'WITHOUT_LINK_RESOLUTION'
+  >
 >(mocks.getEntry({ referenceField: [mocks.entry] }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
-  mocks.getEntry({ referenceField: undefined })
-)
+expectNotAssignable<
+  Entry<
+    FieldsWithContentTypeIdType<
+      { referenceField: EntryFields.AssetLink },
+      'WITHOUT_LINK_RESOLUTION'
+    >
+  >
+>(mocks.getEntry({ referenceField: undefined }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>(
-  mocks.getEntry({ referenceField: mocks.asset })
-)
+expectNotAssignable<
+  Entry<
+    FieldsWithContentTypeIdType<
+      { referenceField: EntryFields.AssetLink },
+      'WITHOUT_LINK_RESOLUTION'
+    >
+  >
+>(mocks.getEntry({ referenceField: mocks.asset }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>(
-  mocks.getEntry({ referenceField: [undefined] })
-)
+expectNotAssignable<
+  Entry<
+    FieldsWithContentTypeIdType<
+      { referenceField: EntryFields.AssetLink[] },
+      'WITHOUT_LINK_RESOLUTION'
+    >
+  >
+>(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>(
-  mocks.getEntry({ referenceField: [mocks.asset] })
-)
+expectNotAssignable<
+  Entry<
+    FieldsWithContentTypeIdType<
+      { referenceField: EntryFields.AssetLink[] },
+      'WITHOUT_LINK_RESOLUTION'
+    >
+  >
+>(mocks.getEntry({ referenceField: [mocks.asset] }))
 
 /**
  * @namespace: Typescript - type test
@@ -120,19 +156,19 @@ expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     undefined
   >
 >(
@@ -152,20 +188,30 @@ expectAssignable<
 )
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> }, undefined>
+  Entry<
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
+    undefined
+  >
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] }, undefined>
+  Entry<
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
+    undefined
+  >
 >(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, undefined>>(
-  mocks.getEntry({ referenceField: undefined })
-)
+expectNotAssignable<
+  Entry<FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>, undefined>
+>(mocks.getEntry({ referenceField: undefined }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, undefined>>(
-  mocks.getEntry({ referenceField: [undefined] })
-)
+expectNotAssignable<
+  Entry<FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>, undefined>
+>(mocks.getEntry({ referenceField: [undefined] }))
 
 /**
  * @namespace: Typescript - type test
@@ -174,13 +220,13 @@ expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink[] }, undefined
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       assetReferenceField: EntryFields.AssetLink
       multiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -197,10 +243,10 @@ expectAssignable<
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
   Entry<
-    {
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+    FieldsWithContentTypeIdType<{
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
       assetReferenceField: EntryFields.AssetLink
-    },
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -210,7 +256,9 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -218,7 +266,9 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -226,7 +276,9 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -234,7 +286,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.AssetLink },
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -242,7 +294,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.AssetLink[] },
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -250,7 +302,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.AssetLink[] },
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -263,19 +315,19 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
@@ -305,10 +357,10 @@ expectAssignable<
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
   Entry<
-    {
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
+    FieldsWithContentTypeIdType<{
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
       assetReferenceField: EntryFields.AssetLink
-    },
+    }>,
     'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
@@ -318,36 +370,42 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITH_ALL_LOCALES', 'US' | 'DE'>
+  Entry<
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    'WITH_ALL_LOCALES',
+    'US' | 'DE'
+  >
 >(mocks.getEntry({ referenceField: { US: [undefined] } }))
 
 /**
  * @namespace: Typescript - type test
  * @description: EntryWithLinkResolutionAndWithoutUnresolvableLinks only resolvable entities are present.
- * unresolvable links are completely removed.
+> * unresolvable links are completely removed.
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(
@@ -368,24 +426,34 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: mocks.entryLink }))
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: [mocks.entryLink] }))
 
-expectNotAssignable<Entry<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  mocks.getEntry({ referenceField: mocks.assetLink })
-)
+expectNotAssignable<
+  Entry<
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
+    'WITHOUT_UNRESOLVABLE_LINKS'
+  >
+>(mocks.getEntry({ referenceField: mocks.assetLink }))
 
 expectNotAssignable<
-  Entry<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_UNRESOLVABLE_LINKS'>
+  Entry<
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    'WITHOUT_UNRESOLVABLE_LINKS'
+  >
 >(mocks.getEntry({ referenceField: [mocks.assetLink] }))
 
 /**
@@ -394,19 +462,19 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    {
+    FieldsWithContentTypeIdType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       unresolvableMultiAssetReferenceField: EntryFields.AssetLink[]
       mixedMultiAssetReferenceField: EntryFields.AssetLink[]
-    },
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
@@ -431,7 +499,9 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields> },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
@@ -439,7 +509,9 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.EntryLink<mocks.SimpleEntryFields>[] },
+    FieldsWithContentTypeIdType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
@@ -447,7 +519,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.AssetLink },
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
@@ -455,7 +527,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    { referenceField: EntryFields.AssetLink[] },
+    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, Entry, FieldsWithContentTypeIdType } from '../../lib'
+import { EntryFields, Entry, EntrySkeletonType } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
 
@@ -11,7 +11,7 @@ import * as mocks from './mocks'
  * @namespace: Typescript - type test
  * @description: A simple Entry with generic fields
  */
-expectAssignable<Entry<FieldsWithContentTypeIdType<Record<string, any>>>>({
+expectAssignable<Entry<EntrySkeletonType<Record<string, any>>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -23,7 +23,7 @@ expectAssignable<Entry<FieldsWithContentTypeIdType<Record<string, any>>>>({
  * @namespace: Typescript - type test
  * @description: A simple Entry generic
  */
-expectAssignable<Entry<FieldsWithContentTypeIdType<{ stringField: EntryFields.Text }>>>({
+expectAssignable<Entry<EntrySkeletonType<{ stringField: EntryFields.Text }>>>({
   ...mocks.entryBasics,
   fields: {
     stringField: mocks.stringValue,
@@ -36,9 +36,9 @@ expectAssignable<Entry<FieldsWithContentTypeIdType<{ stringField: EntryFields.Te
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      referenceField: EntryFields.Link<FieldsWithContentTypeIdType<Record<string, any>>>
+      referenceField: EntryFields.Link<EntrySkeletonType<Record<string, any>>>
     }>
   >
 >({
@@ -58,10 +58,10 @@ expectAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       assetReferenceField: EntryFields.AssetLink
       multiAssetReferenceField: EntryFields.AssetLink[]
     }>,
@@ -79,8 +79,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
     }>,
     'WITHOUT_LINK_RESOLUTION'
   >
@@ -88,8 +88,8 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.Link<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.Link<mocks.SimpleEntrySkeleton>
     }>,
     'WITHOUT_LINK_RESOLUTION'
   >
@@ -97,8 +97,8 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITHOUT_LINK_RESOLUTION'
   >
@@ -106,47 +106,27 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.Link<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.Link<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITHOUT_LINK_RESOLUTION'
   >
 >(mocks.getEntry({ referenceField: [mocks.entry] }))
 
 expectNotAssignable<
-  Entry<
-    FieldsWithContentTypeIdType<
-      { referenceField: EntryFields.AssetLink },
-      'WITHOUT_LINK_RESOLUTION'
-    >
-  >
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>
 >(mocks.getEntry({ referenceField: undefined }))
 
 expectNotAssignable<
-  Entry<
-    FieldsWithContentTypeIdType<
-      { referenceField: EntryFields.AssetLink },
-      'WITHOUT_LINK_RESOLUTION'
-    >
-  >
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink }, 'WITHOUT_LINK_RESOLUTION'>>
 >(mocks.getEntry({ referenceField: mocks.asset }))
 
 expectNotAssignable<
-  Entry<
-    FieldsWithContentTypeIdType<
-      { referenceField: EntryFields.AssetLink[] },
-      'WITHOUT_LINK_RESOLUTION'
-    >
-  >
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>
 >(mocks.getEntry({ referenceField: [undefined] }))
 
 expectNotAssignable<
-  Entry<
-    FieldsWithContentTypeIdType<
-      { referenceField: EntryFields.AssetLink[] },
-      'WITHOUT_LINK_RESOLUTION'
-    >
-  >
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }, 'WITHOUT_LINK_RESOLUTION'>>
 >(mocks.getEntry({ referenceField: [mocks.asset] }))
 
 /**
@@ -156,13 +136,13 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
@@ -189,8 +169,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
     }>,
     undefined
   >
@@ -198,19 +178,19 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     undefined
   >
 >(mocks.getEntry({ referenceField: [undefined] }))
 
-expectNotAssignable<
-  Entry<FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>, undefined>
->(mocks.getEntry({ referenceField: undefined }))
+expectNotAssignable<Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink }>, undefined>>(
+  mocks.getEntry({ referenceField: undefined })
+)
 
 expectNotAssignable<
-  Entry<FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>, undefined>
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>, undefined>
 >(mocks.getEntry({ referenceField: [undefined] }))
 
 /**
@@ -220,10 +200,10 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      multiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       assetReferenceField: EntryFields.AssetLink
       multiAssetReferenceField: EntryFields.AssetLink[]
     }>,
@@ -243,8 +223,8 @@ expectAssignable<
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
       assetReferenceField: EntryFields.AssetLink
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
@@ -256,8 +236,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -266,8 +246,8 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -276,8 +256,8 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
@@ -286,7 +266,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -294,7 +274,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -302,7 +282,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION',
     'US' | 'DE'
   >
@@ -315,13 +295,13 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
@@ -357,8 +337,8 @@ expectAssignable<
 /* links in single reference fields can be undefined because we can’t distinguish between missing translation and missing links */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      entryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
       assetReferenceField: EntryFields.AssetLink
     }>,
     'WITH_ALL_LOCALES',
@@ -370,8 +350,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITH_ALL_LOCALES',
     'US' | 'DE'
@@ -380,7 +360,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES',
     'US' | 'DE'
   >
@@ -393,13 +373,13 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
@@ -426,8 +406,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
     }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
@@ -435,23 +415,20 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: [mocks.entryLink] }))
 
 expectNotAssignable<
-  Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
-    'WITHOUT_UNRESOLVABLE_LINKS'
-  >
+  Entry<EntrySkeletonType<{ referenceField: EntryFields.AssetLink }>, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.getEntry({ referenceField: mocks.assetLink }))
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >(mocks.getEntry({ referenceField: [mocks.assetLink] }))
@@ -462,13 +439,13 @@ expectNotAssignable<
  */
 expectAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
-      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
-      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
-      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+      resolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      unresolvableEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
+      resolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      unresolvableMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
+      mixedMultiEntryReferenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
       resolvableAssetReferenceField: EntryFields.AssetLink
       unresolvableAssetReferenceField: EntryFields.AssetLink
       resolvableMultiAssetReferenceField: EntryFields.AssetLink[]
@@ -499,8 +476,8 @@ expectAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
@@ -509,8 +486,8 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{
-      referenceField: EntryFields.EntryLink<mocks.SimpleEntryFieldsWithContentTypeId>[]
+    EntrySkeletonType<{
+      referenceField: EntryFields.EntryLink<mocks.SimpleEntrySkeleton>[]
     }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
@@ -519,7 +496,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >
@@ -527,7 +504,7 @@ expectNotAssignable<
 
 expectNotAssignable<
   Entry<
-    FieldsWithContentTypeIdType<{ referenceField: EntryFields.AssetLink[] }>,
+    EntrySkeletonType<{ referenceField: EntryFields.AssetLink[] }>,
     'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS',
     'US' | 'DE'
   >

--- a/test/types/mocks.ts
+++ b/test/types/mocks.ts
@@ -57,8 +57,11 @@ export const entryBasics = {
   metadata: metadataValue,
 }
 
-export type SimpleEntryFields = {
-  title: string
+export type SimpleEntryFieldsWithContentTypeId = {
+  fields: {
+    title: string
+  }
+  contentTypeId: string
 }
 
 export type LocalizedEntryFields = {

--- a/test/types/mocks.ts
+++ b/test/types/mocks.ts
@@ -57,7 +57,7 @@ export const entryBasics = {
   metadata: metadataValue,
 }
 
-export type SimpleEntryFieldsWithContentTypeId = {
+export type SimpleEntrySkeleton = {
   fields: {
     title: string
   }

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -5,18 +5,26 @@ import * as mocks from '../mocks'
 
 // all operator
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+>({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+>({
   'fields.stringField[all]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.stringField[all]': mocks.stringArrayValue,
   'fields.stringArrayField[all]': mocks.stringArrayValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.unknownField[all]': mocks.anyValue,
 })
@@ -271,15 +279,24 @@ expectNotAssignable<
 expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   order: ['sys.createdAt', '-sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({ order: ['sys.unknownProperty'] })
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  order: ['sys.unknownProperty'],
+})
 
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({ order: ['fields.someField'] })
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  order: ['fields.someField'],
+})
 expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   order: ['fields.someField', '-fields.someField'],
 })
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ mediaField: EntryFields.AssetLink; referenceField: EntryFields.EntryLink<any> }>>
+  EntriesQueries<
+    FieldsWithContentTypeIdType<{
+      mediaField: EntryFields.AssetLink
+      referenceField: EntryFields.EntryLink<any>
+    }>
+  >
 >({
   content_type: 'id',
   order: [

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -1,29 +1,29 @@
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, EntriesQueries, FieldsWithContentTypeIdType } from '../../../lib'
+import { EntryFields, EntriesQueries, EntrySkeletonType } from '../../../lib'
 // @ts-ignore
 import * as mocks from '../mocks'
 
 // all operator
 
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ stringField: string; stringArrayField: string[] }>>
 >({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ stringField: string; stringArrayField: string[] }>>
 >({
   'fields.stringField[all]': mocks.anyValue,
 })
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ stringField: string; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.stringField[all]': mocks.stringArrayValue,
   'fields.stringArrayField[all]': mocks.stringArrayValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ stringField: string; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.unknownField[all]': mocks.anyValue,
@@ -31,85 +31,85 @@ expectNotAssignable<
 
 // equality
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'fields.numberField': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField': mocks.stringValue,
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.unknownProp': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField': mocks.anyValue,
 })
 
 // exists operator (field is present)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'fields.numberField[exists]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.unknownProp[exists]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField[exists]': mocks.anyValue,
 })
 
 // gt operator (range)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'fields.numberField[gt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[gt]': mocks.numberValue,
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'sys.unknownProp[gt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[gt]': mocks.anyValue,
 })
 
 // gte operator (range)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'fields.numberField[gte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[gte]': mocks.numberValue,
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'sys.unknownProp[gte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[gte]': mocks.anyValue,
 })
@@ -117,30 +117,30 @@ expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: nu
 // in operator
 
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   'metadata.tags.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   'fields.numberField[in]': mocks.anyValue,
   'fields.stringArrayField[in]': mocks.anyValue,
 })
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.numberField[in]': mocks.numberArrayValue,
   'fields.stringArrayField[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.unknownProp[in]': mocks.anyValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.unknownField[in]': mocks.anyValue,
@@ -148,97 +148,91 @@ expectNotAssignable<
 
 // lt operator (range)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'fields.numberField[lt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[lt]': mocks.numberValue,
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'sys.unknownProp[lt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[lt]': mocks.anyValue,
 })
 
 // lte operator (range)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'fields.numberField[lte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[lte]': mocks.numberValue,
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   'sys.unknownProp[lte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[lte]': mocks.anyValue,
 })
 
 // match operator (full-text search)
 
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ textField: string }>>>({
   'fields.textField[match]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ textField: string }>>>({
   content_type: 'id',
   'fields.textField[match]': mocks.stringValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ textField: string }>>>({
   content_type: 'id',
   'fields.unknownField[match]': mocks.anyValue,
 })
 
 // ne operator (inequality)
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'fields.numberField[ne]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField[ne]': mocks.stringValue,
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.unknownProp[ne]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField[ne]': mocks.anyValue,
 })
 
 // near operator (full-text search)
 
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   'fields.locationField[near]': mocks.anyValue,
 })
-expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.locationField[near]': mocks.nearLocationValue,
 })
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.unknownField[near]': mocks.anyValue,
 })
@@ -246,29 +240,29 @@ expectNotAssignable<
 // nin operator
 
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   'fields.numberField[nin]': mocks.anyValue,
   'fields.stringArrayField[nin]': mocks.anyValue,
 })
 expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.numberField[nin]': mocks.numberArrayValue,
   'fields.stringArrayField[nin]': mocks.stringArrayValue,
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   'sys.unknownProp[nin]': mocks.anyValue,
 })
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+  EntriesQueries<EntrySkeletonType<{ numberField: number; stringArrayField: string[] }>>
 >({
   content_type: 'id',
   'fields.unknownField[nin]': mocks.anyValue,
@@ -276,23 +270,23 @@ expectNotAssignable<
 
 // order operator
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   order: ['sys.createdAt', '-sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   order: ['sys.unknownProperty'],
 })
 
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   order: ['fields.someField'],
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   order: ['fields.someField', '-fields.someField'],
 })
 expectAssignable<
   EntriesQueries<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       mediaField: EntryFields.AssetLink
       referenceField: EntryFields.EntryLink<any>
     }>
@@ -306,74 +300,62 @@ expectAssignable<
     '-fields.referenceField.sys.id',
   ],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   order: ['fields.unknownField'],
 })
 
 // select operator
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   select: ['sys'],
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   select: ['sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   select: ['sys.unknownProperty'],
 })
 
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   select: ['fields'],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   select: ['fields.someField'],
 })
-expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   select: ['fields.someField'],
 })
-expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: string }>>>({
   content_type: 'id',
   select: ['fields.unknownField'],
 })
 
 // within operator (bounding circle)
 
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   'fields.locationField[within]': mocks.anyValue,
 })
-expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinCircleLocationValue,
 })
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.unknownField[within]': mocks.anyValue,
 })
 
 // within operator (bounding rectangle)
 
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   'fields.locationField[within]': mocks.anyValue,
 })
-expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinBoxLocationValue,
 })
-expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
->({
+expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFields.Location }>>>({
   content_type: 'id',
   'fields.unknownField[within]': mocks.anyValue,
 })
@@ -381,18 +363,18 @@ expectNotAssignable<
 // search on references
 
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFields.EntryLink<any> }>>
 >({
   'fields.referenceField.sys.contentType.sys.id': 'id',
 })
-expectAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
->({
-  content_type: 'id',
-  'fields.referenceField.sys.contentType.sys.id': 'id',
-})
+expectAssignable<EntriesQueries<EntrySkeletonType<{ referenceField: EntryFields.EntryLink<any> }>>>(
+  {
+    content_type: 'id',
+    'fields.referenceField.sys.contentType.sys.id': 'id',
+  }
+)
 expectNotAssignable<
-  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFields.EntryLink<any> }>>
 >({
   content_type: 'id',
   'fields.unknownField.sys.contentType.sys.id': 'id',

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -1,263 +1,285 @@
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, EntriesQueries } from '../../../lib'
+import { EntryFields, EntriesQueries, FieldsWithContentTypeIdType } from '../../../lib'
 // @ts-ignore
 import * as mocks from '../mocks'
 
 // all operator
 
-expectAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
   'fields.stringField[all]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
   content_type: 'id',
   'fields.stringField[all]': mocks.stringArrayValue,
   'fields.stringArrayField[all]': mocks.stringArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ stringField: string; stringArrayField: string[] }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ stringField: string; stringArrayField: string[] }>>>({
   content_type: 'id',
   'fields.unknownField[all]': mocks.anyValue,
 })
 
 // equality
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'fields.numberField': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField': mocks.stringValue,
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.unknownProp': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField': mocks.anyValue,
 })
 
 // exists operator (field is present)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'fields.numberField[exists]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.unknownProp[exists]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField[exists]': mocks.anyValue,
 })
 
 // gt operator (range)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'fields.numberField[gt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[gt]': mocks.numberValue,
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'sys.unknownProp[gt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[gt]': mocks.anyValue,
 })
 
 // gte operator (range)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'fields.numberField[gte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[gte]': mocks.numberValue,
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'sys.unknownProp[gte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[gte]': mocks.anyValue,
 })
 
 // in operator
 
-expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   'metadata.tags.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   'fields.numberField[in]': mocks.anyValue,
   'fields.stringArrayField[in]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.numberField[in]': mocks.numberArrayValue,
   'fields.stringArrayField[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.unknownProp[in]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.unknownField[in]': mocks.anyValue,
 })
 
 // lt operator (range)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'fields.numberField[lt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[lt]': mocks.numberValue,
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'sys.unknownProp[lt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[lt]': mocks.anyValue,
 })
 
 // lte operator (range)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'fields.numberField[lte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.numberField[lte]': mocks.numberValue,
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   'sys.unknownProp[lte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number }>>>({
   content_type: 'id',
   'fields.unknownField[lte]': mocks.anyValue,
 })
 
 // match operator (full-text search)
 
-expectNotAssignable<EntriesQueries<{ textField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
   'fields.textField[match]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ textField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
   content_type: 'id',
   'fields.textField[match]': mocks.stringValue,
 })
-expectNotAssignable<EntriesQueries<{ textField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ textField: string }>>>({
   content_type: 'id',
   'fields.unknownField[match]': mocks.anyValue,
 })
 
 // ne operator (inequality)
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'fields.numberField[ne]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.someField[ne]': mocks.stringValue,
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.unknownProp[ne]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   'fields.unknownField[ne]': mocks.anyValue,
 })
 
 // near operator (full-text search)
 
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   'fields.locationField[near]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.locationField[near]': mocks.nearLocationValue,
 })
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.unknownField[near]': mocks.anyValue,
 })
 
 // nin operator
 
-expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   'fields.numberField[nin]': mocks.anyValue,
   'fields.stringArrayField[nin]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.numberField[nin]': mocks.numberArrayValue,
   'fields.stringArrayField[nin]': mocks.stringArrayValue,
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   'sys.unknownProp[nin]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<{ numberField: number; stringArrayField: string[] }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ numberField: number; stringArrayField: string[] }>>
+>({
   content_type: 'id',
   'fields.unknownField[nin]': mocks.anyValue,
 })
 
 // order operator
 
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   order: ['sys.createdAt', '-sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({ order: ['sys.unknownProperty'] })
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({ order: ['sys.unknownProperty'] })
 
-expectNotAssignable<EntriesQueries<{ someField: string }>>({ order: ['fields.someField'] })
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({ order: ['fields.someField'] })
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   order: ['fields.someField', '-fields.someField'],
 })
 expectAssignable<
-  EntriesQueries<{ mediaField: EntryFields.AssetLink; referenceField: EntryFields.EntryLink<any> }>
+  EntriesQueries<FieldsWithContentTypeIdType<{ mediaField: EntryFields.AssetLink; referenceField: EntryFields.EntryLink<any> }>>
 >({
   content_type: 'id',
   order: [
@@ -267,66 +289,94 @@ expectAssignable<
     '-fields.referenceField.sys.id',
   ],
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   order: ['fields.unknownField'],
 })
 
 // select operator
 
-expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys'] })
-expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys.createdAt'] })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({ select: ['sys.unknownProperty'] })
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  select: ['sys'],
+})
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  select: ['sys.createdAt'],
+})
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  select: ['sys.unknownProperty'],
+})
 
-expectAssignable<EntriesQueries<{ someField: string }>>({ select: ['fields'] })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({ select: ['fields.someField'] })
-expectAssignable<EntriesQueries<{ someField: string }>>({
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  select: ['fields'],
+})
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
+  select: ['fields.someField'],
+})
+expectAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   select: ['fields.someField'],
 })
-expectNotAssignable<EntriesQueries<{ someField: string }>>({
+expectNotAssignable<EntriesQueries<FieldsWithContentTypeIdType<{ someField: string }>>>({
   content_type: 'id',
   select: ['fields.unknownField'],
 })
 
 // within operator (bounding circle)
 
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   'fields.locationField[within]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinCircleLocationValue,
 })
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.unknownField[within]': mocks.anyValue,
 })
 
 // within operator (bounding rectangle)
 
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   'fields.locationField[within]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinBoxLocationValue,
 })
-expectNotAssignable<EntriesQueries<{ locationField: EntryFields.Location }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ locationField: EntryFields.Location }>>
+>({
   content_type: 'id',
   'fields.unknownField[within]': mocks.anyValue,
 })
 
 // search on references
 
-expectNotAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
+>({
   'fields.referenceField.sys.contentType.sys.id': 'id',
 })
-expectAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+expectAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
+>({
   content_type: 'id',
   'fields.referenceField.sys.contentType.sys.id': 'id',
 })
-expectNotAssignable<EntriesQueries<{ referenceField: EntryFields.EntryLink<any> }>>({
+expectNotAssignable<
+  EntriesQueries<FieldsWithContentTypeIdType<{ referenceField: EntryFields.EntryLink<any> }>>
+>({
   content_type: 'id',
   'fields.unknownField.sys.contentType.sys.id': 'id',
 })

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { EntriesQueries, EntryFields, FieldsWithContentTypeIdType } from '../../lib'
+import { EntriesQueries, EntryFields, EntrySkeletonType } from '../../lib'
 import { EntryFieldsQueries } from '../../lib/types/query/query'
 
 export const stringValue = ''
@@ -128,9 +128,7 @@ expectAssignable<Required<EntryFieldsQueries<{ arrayStringField: EntryFields.Arr
  * EntryFields: Type Reference
  */
 expectAssignable<
-  Required<
-    EntryFieldsQueries<{ referenceField: EntryFields.EntryLink<FieldsWithContentTypeIdType> }>
-  >
+  Required<EntryFieldsQueries<{ referenceField: EntryFields.EntryLink<EntrySkeletonType> }>>
 >({
   select: ['fields.referenceField'],
   'fields.referenceField[exists]': booleanValue,
@@ -143,7 +141,7 @@ expectAssignable<
  */
 expectAssignable<
   EntriesQueries<
-    FieldsWithContentTypeIdType<{
+    EntrySkeletonType<{
       stringField: EntryFields.Text
       numberField: EntryFields.Number
     }>

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { EntriesQueries, EntryFields, FieldsType } from '../../lib'
+import { EntriesQueries, EntryFields, FieldsWithContentTypeIdType } from '../../lib'
 import { EntryFieldsQueries } from '../../lib/types/query/query'
 
 export const stringValue = ''
@@ -128,7 +128,9 @@ expectAssignable<Required<EntryFieldsQueries<{ arrayStringField: EntryFields.Arr
  * EntryFields: Type Reference
  */
 expectAssignable<
-  Required<EntryFieldsQueries<{ referenceField: EntryFields.EntryLink<FieldsType> }>>
+  Required<
+    EntryFieldsQueries<{ referenceField: EntryFields.EntryLink<FieldsWithContentTypeIdType> }>
+  >
 >({
   select: ['fields.referenceField'],
   'fields.referenceField[exists]': booleanValue,
@@ -140,10 +142,12 @@ expectAssignable<
  * Entry
  */
 expectAssignable<
-  EntriesQueries<{
-    stringField: EntryFields.Text
-    numberField: EntryFields.Number
-  }>
+  EntriesQueries<
+    FieldsWithContentTypeIdType<{
+      stringField: EntryFields.Text
+      numberField: EntryFields.Number
+    }>
+  >
 >({
   content_type: 'id',
   'fields.stringField[exists]': booleanValue,

--- a/test/types/resolved-field.test-d.ts
+++ b/test/types/resolved-field.test-d.ts
@@ -3,12 +3,12 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, FieldsWithContentTypeIdType, ResolvedField } from '../../lib'
+import { EntryFields, EntrySkeletonType, ResolvedField } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
 
 type SimpleEntryFields = { title: string }
-type SimpleEntryWithContentTypeId = FieldsWithContentTypeIdType<SimpleEntryFields>
+type SimpleEntryWithContentTypeId = EntrySkeletonType<SimpleEntryFields>
 
 expectAssignable<ResolvedField<EntryFields.Symbol, undefined>>(mocks.stringValue)
 expectAssignable<ResolvedField<EntryFields.Text, undefined>>(mocks.stringValue)

--- a/test/types/resolved-field.test-d.ts
+++ b/test/types/resolved-field.test-d.ts
@@ -6,8 +6,10 @@ import { expectAssignable, expectNotAssignable } from 'tsd'
 import { EntryFields, ResolvedField } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
+import { FieldsWithContentTypeIdType } from '../../dist/types/types/query/util'
 
 type SimpleEntryFields = { title: string }
+type SimpleEntryWithContentTypeId = FieldsWithContentTypeIdType<SimpleEntryFields>
 
 expectAssignable<ResolvedField<EntryFields.Symbol, undefined>>(mocks.stringValue)
 expectAssignable<ResolvedField<EntryFields.Text, undefined>>(mocks.stringValue)
@@ -23,76 +25,82 @@ expectAssignable<ResolvedField<EntryFields.Object, undefined>>(mocks.jsonValue)
 
 // entries
 
-expectAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, undefined>>(mocks.entry)
-expectAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, undefined>>(
+expectAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, undefined>>(
+  mocks.entry
+)
+expectAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, undefined>>(
   mocks.entryLink
 )
-expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, undefined>>(undefined)
-expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, undefined>>(mocks.asset)
-expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, undefined>>(
+expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, undefined>>(
+  undefined
+)
+expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, undefined>>(
+  mocks.asset
+)
+expectNotAssignable<ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, undefined>>(
   mocks.assetLink
 )
 expectAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entry])
 expectAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entryLink])
 expectAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entry, mocks.entryLink])
 expectNotAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entry, mocks.entryLink, undefined])
 expectNotAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entry, mocks.entryLink, mocks.asset])
 expectNotAssignable<
-  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>, undefined>
+  ResolvedField<EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>, undefined>
 >([mocks.entry, mocks.entryLink, mocks.assetLink])
 
 expectAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_UNRESOLVABLE_LINKS'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.entry)
 expectAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_UNRESOLVABLE_LINKS'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(undefined)
 expectNotAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_UNRESOLVABLE_LINKS'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_UNRESOLVABLE_LINKS'>
 >(mocks.entryLink)
 expectAssignable<
   ResolvedField<
-    EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>,
+    EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >([mocks.entry])
 expectAssignable<
   ResolvedField<
-    EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>,
+    EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >([undefined])
 expectAssignable<
   ResolvedField<
-    EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>,
+    EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >([mocks.entry, undefined])
 expectNotAssignable<
   ResolvedField<
-    EntryFields.Array<EntryFields.EntryLink<SimpleEntryFields>>,
+    EntryFields.Array<EntryFields.EntryLink<SimpleEntryWithContentTypeId>>,
     'WITHOUT_UNRESOLVABLE_LINKS'
   >
 >([mocks.entry, mocks.entryLink, undefined])
 
 expectAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_LINK_RESOLUTION'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_LINK_RESOLUTION'>
 >(mocks.entryLink)
 expectNotAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_LINK_RESOLUTION'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_LINK_RESOLUTION'>
 >(undefined)
 expectNotAssignable<
-  ResolvedField<EntryFields.EntryLink<SimpleEntryFields>, 'WITHOUT_LINK_RESOLUTION'>
+  ResolvedField<EntryFields.EntryLink<SimpleEntryWithContentTypeId>, 'WITHOUT_LINK_RESOLUTION'>
 >(mocks.entry)
 
 // assets

--- a/test/types/resolved-field.test-d.ts
+++ b/test/types/resolved-field.test-d.ts
@@ -3,10 +3,9 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { EntryFields, ResolvedField } from '../../lib'
+import { EntryFields, FieldsWithContentTypeIdType, ResolvedField } from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
-import { FieldsWithContentTypeIdType } from '../../dist/types/types/query/util'
 
 type SimpleEntryFields = { title: string }
 type SimpleEntryWithContentTypeId = FieldsWithContentTypeIdType<SimpleEntryFields>

--- a/test/unit/make-contentful-api-client-parseentries.test.ts
+++ b/test/unit/make-contentful-api-client-parseentries.test.ts
@@ -1,6 +1,6 @@
 import { makeClient } from '../../lib/make-client'
 import createGlobalOptions from '../../lib/create-global-options'
-import { EntrySys, EntryCollection, Link, FieldsWithContentTypeIdType } from '../../lib/types'
+import { EntrySys, EntryCollection, Link, EntrySkeletonType } from '../../lib/types'
 import { ResourceLink } from '../../lib/types/resource-link'
 
 interface AnimalTypeFields {
@@ -9,14 +9,14 @@ interface AnimalTypeFields {
   anotheranimal?: { sys: Link<'Entry'> }
 }
 
-type AnimalTypeFieldsWithContentTypeId = FieldsWithContentTypeIdType<AnimalTypeFields>
+type AnimalTypeSkeleton = EntrySkeletonType<AnimalTypeFields>
 
 export interface XspaceTypeFields {
   xspace?: { sys: ResourceLink }[]
   xspace2?: { sys: ResourceLink }[]
 }
 
-type XspaceTypeFieldsWithContentTypeId = FieldsWithContentTypeIdType<XspaceTypeFields>
+type XspaceTypeSkeleton = EntrySkeletonType<XspaceTypeFields>
 
 const pigEntry = {
   sys: {
@@ -44,7 +44,7 @@ test('Given json should be parsed correctly as a collection of entries', () => {
     getGlobalOptions: createGlobalOptions({ resolveLinks: true }),
   })
 
-  const data: EntryCollection<AnimalTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<AnimalTypeSkeleton, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,
@@ -91,7 +91,7 @@ test('Given json should be parsed correctly as a collection of entries where a f
     // @ts-ignore
     getGlobalOptions: createGlobalOptions({ resolveLinks: true }),
   })
-  const data: EntryCollection<AnimalTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<AnimalTypeSkeleton, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,
@@ -147,7 +147,7 @@ test('Given json should be parsed correctly as a collection of entries with reso
     getGlobalOptions: createGlobalOptions({ resolveLinks: false }),
   })
 
-  const data: EntryCollection<XspaceTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<XspaceTypeSkeleton, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,

--- a/test/unit/make-contentful-api-client-parseentries.test.ts
+++ b/test/unit/make-contentful-api-client-parseentries.test.ts
@@ -1,18 +1,22 @@
 import { makeClient } from '../../lib/make-client'
 import createGlobalOptions from '../../lib/create-global-options'
-import { EntrySys, EntryCollection, Link } from '../../lib/types'
+import { EntrySys, EntryCollection, Link, FieldsWithContentTypeIdType } from '../../lib/types'
 import { ResourceLink } from '../../lib/types/resource-link'
 
-export interface AnimalTypeFields {
+interface AnimalTypeFields {
   animal?: { sys: Link<'Entry'> }
   metadata?: { sys: Link<'Entry'> }
   anotheranimal?: { sys: Link<'Entry'> }
 }
 
+type AnimalTypeFieldsWithContentTypeId = FieldsWithContentTypeIdType<AnimalTypeFields>
+
 export interface XspaceTypeFields {
   xspace?: { sys: ResourceLink }[]
   xspace2?: { sys: ResourceLink }[]
 }
+
+type XspaceTypeFieldsWithContentTypeId = FieldsWithContentTypeIdType<XspaceTypeFields>
 
 const pigEntry = {
   sys: {
@@ -40,7 +44,7 @@ test('Given json should be parsed correctly as a collection of entries', () => {
     getGlobalOptions: createGlobalOptions({ resolveLinks: true }),
   })
 
-  const data: EntryCollection<AnimalTypeFields, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<AnimalTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,
@@ -87,7 +91,7 @@ test('Given json should be parsed correctly as a collection of entries where a f
     // @ts-ignore
     getGlobalOptions: createGlobalOptions({ resolveLinks: true }),
   })
-  const data: EntryCollection<AnimalTypeFields, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<AnimalTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,
@@ -143,7 +147,7 @@ test('Given json should be parsed correctly as a collection of entries with reso
     getGlobalOptions: createGlobalOptions({ resolveLinks: false }),
   })
 
-  const data: EntryCollection<XspaceTypeFields, 'WITHOUT_LINK_RESOLUTION'> = {
+  const data: EntryCollection<XspaceTypeFieldsWithContentTypeId, 'WITHOUT_LINK_RESOLUTION'> = {
     total: 1,
     skip: 0,
     limit: 1,

--- a/test/unit/make-contentful-api-client.test.ts
+++ b/test/unit/make-contentful-api-client.test.ts
@@ -141,7 +141,9 @@ describe('make Contentful API client', () => {
       promise: Promise.resolve({ data: mocks.entryMock }),
     })
     api.getEntries = jest.fn().mockResolvedValue({ items: [mocks.entryMock] })
-    await expect(api.getEntry<mocks.EntryFields>('eid')).resolves.toEqual(mocks.entryMock)
+    await expect(api.getEntry<mocks.EntryFieldsWithContentTypeId>('eid')).resolves.toEqual(
+      mocks.entryMock
+    )
     expect(api.getEntries).toHaveBeenCalledTimes(1)
   })
 
@@ -155,7 +157,10 @@ describe('make Contentful API client', () => {
     const { api } = setupWithData({
       promise: Promise.reject(rejectError),
     })
-    await expect(api.getEntry<mocks.EntryFields>('eid')).rejects.toHaveProperty('data', data)
+    await expect(api.getEntry<mocks.EntryFieldsWithContentTypeId>('eid')).rejects.toHaveProperty(
+      'data',
+      data
+    )
   })
 
   test('API call getEntries', async () => {

--- a/test/unit/make-contentful-api-client.test.ts
+++ b/test/unit/make-contentful-api-client.test.ts
@@ -141,9 +141,7 @@ describe('make Contentful API client', () => {
       promise: Promise.resolve({ data: mocks.entryMock }),
     })
     api.getEntries = jest.fn().mockResolvedValue({ items: [mocks.entryMock] })
-    await expect(api.getEntry<mocks.EntryFieldsWithContentTypeId>('eid')).resolves.toEqual(
-      mocks.entryMock
-    )
+    await expect(api.getEntry<mocks.EntrySkeleton>('eid')).resolves.toEqual(mocks.entryMock)
     expect(api.getEntries).toHaveBeenCalledTimes(1)
   })
 
@@ -157,10 +155,7 @@ describe('make Contentful API client', () => {
     const { api } = setupWithData({
       promise: Promise.reject(rejectError),
     })
-    await expect(api.getEntry<mocks.EntryFieldsWithContentTypeId>('eid')).rejects.toHaveProperty(
-      'data',
-      data
-    )
+    await expect(api.getEntry<mocks.EntrySkeleton>('eid')).rejects.toHaveProperty('data', data)
   })
 
   test('API call getEntries', async () => {

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -13,6 +13,7 @@ import {
   Tag,
   TagSys,
   Entry,
+  FieldsWithContentTypeIdType,
 } from '../../lib'
 
 const date: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -147,11 +148,11 @@ const contentTypeMock: ContentType = {
   ],
 }
 
-export type EntryFields = {
+export type EntryFieldsWithContentTypeId = FieldsWithContentTypeIdType<{
   field1: string
-}
+}>
 
-const entryMock: Entry<EntryFields> = {
+const entryMock: Entry<EntryFieldsWithContentTypeId> = {
   sys: {
     ...copy(sysMock),
     locale: 'locale',

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -13,7 +13,7 @@ import {
   Tag,
   TagSys,
   Entry,
-  FieldsWithContentTypeIdType,
+  EntrySkeletonType,
 } from '../../lib'
 
 const date: EntryFields.Date = '2018-05-03T09:18:16.329Z'
@@ -148,11 +148,11 @@ const contentTypeMock: ContentType = {
   ],
 }
 
-export type EntryFieldsWithContentTypeId = FieldsWithContentTypeIdType<{
+export type EntrySkeleton = EntrySkeletonType<{
   field1: string
 }>
 
-const entryMock: Entry<EntryFieldsWithContentTypeId> = {
+const entryMock: Entry<EntrySkeleton> = {
   sys: {
     ...copy(sysMock),
     locale: 'locale',


### PR DESCRIPTION
Introduce `EntrySkeletonType` type that replaces `FieldsType` in calls to `getEntry`, `getEntries`, and `parseEntries`. In addition to fields it contains the content type id and allows stronger typing of the returned values.