### PR TITLE
chore: document client methods

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -14,7 +14,6 @@ import {
   ContentfulClientApi,
   ContentType,
   ContentTypeCollection,
-  EntriesQueries,
   LocaleCollection,
   LocaleCode,
   Space,
@@ -25,7 +24,6 @@ import {
   SyncOptions,
   EntrySkeletonType,
 } from './types'
-import { EntryQueries, LocaleOption } from './types/query/query'
 import normalizeSearchParameters from './utils/normalize-search-parameters'
 import normalizeSelect from './utils/normalize-select'
 import resolveCircular from './utils/resolve-circular'
@@ -139,17 +137,12 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     })
   }
 
-  async function getEntry<EntrySkeleton extends EntrySkeletonType = EntrySkeletonType>(
-    id: string,
-    query: EntryQueries & LocaleOption = {}
-  ) {
-    return makeGetEntry<EntrySkeleton>(id, query, options)
+  async function getEntry(id, query = {}) {
+    return makeGetEntry(id, query, options)
   }
 
-  async function getEntries<EntrySkeleton extends EntrySkeletonType = EntrySkeletonType>(
-    query: EntriesQueries<EntrySkeleton> & LocaleOption = {}
-  ) {
-    return makeGetEntries<EntrySkeleton>(query, options)
+  async function getEntries(query = {}) {
+    return makeGetEntries(query, options)
   }
 
   async function makeGetEntry<EntrySkeleton extends EntrySkeletonType>(

--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -1,8 +1,8 @@
-import { ChainModifiers } from '../utils/client-helpers'
 import { ContentfulCollection } from './collection'
 import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { EntitySys } from './sys'
+import { ChainModifiers } from './client'
 
 /**
  * @module Asset

--- a/lib/types/client.ts
+++ b/lib/types/client.ts
@@ -260,7 +260,7 @@ export type ContentfulClientApi<Modifiers extends ChainModifiers> = {
    * let parsedData = client.parseEntries(data);
    * console.log( parsedData.items[0].fields.foo ); // foo
    */
-  parseEntries: <
+  parseEntries<
     EntrySkeleton extends EntrySkeletonType = EntrySkeletonType,
     Locales extends LocaleCode = LocaleCode
   >(
@@ -269,7 +269,7 @@ export type ContentfulClientApi<Modifiers extends ChainModifiers> = {
       AddChainModifier<Modifiers, 'WITHOUT_LINK_RESOLUTION'>,
       Locales
     >
-  ) => EntryCollection<EntrySkeleton, Modifiers, Locales>
+  ): EntryCollection<EntrySkeleton, Modifiers, Locales>
 
   /**
    * Gets an Asset

--- a/lib/types/client.ts
+++ b/lib/types/client.ts
@@ -1,11 +1,17 @@
 import { ContentType, ContentTypeCollection } from './content-type'
 import { Space } from './space'
 import { LocaleCode, LocaleCollection } from './locale'
-import { AssetsQueries, EntriesQueries, EntrySkeletonType, TagQueries } from './query'
+import {
+  AssetQueries,
+  AssetsQueries,
+  EntriesQueries,
+  EntryQueries,
+  EntrySkeletonType,
+  TagQueries,
+} from './query'
 import { SyncCollection, SyncQuery } from './sync'
 import { Tag, TagCollection } from './tag'
 import { AssetKey } from './asset-key'
-import { AssetQueries, EntryQueries } from './query/query'
 import { Entry, EntryCollection } from './entry'
 import { Asset, AssetCollection, AssetFields } from './asset'
 

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -6,9 +6,9 @@ import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { EntrySkeletonType } from './query'
 import { EntitySys } from './sys'
-import { ChainModifiers } from '../utils/client-helpers'
 import { JsonArray, JsonObject } from 'type-fest'
 import { ResourceLink } from './resource-link'
+import { ChainModifiers } from './client'
 
 /**
  * @category Entry

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,6 +1,6 @@
 export * from './asset'
 export * from './asset-key'
-export { ContentfulClientApi } from './client'
+export { ChainModifiers, ContentfulClientApi } from './client'
 export * from './collection'
 export * from './content-type'
 export * from './entry'

--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,2 +1,2 @@
-export { type AssetQueries, type EntriesQueries, type TagQueries } from './query'
+export { type AssetsQueries, type EntriesQueries, type TagQueries } from './query'
 export { type FieldsType, EntrySkeletonType } from './util'

--- a/lib/types/query/index.ts
+++ b/lib/types/query/index.ts
@@ -1,2 +1,8 @@
-export { type AssetsQueries, type EntriesQueries, type TagQueries } from './query'
+export {
+  type AssetQueries,
+  type AssetsQueries,
+  type EntryQueries,
+  type EntriesQueries,
+  type TagQueries,
+} from './query'
 export { type FieldsType, EntrySkeletonType } from './util'

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -29,6 +29,7 @@ import {
   TagOrderFilter,
 } from './order'
 import { EntryFieldsSetFilter } from './set'
+import { ChainModifiers } from '../client'
 
 type FixedPagedOptions = {
   skip?: number
@@ -80,18 +81,25 @@ export type EntryContentTypeQuery<T extends string> = {
 /**
  * @category Query
  */
-export type EntriesQueries<EntrySkeleton extends EntrySkeletonType> =
+export type EntriesQueries<
+  EntrySkeleton extends EntrySkeletonType,
+  Modifiers extends ChainModifiers
+> =
   | (EntryFieldsQueries<EntrySkeleton['fields']> &
       EntryContentTypeQuery<EntrySkeleton['contentTypeId']>)
-  | (SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
+  | ((SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       MetadataTagsQueries &
       EntrySelectFilter &
       EntryOrderFilter &
       FixedQueryOptions &
       FixedPagedOptions &
-      FixedLinkOptions)
+      FixedLinkOptions) &
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      ('WITH_ALL_LOCALES' extends Modifiers ? {} : LocaleOption))
 
-export type EntryQueries = Omit<FixedQueryOptions, 'query'>
+export type EntryQueries<Modifiers extends ChainModifiers> = Omit<FixedQueryOptions, 'query'> &
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  ('WITH_ALL_LOCALES' extends Modifiers ? {} : LocaleOption)
 
 export type AssetFieldsQueries<Fields extends FieldsType> = ExistenceFilter<Fields, 'fields'> &
   EqualityFilter<Fields, 'fields'> &
@@ -121,13 +129,23 @@ export type AssetFieldsFileDetailsQueries = ExistenceFilter<
 /**
  * @category Query
  */
-export type AssetQueries<Fields extends FieldsType> = AssetFieldsQueries<Fields> &
+export type AssetsQueries<
+  Fields extends FieldsType,
+  Modifiers extends ChainModifiers
+> = AssetFieldsQueries<Fields> &
   AssetFieldsFileQueries &
   AssetFieldsFileDetailsQueries &
   SysQueries<Pick<AssetSys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
   MetadataTagsQueries &
   FixedQueryOptions &
-  FixedPagedOptions & { mimetype_group?: AssetMimeType }
+  FixedPagedOptions & { mimetype_group?: AssetMimeType } & ('WITH_ALL_LOCALES' extends Modifiers
+    ? // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+    : LocaleOption)
+
+export type AssetQueries<Modifiers extends ChainModifiers> = 'WITH_ALL_LOCALES' extends Modifiers
+  ? never
+  : LocaleOption
 
 export type TagNameFilters = {
   'name[exists]'?: boolean

--- a/lib/types/sync.ts
+++ b/lib/types/sync.ts
@@ -3,7 +3,7 @@ import { Entry } from './entry'
 import { EntitySys } from './sys'
 import { EntrySkeletonType } from './query'
 import { LocaleCode } from './locale'
-import { ChainModifiers } from '../utils/client-helpers'
+import { ChainModifiers } from './client'
 
 /**
  * @category Sync

--- a/lib/utils/client-helpers.ts
+++ b/lib/utils/client-helpers.ts
@@ -1,13 +1,4 @@
-export type ChainModifiers =
-  | 'WITH_ALL_LOCALES'
-  | 'WITHOUT_LINK_RESOLUTION'
-  | 'WITHOUT_UNRESOLVABLE_LINKS'
-  | undefined
-
-export type AddChainModifier<
-  Modifiers extends ChainModifiers,
-  AddedModifiers extends Exclude<ChainModifiers, undefined>
-> = undefined extends Modifiers ? AddedModifiers : Modifiers | AddedModifiers
+import { ChainModifiers } from '../types/client'
 
 export type ChainOption<Modifiers extends ChainModifiers = ChainModifiers> = {
   withoutLinkResolution: ChainModifiers extends Modifiers

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -4,10 +4,16 @@
 /// <reference path="../../lib/global.d.ts" />
 import { expectAssignable, expectNotAssignable } from 'tsd'
 
-import { Asset, AssetCollection, AssetDetails, AssetFields, AssetFile } from '../../lib'
+import {
+  Asset,
+  AssetCollection,
+  AssetDetails,
+  AssetFields,
+  AssetFile,
+  ChainModifiers,
+} from '../../lib'
 // @ts-ignore
 import * as mocks from './mocks'
-import { ChainModifiers } from '../../lib/utils/client-helpers'
 
 type AssetLocales = 'US' | 'DE'
 

--- a/test/types/chain-options.test-d.ts
+++ b/test/types/chain-options.test-d.ts
@@ -1,5 +1,6 @@
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd'
-import { ChainModifiers, ChainOption, ChainOptions } from '../../lib/utils/client-helpers'
+import { ChainOption, ChainOptions } from '../../lib/utils/client-helpers'
+import { ChainModifiers } from '../../lib'
 
 expectNotAssignable<ChainModifiers>('ANY_STRING')
 

--- a/test/types/client/createClient.test-d.ts
+++ b/test/types/client/createClient.test-d.ts
@@ -1,4 +1,4 @@
-import { expectNotAssignable, expectType } from 'tsd'
+import { expectType } from 'tsd'
 
 import { ContentfulClientApi, createClient } from '../../../lib'
 
@@ -12,51 +12,41 @@ expectType<ContentfulClientApi<undefined>>(createClient(CLIENT_OPTIONS))
 expectType<ContentfulClientApi<'WITHOUT_LINK_RESOLUTION'>>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution
 )
-expectNotAssignable<{ withoutLinkResolution: any }>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution
-)
-expectNotAssignable<{ withoutUnresolvableLinks: any }>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution
-)
+expectType<never>(createClient(CLIENT_OPTIONS).withoutLinkResolution.withoutLinkResolution)
+expectType<never>(createClient(CLIENT_OPTIONS).withoutLinkResolution.withoutUnresolvableLinks)
 
 expectType<ContentfulClientApi<'WITHOUT_LINK_RESOLUTION' | 'WITH_ALL_LOCALES'>>(
   createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
 )
-expectNotAssignable<{ withoutLinkResolution: any }>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+expectType<never>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales.withoutLinkResolution
 )
-expectNotAssignable<{ withAllLocales: any }>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
-)
-expectNotAssignable<{ withoutLinkResolution: any }>(
-  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales
+expectType<never>(createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales.withAllLocales)
+expectType<never>(
+  createClient(CLIENT_OPTIONS).withoutLinkResolution.withAllLocales.withoutLinkResolution
 )
 
 expectType<ContentfulClientApi<'WITHOUT_UNRESOLVABLE_LINKS'>>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
 )
-expectNotAssignable<{ withoutUnresolvableLinks: any }>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
-)
-expectNotAssignable<{ withoutLinkResolution: any }>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks
-)
+expectType<never>(createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withoutUnresolvableLinks)
+expectType<never>(createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withoutLinkResolution)
 
 expectType<ContentfulClientApi<'WITHOUT_UNRESOLVABLE_LINKS' | 'WITH_ALL_LOCALES'>>(
   createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
 )
-expectNotAssignable<{ withoutUnresolvableLinks: any }>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+expectType<never>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales.withoutUnresolvableLinks
 )
-expectNotAssignable<{ withAllLocales: any }>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+expectType<never>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales.withAllLocales
 )
-expectNotAssignable<{ withoutLinkResolution: any }>(
-  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales
+expectType<never>(
+  createClient(CLIENT_OPTIONS).withoutUnresolvableLinks.withAllLocales.withoutLinkResolution
 )
 
 expectType<ContentfulClientApi<'WITH_ALL_LOCALES'>>(createClient(CLIENT_OPTIONS).withAllLocales)
-expectNotAssignable<{ withAllLocales: any }>(createClient(CLIENT_OPTIONS).withAllLocales)
+expectType<never>(createClient(CLIENT_OPTIONS).withAllLocales.withAllLocales)
 
 expectType<ContentfulClientApi<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   createClient(CLIENT_OPTIONS).withAllLocales.withoutLinkResolution

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -1,9 +1,9 @@
 import { expectAssignable, expectNotAssignable } from 'tsd'
-import { AssetFields, AssetQueries } from '../../../lib'
+import { AssetFields, AssetsQueries } from '../../../lib'
 // @ts-ignore
 import * as mocks from '../mocks'
 
-type DefaultAssetQueries = AssetQueries<AssetFields>
+type DefaultAssetQueries = AssetsQueries<AssetFields, undefined>
 
 // all operator
 
@@ -186,3 +186,8 @@ expectNotAssignable<DefaultAssetQueries>({ select: ['sys.unknownProperty'] })
 expectAssignable<DefaultAssetQueries>({ select: ['fields'] })
 expectAssignable<DefaultAssetQueries>({ select: ['fields.title'] })
 expectNotAssignable<DefaultAssetQueries>({ select: ['fields.unknownField'] })
+
+// locale option
+
+expectAssignable<AssetsQueries<AssetFields, undefined>>({ locale: mocks.stringValue })
+expectNotAssignable<AssetsQueries<AssetFields, 'WITH_ALL_LOCALES'>>({ locale: mocks.anyValue })

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -10,7 +10,8 @@ expectAssignable<
     EntrySkeletonType<{
       stringField: EntryFieldTypes.Symbol
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
@@ -20,7 +21,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       stringField: EntryFieldTypes.Symbol
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'fields.stringField[all]': mocks.anyValue,
@@ -30,7 +32,8 @@ expectAssignable<
     EntrySkeletonType<{
       stringField: EntryFieldTypes.Symbol
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -42,7 +45,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       stringField: EntryFieldTypes.Symbol
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -51,85 +55,125 @@ expectNotAssignable<
 
 // equality
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'fields.numberField': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.someField': mocks.stringValue,
   'sys.updatedAt': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.unknownProp': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField': mocks.anyValue,
 })
 
 // exists operator (field is present)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'metadata.tags[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'fields.numberField[exists]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.someField[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.unknownProp[exists]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[exists]': mocks.anyValue,
 })
 
 // gt operator (range)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'fields.numberField[gt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.numberField[gt]': mocks.numberValue,
   'sys.updatedAt[gt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'sys.unknownProp[gt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[gt]': mocks.anyValue,
 })
 
 // gte operator (range)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Number }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Number }>, undefined>
+>({
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'fields.numberField[gte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.numberField[gte]': mocks.numberValue,
   'sys.updatedAt[gte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'sys.unknownProp[gte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[gte]': mocks.anyValue,
 })
@@ -141,7 +185,8 @@ expectAssignable<
     EntrySkeletonType<{
       numberField: number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'metadata.tags.sys.id[in]': mocks.stringArrayValue,
@@ -152,7 +197,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'fields.numberField[in]': mocks.anyValue,
@@ -163,7 +209,8 @@ expectAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -171,7 +218,9 @@ expectAssignable<
   'fields.stringArrayField[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.unknownProp[in]': mocks.anyValue,
 })
 expectNotAssignable<
@@ -179,7 +228,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -188,98 +238,136 @@ expectNotAssignable<
 
 // lt operator (range)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'fields.numberField[lt]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.numberField[lt]': mocks.numberValue,
   'sys.updatedAt[lt]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'sys.unknownProp[lt]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[lt]': mocks.anyValue,
 })
 
 // lte operator (range)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'fields.numberField[lte]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.numberField[lte]': mocks.numberValue,
   'sys.updatedAt[lte]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   'sys.unknownProp[lte]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ numberField: EntryFieldTypes.Number }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[lte]': mocks.anyValue,
 })
 
 // match operator (full-text search)
 
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'fields.textField[match]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.textField[match]': mocks.stringValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ textField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[match]': mocks.anyValue,
 })
 
 // ne operator (inequality)
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'fields.numberField[ne]': mocks.anyValue,
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.someField[ne]': mocks.stringValue,
   'sys.updatedAt[ne]': mocks.dateValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.unknownProp[ne]': mocks.anyValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   'fields.unknownField[ne]': mocks.anyValue,
 })
 
 // near operator (full-text search)
 
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    'fields.locationField[near]': mocks.anyValue,
-  }
-)
-expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  'fields.locationField[near]': mocks.anyValue,
+})
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
   content_type: 'id',
   'fields.locationField[near]': mocks.nearLocationValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    content_type: 'id',
-    'fields.unknownField[near]': mocks.anyValue,
-  }
-)
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  content_type: 'id',
+  'fields.unknownField[near]': mocks.anyValue,
+})
 
 // nin operator
 
@@ -288,7 +376,8 @@ expectAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'sys.updatedAt[nin]': mocks.dateArrayValue,
@@ -298,7 +387,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   'fields.numberField[nin]': mocks.anyValue,
@@ -309,7 +399,8 @@ expectAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -317,7 +408,9 @@ expectAssignable<
   'fields.stringArrayField[nin]': mocks.stringArrayValue,
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   'sys.unknownProp[nin]': mocks.anyValue,
 })
 expectNotAssignable<
@@ -325,7 +418,8 @@ expectNotAssignable<
     EntrySkeletonType<{
       numberField: EntryFieldTypes.Number
       stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -334,17 +428,25 @@ expectNotAssignable<
 
 // order operator
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   order: ['sys.createdAt', '-sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   order: ['sys.unknownProperty'],
 })
 
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   order: ['fields.someField'],
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   order: ['fields.someField', '-fields.someField'],
 })
@@ -353,7 +455,8 @@ expectAssignable<
     EntrySkeletonType<{
       mediaField: EntryFieldTypes.AssetLink
       referenceField: EntryFieldTypes.EntryLink<any>
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',
@@ -364,90 +467,122 @@ expectAssignable<
     '-fields.referenceField.sys.id',
   ],
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   order: ['fields.unknownField'],
 })
 
 // select operator
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   select: ['sys'],
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   select: ['sys.createdAt'],
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   select: ['sys.unknownProperty'],
 })
 
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   select: ['fields'],
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   select: ['fields.someField'],
 })
-expectAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   select: ['fields.someField'],
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
+>({
   content_type: 'id',
   select: ['fields.unknownField'],
 })
 
 // within operator (bounding circle)
 
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    'fields.locationField[within]': mocks.anyValue,
-  }
-)
-expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  'fields.locationField[within]': mocks.anyValue,
+})
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinCircleLocationValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    content_type: 'id',
-    'fields.unknownField[within]': mocks.anyValue,
-  }
-)
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  content_type: 'id',
+  'fields.unknownField[within]': mocks.anyValue,
+})
 
 // within operator (bounding rectangle)
 
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    'fields.locationField[within]': mocks.anyValue,
-  }
-)
-expectAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>({
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  'fields.locationField[within]': mocks.anyValue,
+})
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
   content_type: 'id',
   'fields.locationField[within]': mocks.withinBoxLocationValue,
 })
-expectNotAssignable<EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>>>(
-  {
-    content_type: 'id',
-    'fields.unknownField[within]': mocks.anyValue,
-  }
-)
+expectNotAssignable<
+  EntriesQueries<EntrySkeletonType<{ locationField: EntryFieldTypes.Location }>, undefined>
+>({
+  content_type: 'id',
+  'fields.unknownField[within]': mocks.anyValue,
+})
 
 // search on references
 
 expectNotAssignable<
-  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>>
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>, undefined>
 >({
   'fields.referenceField.sys.contentType.sys.id': 'id',
 })
 expectAssignable<
-  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>>
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>, undefined>
 >({
   content_type: 'id',
   'fields.referenceField.sys.contentType.sys.id': 'id',
 })
 expectNotAssignable<
-  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>>
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>, undefined>
 >({
   content_type: 'id',
   'fields.unknownField.sys.contentType.sys.id': 'id',
 })
+
+// locale option
+
+expectAssignable<
+  EntriesQueries<EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>, undefined>
+>({ locale: mocks.stringValue })
+expectNotAssignable<
+  EntriesQueries<
+    EntrySkeletonType<{ referenceField: EntryFieldTypes.EntryLink<any> }>,
+    'WITH_ALL_LOCALES'
+  >
+>({ locale: mocks.anyValue })

--- a/test/types/query.test-d.ts
+++ b/test/types/query.test-d.ts
@@ -141,7 +141,8 @@ expectAssignable<
     EntrySkeletonType<{
       stringField: EntryFieldTypes.Symbol
       numberField: EntryFieldTypes.Number
-    }>
+    }>,
+    undefined
   >
 >({
   content_type: 'id',


### PR DESCRIPTION
## Summary

Document the client methods and reorganize the client type to create readable documentation.

## Description

* Put all client methods directly into `ContentfulClientApi` to generate readable documentation. Small caveats:
  * `Locales` type parameter is now also available for methods that don’t need it.
  * Client properties that can’t be used are now typed as `never` instead of omitted.
* Move `LocaleOption` into `…Queries` types to improve readability.

## Motivation and Context

TypeDoc doesn’t do well with complex types. We can spend all day coming up with clever dynamic solutions for types but at least for those types that we want to cover with generated documentation we have to be a little bit more straightforward.
