### PR TITLE
chore: ignore axios version upgrade by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,4 +42,7 @@ updates:
       - dependency-name: "semantic-release"
         versions:
           - ">=20.0.0"
+      - dependency-name: "axios"
+        versions:
+          - ">=1.0.0"
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->
Axios new version is causing pipeline to fail on beta-v10, so we need to ignore this upgrade before the release of the v10
