### PR TITLE
chore: reduce number of client types

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -35,7 +35,7 @@
 
 - contentful
   - {@link createClient | createClient}
-- ContentfulClientAPI
+- {@link ContentfulClientApi | ContentfulClientApi }
   - {@link createAssetKey | createAssetKey }
   - {@link getAsset | getAsset }
   - {@link getAssets | getAssets }

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ In order to provide type support for each configuration, we provide the possibil
 
 This way, we make developing with `contentful.js` much more predictable and safer.
 
-When initialising a client, you will receive an instance of the [`DefaultClient`](lib/create-contentful-api.ts#L91) shape.
+When initialising a client, you will receive an instance of the [`ContentfulClientApi`](lib/create-contentful-api.ts#L91) shape.
 
 #### Entries
 

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -5,11 +5,11 @@
 
 import axios from 'axios'
 import { createHttpClient, getUserAgentHeader } from 'contentful-sdk-core'
-import { ContentfulClientApi } from './create-contentful-api'
 import createGlobalOptions from './create-global-options'
 import { makeClient } from './make-client'
 import type { AxiosAdapter, AxiosRequestConfig } from 'axios'
 import { validateRemoveUnresolvedParam, validateResolveLinksParam } from './utils/validate-params'
+import { ContentfulClientApi } from './types'
 
 /**
  * @category Client
@@ -114,7 +114,7 @@ export interface CreateClientParams {
  *   space: 'mySpaceId'
  * })
  */
-export function createClient(params: CreateClientParams): ContentfulClientApi {
+export function createClient(params: CreateClientParams): ContentfulClientApi<undefined> {
   if (!params.accessToken) {
     throw new TypeError('Expected parameter accessToken')
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,4 +5,3 @@ export * from './utils/normalize-select'
 export * from './utils/resolve-circular'
 
 export * from './types'
-export type { ContentfulClientApi } from './create-contentful-api'

--- a/lib/make-client.ts
+++ b/lib/make-client.ts
@@ -1,19 +1,16 @@
-import createContentfulApi, {
-  Client,
-  ContentfulClientApi,
-  CreateContentfulApiParams,
-} from './create-contentful-api'
+import createContentfulApi, { CreateContentfulApiParams } from './create-contentful-api'
 import {
   ChainOptions,
   DefaultChainOption,
   ChainOption,
   ModifiersFromOptions,
 } from './utils/client-helpers'
+import { ContentfulClientApi } from './types'
 
 function create<OptionsType extends ChainOptions>(
   { http, getGlobalOptions }: CreateContentfulApiParams,
   options: OptionsType,
-  makeInnerClient: (options: OptionsType) => Client<ModifiersFromOptions<OptionsType>>
+  makeInnerClient: (options: OptionsType) => ContentfulClientApi<ModifiersFromOptions<OptionsType>>
 ) {
   const client = createContentfulApi<OptionsType>(
     {
@@ -32,16 +29,16 @@ function create<OptionsType extends ChainOptions>(
   Object.defineProperty(response, 'withoutUnresolvableLinks', {
     get: () => makeInnerClient({ ...options, withoutUnresolvableLinks: true }),
   })
-  return Object.create(response) as Client<ModifiersFromOptions<OptionsType>>
+  return Object.create(response) as ContentfulClientApi<ModifiersFromOptions<OptionsType>>
 }
 
 export const makeClient = ({
   http,
   getGlobalOptions,
-}: CreateContentfulApiParams): ContentfulClientApi => {
+}: CreateContentfulApiParams): ContentfulClientApi<undefined> => {
   function makeInnerClient<Options extends ChainOptions>(
     options: Options
-  ): Client<ModifiersFromOptions<Options>> {
+  ): ContentfulClientApi<ModifiersFromOptions<Options>> {
     return create<Options>({ http, getGlobalOptions }, options, makeInnerClient)
   }
 

--- a/lib/types/client.ts
+++ b/lib/types/client.ts
@@ -1,0 +1,244 @@
+import { AddChainModifier, ChainModifiers } from '../utils/client-helpers'
+import { ContentType, ContentTypeCollection } from './content-type'
+import { Space } from './space'
+import { LocaleCode, LocaleCollection } from './locale'
+import { AssetQueries, EntriesQueries, EntrySkeletonType, TagQueries } from './query'
+import { SyncCollection, SyncQuery } from './sync'
+import { Tag, TagCollection } from './tag'
+import { AssetKey } from './asset-key'
+import { EntryQueries, LocaleOption } from './query/query'
+import { Entry, EntryCollection } from './entry'
+import { Asset, AssetCollection, AssetFields } from './asset'
+
+interface BaseClient {
+  version: string
+
+  /**
+   * Gets a Content Type
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const contentType = await client.getContentType('<content_type_id>')
+   * console.log(contentType)
+   * ```
+   */
+  getContentType(id: string): Promise<ContentType>
+
+  /**
+   * Gets a collection of Content Types
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getContentTypes()
+   * console.log(response.items)
+   * ```
+   */
+  getContentTypes(query?: { query?: string }): Promise<ContentTypeCollection>
+
+  /**
+   * Gets the Space which the client is currently configured to use
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   * // returns the space object with the above <space-id>
+   * const space = await client.getSpace()
+   * console.log(space)
+   * ```
+   */
+  getSpace(): Promise<Space>
+
+  /**
+   * Gets a collection of Locales
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getLocales()
+   * console.log(response.items)
+   * ```
+   */
+
+  getLocales(): Promise<LocaleCollection>
+
+  /**
+   * Synchronizes either all the content or only new content since last sync
+   * See <a href="https://www.contentful.com/developers/docs/concepts/sync/">Synchronization</a> for more information.
+   * <strong> Important note: </strong> The the sync api endpoint does not support include or link resolution.
+   * However contentful.js is doing link resolution client side if you only make an initial sync.
+   * For the delta sync (using nextSyncToken) it is not possible since the sdk wont have access to all the data to make such an operation.
+   * @category API
+   * @example
+   * ```javascript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.sync({
+   *   initial: true
+   * })
+   * console.log({
+   *   entries: response.entries,
+   *   assets: response.assets,
+   *   nextSyncToken: response.nextSyncToken
+   * })
+   * ```
+   */
+  sync<
+    EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
+    Modifiers extends ChainModifiers = ChainModifiers,
+    Locales extends LocaleCode = LocaleCode
+  >(
+    query: SyncQuery
+  ): Promise<SyncCollection<EntrySkeleton, Modifiers, Locales>>
+
+  /**
+   * Gets a Tag
+   * @category API
+   * @example
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const tag = await client.getTag('<asset_id>')
+   * console.log(tag)
+   */
+  getTag(id: string): Promise<Tag>
+
+  /**
+   * Gets a collection of Tags
+   * @category API
+   * @example
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const response = await client.getTags()
+   * console.log(response.items)
+   */
+  getTags(query?: TagQueries): Promise<TagCollection>
+
+  /**
+   * Creates an asset key for signing asset URLs (Embargoed Assets)
+   * @category API
+   * @example
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const assetKey = await client.getAssetKey(<UNIX timestamp>)
+   * console.log(assetKey)
+   */
+  createAssetKey(expiresAt: number): Promise<AssetKey>
+}
+
+type ClientMethodsWithAllLocales<Modifiers extends ChainModifiers> = {
+  getEntry<
+    EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
+    Locales extends LocaleCode = LocaleCode
+  >(
+    id: string,
+    query?: EntryQueries
+  ): Promise<Entry<EntrySkeleton, Modifiers, Locales>>
+
+  getEntries<
+    EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
+    Locales extends LocaleCode = LocaleCode
+  >(
+    query?: EntriesQueries<EntrySkeleton>
+  ): Promise<EntryCollection<EntrySkeleton, Modifiers, Locales>>
+
+  parseEntries<
+    EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
+    Locales extends LocaleCode = LocaleCode
+  >(
+    data: EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locales>
+  ): EntryCollection<EntrySkeleton, Modifiers, Locales>
+
+  getAsset<Locales extends LocaleCode = LocaleCode>(
+    id: string
+  ): Promise<Asset<'WITH_ALL_LOCALES', Locales>>
+
+  getAssets<Locales extends LocaleCode = LocaleCode>(
+    query?: AssetQueries<AssetFields>
+  ): Promise<AssetCollection<'WITH_ALL_LOCALES', Locales>>
+}
+
+type ClientMethodsWithoutAllLocales<Modifiers extends ChainModifiers> = {
+  withAllLocales: ContentfulClientApi<AddChainModifier<Modifiers, 'WITH_ALL_LOCALES'>>
+  getEntry<EntrySkeleton extends EntrySkeletonType = EntrySkeletonType>(
+    id: string,
+    query?: EntryQueries & LocaleOption
+  ): Promise<Entry<EntrySkeleton, Modifiers>>
+
+  getEntries<EntrySkeleton extends EntrySkeletonType = EntrySkeletonType>(
+    query?: EntriesQueries<EntrySkeleton> & LocaleOption
+  ): Promise<EntryCollection<EntrySkeleton, Modifiers>>
+
+  parseEntries<EntrySkeleton extends EntrySkeletonType = EntrySkeletonType>(
+    data: EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>
+  ): EntryCollection<EntrySkeleton, Modifiers>
+
+  getAsset(id: string, query?: LocaleOption): Promise<Asset<undefined>>
+
+  getAssets(query?: AssetQueries<AssetFields> & LocaleOption): Promise<AssetCollection<undefined>>
+}
+
+/**
+ * @category Client
+ */
+export type ContentfulClientApi<Modifiers extends ChainModifiers> = BaseClient &
+  ('WITHOUT_LINK_RESOLUTION' extends Modifiers
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : {
+        withoutLinkResolution: ContentfulClientApi<
+          AddChainModifier<Modifiers, 'WITHOUT_LINK_RESOLUTION'>
+        >
+        withoutUnresolvableLinks: ContentfulClientApi<
+          AddChainModifier<Modifiers, 'WITHOUT_UNRESOLVABLE_LINKS'>
+        >
+      }) &
+  ('WITH_ALL_LOCALES' extends Modifiers
+    ? ClientMethodsWithAllLocales<Modifiers>
+    : ClientMethodsWithoutAllLocales<Modifiers>)

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,5 +1,6 @@
 export * from './asset'
 export * from './asset-key'
+export { ContentfulClientApi } from './client'
 export * from './collection'
 export * from './content-type'
 export * from './entry'

--- a/test/types/client/createClient.test-d.ts
+++ b/test/types/client/createClient.test-d.ts
@@ -1,16 +1,17 @@
 import { expectNotAssignable, expectType } from 'tsd'
 
-import { createClient } from '../../../lib'
-import { Client } from '../../../lib/create-contentful-api'
+import { ContentfulClientApi, createClient } from '../../../lib'
 
 const CLIENT_OPTIONS = {
   accessToken: 'accessToken',
   space: 'spaceId',
 }
 
-expectType<Client<undefined>>(createClient(CLIENT_OPTIONS))
+expectType<ContentfulClientApi<undefined>>(createClient(CLIENT_OPTIONS))
 
-expectType<Client<'WITHOUT_LINK_RESOLUTION'>>(createClient(CLIENT_OPTIONS).withoutLinkResolution)
+expectType<ContentfulClientApi<'WITHOUT_LINK_RESOLUTION'>>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution
+)
 expectNotAssignable<{ withoutLinkResolution: any }>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution
 )
@@ -18,7 +19,7 @@ expectNotAssignable<{ withoutUnresolvableLinks: any }>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution
 )
 
-expectType<Client<'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES'>>(
+expectType<ContentfulClientApi<'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES'>>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
 )
 expectNotAssignable<{ withoutLinkResolution: any }>(
@@ -31,7 +32,7 @@ expectNotAssignable<{ withoutLinkResolution: any }>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
 )
 
-expectType<Client<'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<ContentfulClientApi<'WITHOUT_UNRESOLVABLE_LINKS'>>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
 )
 expectNotAssignable<{ withoutUnresolvableLinks: any }>(
@@ -41,7 +42,7 @@ expectNotAssignable<{ withoutLinkResolution: any }>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
 )
 
-expectType<Client<'WITHOUT_UNRESOLVABLE_LINKS' | 'WITH_ALL_LOCALES'>>(
+expectType<ContentfulClientApi<'WITHOUT_UNRESOLVABLE_LINKS' | 'WITH_ALL_LOCALES'>>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
 )
 expectNotAssignable<{ withoutUnresolvableLinks: any }>(
@@ -54,13 +55,13 @@ expectNotAssignable<{ withoutLinkResolution: any }>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
 )
 
-expectType<Client<'WITH_ALL_LOCALES'>>(createClient(CLIENT_OPTIONS).withAllLocales)
+expectType<ContentfulClientApi<'WITH_ALL_LOCALES'>>(createClient(CLIENT_OPTIONS).withAllLocales)
 expectNotAssignable<{ withAllLocales: any }>(createClient(CLIENT_OPTIONS).withAllLocales)
 
-expectType<Client<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<ContentfulClientApi<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutLinkResolution
 )
 
-expectType<Client<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<ContentfulClientApi<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutUnresolvableLinks
 )


### PR DESCRIPTION
## Summary

Replace existing client types (`Client`, `ContentfulClientApi`, and `DefaultClient`) with just `ContentfulClientApi`, move it to the `types` folder, and link it in the docs.
