### PR TITLE
chore: ignore semantic-release version upgrade starting from v20.0.0 …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,4 +39,7 @@ updates:
       - dependency-name: "eslint-plugin-promise"
         versions:
           - ">=6.0.0"
+      - dependency-name: "semantic-release"
+        versions:
+          - ">=20.0.0"
 


### PR DESCRIPTION

<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

Ensure that dependabot no longer upgrades semantic-release versions to.avoid messing up the release job before v10 release
