### PR TITLE
fix: search on reference filter

### DIFF
--- a/lib/types/query/reference.ts
+++ b/lib/types/query/reference.ts
@@ -1,7 +1,7 @@
 import { EntryFields } from '../entry'
 import { ConditionalPick } from 'type-fest'
 
-type SupportedTypes = EntryFields.EntryLink<any>
+type SupportedTypes = EntryFields.EntryLink<any> | undefined
 
 /**
  * @desc search on references


### PR DESCRIPTION
## Summary

Fix search on reference filter. Our type tests didn’t catch this because `ConditionalPick` behaves differently in different environments when it comes to optional properties.