### PR TITLE
fix: using media to generate contentful logo correctly in typedoc output

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.contentful.com/developers/docs/references/content-delivery-api/">
-    <img alt="Contentful Logo" title="Contentful" src="../images/contentful-icon.png" width="150">
+    <img alt="Contentful Logo" title="Contentful" src="media://contentful-icon.png" width="150">
   </a>
 </p>
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,5 +7,6 @@
   "includeVersion": false,
   "hideGenerator": true,
   "excludePrivate": true,
-  "categorizeByGroup": false
+  "categorizeByGroup": false,
+  "media": "./images"
 }


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

fixing the contentful logo in typedoc
