### PR TITLE
fix: query parameters compatible with strict mode

### DIFF
--- a/lib/types/query/existence.ts
+++ b/lib/types/query/existence.ts
@@ -26,4 +26,10 @@ export type ExistenceFilter<
 export type EntryFieldsExistenceFilter<
   Fields extends FieldsType,
   Prefix extends string
-> = ConditionalFixedQueries<Fields, EntryFieldType<EntrySkeletonType>, boolean, Prefix, '[exists]'>
+> = ConditionalFixedQueries<
+  Fields,
+  EntryFieldType<EntrySkeletonType> | undefined,
+  boolean,
+  Prefix,
+  '[exists]'
+>

--- a/lib/types/query/util.ts
+++ b/lib/types/query/util.ts
@@ -63,7 +63,5 @@ export type EntryFieldsConditionalQueries<
   QueryFilter extends string = ''
 > = {
   [FieldName in keyof ConditionalPick<Fields, SupportedTypes> as `${Prefix}.${string &
-    FieldName}${QueryFilter}`]?: Fields[FieldName] extends EntryFieldTypes.Array<infer T>
-    ? BaseFieldMap<T>
-    : BaseFieldMap<Fields[FieldName]>
+    FieldName}${QueryFilter}`]?: BaseFieldMap<EntryFieldBaseOrArrayType<Fields[FieldName]>>
 }

--- a/test/types/query-types/boolean.test-d.ts
+++ b/test/types/query-types/boolean.test-d.ts
@@ -20,21 +20,23 @@ expectAssignable<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Bool
 )
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Boolean }, 'fields'>>>({
   'fields.testField': mocks.booleanValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>>(
-  {
-    'fields.testField[ne]': mocks.booleanValue,
-  }
-)
+expectType<
+  Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Boolean }, 'fields'>>
+>({
+  'fields.testField[ne]': mocks.booleanValue,
+})
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Boolean }, 'fields'>>>({
-  'fields.testField[exists]': mocks.booleanValue,
-})
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Boolean }, 'fields'>>>(
+  {
+    'fields.testField[exists]': mocks.booleanValue,
+  }
+)
 
 expectAssignable<Required<LocationSearchFilters<{ testField: EntryFieldTypes.Boolean }, 'fields'>>>(
   {}
@@ -49,17 +51,17 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Boolean }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Boolean }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Boolean }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Boolean }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Boolean }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Boolean }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Boolean }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Boolean }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Boolean }, 'fields'>>>({
   'fields.testField[in]': mocks.booleanArrayValue,
   'fields.testField[nin]': mocks.booleanArrayValue,
 })

--- a/test/types/query-types/date.test-d.ts
+++ b/test/types/query-types/date.test-d.ts
@@ -18,24 +18,24 @@ import { EntryFieldTypes } from '../../../lib'
 expectAssignable<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>>({})
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Date }, 'fields'>>>({
   'fields.testField': mocks.dateValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>>({
+expectType<Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Date }, 'fields'>>>({
   'fields.testField[ne]': mocks.dateValue,
 })
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Date }, 'fields'>>>({
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Date }, 'fields'>>>({
   'fields.testField[exists]': mocks.booleanValue,
 })
 
 expectAssignable<Required<LocationSearchFilters<{ testField: EntryFieldTypes.Date }, 'fields'>>>({})
 
 expectAssignable<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Date }, 'fields'>>({})
-expectType<Required<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Date }, 'fields'>>>({
+expectType<Required<EntryFieldsRangeFilters<{ testField?: EntryFieldTypes.Date }, 'fields'>>>({
   'fields.testField[lt]': mocks.dateValue,
   'fields.testField[lte]': mocks.dateValue,
   'fields.testField[gt]': mocks.dateValue,
@@ -47,17 +47,17 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Date }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Date }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Date }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Date }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Date }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Date }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Date }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Date }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Date }, 'fields'>>>({
   'fields.testField[in]': mocks.dateArrayValue,
   'fields.testField[nin]': mocks.dateArrayValue,
 })

--- a/test/types/query-types/integer.test-d.ts
+++ b/test/types/query-types/integer.test-d.ts
@@ -20,28 +20,30 @@ expectAssignable<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Inte
 )
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Integer }, 'fields'>>>({
   'fields.testField': mocks.numberValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>>(
-  {
-    'fields.testField[ne]': mocks.numberValue,
-  }
-)
+expectType<
+  Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Integer }, 'fields'>>
+>({
+  'fields.testField[ne]': mocks.numberValue,
+})
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Integer }, 'fields'>>>({
-  'fields.testField[exists]': mocks.booleanValue,
-})
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Integer }, 'fields'>>>(
+  {
+    'fields.testField[exists]': mocks.booleanValue,
+  }
+)
 
 expectAssignable<Required<LocationSearchFilters<{ testField: EntryFieldTypes.Integer }, 'fields'>>>(
   {}
 )
 
 expectAssignable<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Integer }, 'fields'>>({})
-expectType<Required<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Integer }, 'fields'>>>({
+expectType<Required<EntryFieldsRangeFilters<{ testField?: EntryFieldTypes.Integer }, 'fields'>>>({
   'fields.testField[lt]': mocks.numberValue,
   'fields.testField[lte]': mocks.numberValue,
   'fields.testField[gt]': mocks.numberValue,
@@ -53,17 +55,17 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Integer }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Integer }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Integer }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Integer }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Integer }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Integer }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Integer }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Integer }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Integer }, 'fields'>>>({
   'fields.testField[in]': mocks.numberArrayValue,
   'fields.testField[nin]': mocks.numberArrayValue,
 })

--- a/test/types/query-types/location.test-d.ts
+++ b/test/types/query-types/location.test-d.ts
@@ -28,15 +28,15 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Location }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Location }, 'fields'>>>(
-  {
-    'fields.testField[exists]': mocks.booleanValue,
-  }
-)
+expectType<
+  Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Location }, 'fields'>>
+>({
+  'fields.testField[exists]': mocks.booleanValue,
+})
 
 expectAssignable<LocationSearchFilters<{ testField: EntryFieldTypes.Location }, 'fields'>>({})
 expectAssignable<
-  Required<LocationSearchFilters<{ testField: EntryFieldTypes.Location }, 'fields'>>
+  Required<LocationSearchFilters<{ testField?: EntryFieldTypes.Location }, 'fields'>>
 >({
   'fields.testField[near]': mocks.nearLocationValue,
   'fields.testField[within]': mocks.withinCircleLocationValue,
@@ -69,12 +69,12 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Number }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Location }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Location }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Location }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Location }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Location }>>>({
   select: ['fields.testField'],
 })
 

--- a/test/types/query-types/number.test-d.ts
+++ b/test/types/query-types/number.test-d.ts
@@ -20,24 +20,26 @@ expectAssignable<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Numb
 )
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Number }, 'fields'>>>({
   'fields.testField': mocks.numberValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>>({
-  'fields.testField[ne]': mocks.numberValue,
-})
+expectType<Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Number }, 'fields'>>>(
+  {
+    'fields.testField[ne]': mocks.numberValue,
+  }
+)
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Number }, 'fields'>>>({
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Number }, 'fields'>>>({
   'fields.testField[exists]': mocks.booleanValue,
 })
 
 expectType<Required<LocationSearchFilters<{ testField: EntryFieldTypes.Number }, 'fields'>>>({})
 
 expectAssignable<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Number }, 'fields'>>({})
-expectType<Required<EntryFieldsRangeFilters<{ testField: EntryFieldTypes.Number }, 'fields'>>>({
+expectType<Required<EntryFieldsRangeFilters<{ testField?: EntryFieldTypes.Number }, 'fields'>>>({
   'fields.testField[lt]': mocks.numberValue,
   'fields.testField[lte]': mocks.numberValue,
   'fields.testField[gt]': mocks.numberValue,
@@ -49,17 +51,17 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Number }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Number }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Number }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Number }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Number }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Number }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Number }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Number }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Number }, 'fields'>>>({
   'fields.testField[in]': mocks.numberArrayValue,
   'fields.testField[nin]': mocks.numberArrayValue,
 })

--- a/test/types/query-types/object.test-d.ts
+++ b/test/types/query-types/object.test-d.ts
@@ -28,7 +28,7 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Object }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Object }, 'fields'>>>({
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Object }, 'fields'>>>({
   'fields.testField[exists]': mocks.booleanValue,
 })
 
@@ -49,7 +49,7 @@ expectNotAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Obje
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Object }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Object }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Object }>>>({
   select: ['fields.testField'],
 })
 

--- a/test/types/query-types/richtext.test-d.ts
+++ b/test/types/query-types/richtext.test-d.ts
@@ -28,11 +28,11 @@ expectAssignable<
 >({})
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.RichText }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.RichText }, 'fields'>>>(
-  {
-    'fields.testField[exists]': mocks.booleanValue,
-  }
-)
+expectType<
+  Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.RichText }, 'fields'>>
+>({
+  'fields.testField[exists]': mocks.booleanValue,
+})
 
 expectAssignable<
   Required<LocationSearchFilters<{ testField: EntryFieldTypes.RichText }, 'fields'>>
@@ -54,7 +54,7 @@ expectNotAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Obje
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.RichText }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.RichText }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.RichText }>>>({
   select: ['fields.testField'],
 })
 

--- a/test/types/query-types/symbol-array.test-d.ts
+++ b/test/types/query-types/symbol-array.test-d.ts
@@ -20,7 +20,7 @@ expectAssignable<
 >({})
 expectType<
   Required<
-    EntryFieldsSetFilter<{ testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> }, 'fields'>
+    EntryFieldsSetFilter<{ testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> }, 'fields'>
   >
 >({
   'fields.testField[all]': mocks.stringArrayValue,
@@ -32,7 +32,7 @@ expectAssignable<
 expectType<
   Required<
     EntryFieldsEqualityFilter<
-      { testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
+      { testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
       'fields'
     >
   >
@@ -49,7 +49,7 @@ expectAssignable<
 expectType<
   Required<
     EntryFieldsInequalityFilter<
-      { testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
+      { testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
       'fields'
     >
   >
@@ -63,7 +63,7 @@ expectAssignable<
 expectType<
   Required<
     EntryFieldsExistenceFilter<
-      { testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
+      { testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
       'fields'
     >
   >
@@ -92,7 +92,7 @@ expectAssignable<
 expectType<
   Required<
     EntryFieldsFullTextSearchFilters<
-      { testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
+      { testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
       'fields'
     >
   >
@@ -122,7 +122,10 @@ expectAssignable<
 >({})
 expectType<
   Required<
-    EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Array<EntryFieldTypes.Symbol> }, 'fields'>
+    EntryFieldsSubsetFilters<
+      { testField?: EntryFieldTypes.Array<EntryFieldTypes.Symbol> },
+      'fields'
+    >
   >
 >({
   'fields.testField[in]': mocks.stringArrayValue,

--- a/test/types/query-types/symbol.test-d.ts
+++ b/test/types/query-types/symbol.test-d.ts
@@ -16,22 +16,24 @@ import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
 import { EntryFieldsSetFilter } from '../../../lib/types/query/set'
 
 expectAssignable<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>({})
-expectType<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>>({
+expectType<Required<EntryFieldsSetFilter<{ testField?: EntryFieldTypes.Symbol }, 'fields'>>>({
   'fields.testField[all]': mocks.stringArrayValue,
 })
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Symbol }, 'fields'>>>({
   'fields.testField': mocks.stringValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>>({
-  'fields.testField[ne]': mocks.stringValue,
-})
+expectType<Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Symbol }, 'fields'>>>(
+  {
+    'fields.testField[ne]': mocks.stringValue,
+  }
+)
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Symbol }, 'fields'>>>({
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Symbol }, 'fields'>>>({
   'fields.testField[exists]': mocks.booleanValue,
 })
 
@@ -53,17 +55,17 @@ expectType<
 })
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Symbol }>>({})
-expectAssignable<Required<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<Required<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Symbol }>>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Symbol }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Symbol }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Symbol }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Symbol }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Symbol }, 'fields'>>>({
   'fields.testField[in]': mocks.stringArrayValue,
   'fields.testField[nin]': mocks.stringArrayValue,
 })

--- a/test/types/query-types/text.test-d.ts
+++ b/test/types/query-types/text.test-d.ts
@@ -16,22 +16,22 @@ import { EntryOrderFilterWithFields } from '../../../lib/types/query/order'
 import { EntryFieldsSetFilter } from '../../../lib/types/query/set'
 
 expectAssignable<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>({})
-expectType<Required<EntryFieldsSetFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>>({
+expectType<Required<EntryFieldsSetFilter<{ testField?: EntryFieldTypes.Text }, 'fields'>>>({
   'fields.testField[all]': mocks.stringArrayValue,
 })
 
 expectAssignable<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>({})
-expectType<Required<EntryFieldsEqualityFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>>({
+expectType<Required<EntryFieldsEqualityFilter<{ testField?: EntryFieldTypes.Text }, 'fields'>>>({
   'fields.testField': mocks.stringValue,
 })
 
 expectAssignable<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>({})
-expectType<Required<EntryFieldsInequalityFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>>({
+expectType<Required<EntryFieldsInequalityFilter<{ testField?: EntryFieldTypes.Text }, 'fields'>>>({
   'fields.testField[ne]': mocks.stringValue,
 })
 
 expectAssignable<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>({})
-expectType<Required<EntryFieldsExistenceFilter<{ testField: EntryFieldTypes.Text }, 'fields'>>>({
+expectType<Required<EntryFieldsExistenceFilter<{ testField?: EntryFieldTypes.Text }, 'fields'>>>({
   'fields.testField[exists]': mocks.booleanValue,
 })
 
@@ -45,23 +45,23 @@ expectAssignable<EntryFieldsFullTextSearchFilters<{ testField: EntryFieldTypes.T
   {}
 )
 expectType<
-  Required<EntryFieldsFullTextSearchFilters<{ testField: EntryFieldTypes.Text }, 'fields'>>
+  Required<EntryFieldsFullTextSearchFilters<{ testField?: EntryFieldTypes.Text }, 'fields'>>
 >({
   'fields.testField[match]': mocks.stringValue,
 })
 
 expectAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Text }>>({})
-expectNotAssignable<EntryOrderFilterWithFields<{ testField: EntryFieldTypes.Text }>>({
+expectNotAssignable<EntryOrderFilterWithFields<{ testField?: EntryFieldTypes.Text }>>({
   order: ['fields.testField', '-fields.testField'],
 })
 
 expectAssignable<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Text }>>({})
-expectAssignable<Required<EntrySelectFilterWithFields<{ testField: EntryFieldTypes.Text }>>>({
+expectAssignable<Required<EntrySelectFilterWithFields<{ testField?: EntryFieldTypes.Text }>>>({
   select: ['fields.testField'],
 })
 
 expectAssignable<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Text }, 'fields'>>({})
-expectType<Required<EntryFieldsSubsetFilters<{ testField: EntryFieldTypes.Text }, 'fields'>>>({
+expectType<Required<EntryFieldsSubsetFilters<{ testField?: EntryFieldTypes.Text }, 'fields'>>>({
   'fields.testField[in]': mocks.stringArrayValue,
   'fields.testField[nin]': mocks.stringArrayValue,
 })


### PR DESCRIPTION
## Summary

Add tests to make sure all query parameter types are compatible with strict modes and fix resulting errors.

## Description

* Fix existence filter
* Fix edge case with list of symbols field
