### PR TITLE
fix: allow ordering entries by location

### DIFF
--- a/lib/types/query/order.ts
+++ b/lib/types/query/order.ts
@@ -10,6 +10,7 @@ type SupportedTypes =
   | EntryFields.Number
   | EntryFields.Date
   | EntryFields.Boolean
+  | EntryFields.Location
   | undefined
 
 type SupportedLinkTypes = EntryFields.AssetLink | EntryFields.EntryLink<any> | undefined

--- a/test/types/query-types/location.test-d.ts
+++ b/test/types/query-types/location.test-d.ts
@@ -46,8 +46,9 @@ expectAssignable<Required<RangeFilters<{ testField: EntryFields.Location }, 'fie
 
 expectAssignable<Required<FullTextSearchFilters<{ testField: EntryFields.Location }, 'fields'>>>({})
 
-expectNotAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFields.Location }>>>({
-  order: ['fields.testField'],
+expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFields.Number }>>({})
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFields.Location }>>>({
+  order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFields.Location }>>({})


### PR DESCRIPTION
# Summary

Allow ordering entries by _Location_ fields.