### PR TITLE
chore: fix release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
       - image: 'cimg/node:18.15-browsers'
     steps:
       - checkout
+      - vault/get-secrets: # Loads vault secrets
+          template-preset: 'semantic-release-ecosystem'
       - node/install-packages
       - run: npm run build
       - run: npm run semantic-release


### PR DESCRIPTION
re-add vault usage for the release step