### PR TITLE
feat: support in validation in entry field types

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -25,10 +25,10 @@ export interface EntrySys extends EntitySys {
  * @category Entry
  */
 export declare namespace EntryFieldTypes {
-  type Symbol = { type: 'Symbol' }
-  type Text = { type: 'Text' }
-  type Integer = { type: 'Integer' }
-  type Number = { type: 'Number' }
+  type Symbol<Values extends string = string> = { type: 'Symbol'; values: Values }
+  type Text<Values extends string = string> = { type: 'Text'; values: Values }
+  type Integer<Values extends number = number> = { type: 'Integer'; values: Values }
+  type Number<Values extends number = number> = { type: 'Number'; values: Values }
   type Date = { type: 'Date' }
   type Boolean = { type: 'Boolean' }
   type Location = { type: 'Location' }
@@ -61,10 +61,10 @@ export declare namespace EntryFieldTypes {
  * @category Entry
  */
 export declare namespace EntryFields {
-  type Symbol = string
-  type Text = string
-  type Integer = number
-  type Number = number
+  type Symbol<Values extends string = string> = Values
+  type Text<Values extends string = string> = Values
+  type Integer<Values extends number = number> = Values
+  type Number<Values extends number = number> = Values
   type Date = `${number}-${number}-${number}T${number}:${number}:${number}Z`
   type Boolean = boolean
 
@@ -137,14 +137,14 @@ export type BaseEntry = {
  * @category Entry
  */
 export type BaseFieldMap<Field extends EntryFieldType<EntrySkeletonType>> =
-  Field extends EntryFieldTypes.Symbol
-    ? EntryFields.Symbol
-    : Field extends EntryFieldTypes.Text
-    ? EntryFields.Text
-    : Field extends EntryFieldTypes.Integer
-    ? EntryFields.Integer
-    : Field extends EntryFieldTypes.Number
-    ? EntryFields.Number
+  Field extends EntryFieldTypes.Symbol<infer Values>
+    ? EntryFields.Symbol<Values>
+    : Field extends EntryFieldTypes.Text<infer Values>
+    ? EntryFields.Text<Values>
+    : Field extends EntryFieldTypes.Integer<infer Values>
+    ? EntryFields.Integer<Values>
+    : Field extends EntryFieldTypes.Number<infer Values>
+    ? EntryFields.Number<Values>
     : Field extends EntryFieldTypes.Date
     ? EntryFields.Date
     : Field extends EntryFieldTypes.Boolean

--- a/test/types/resolved-field.test-d.ts
+++ b/test/types/resolved-field.test-d.ts
@@ -12,15 +12,39 @@ type SimpleEntryFields = { title: EntryFieldTypes.Symbol }
 type SimpleEntryWithContentTypeId = EntrySkeletonType<SimpleEntryFields>
 
 expectAssignable<ResolvedField<EntryFieldTypes.Symbol, undefined>>(mocks.stringValue)
+expectAssignable<ResolvedField<EntryFieldTypes.Symbol<'a' | 'b'>, undefined>>('a')
+expectAssignable<ResolvedField<EntryFieldTypes.Symbol<'a' | 'b'>, undefined>>('b')
+expectNotAssignable<ResolvedField<EntryFieldTypes.Symbol<'a' | 'b'>, undefined>>('c')
+
 expectAssignable<ResolvedField<EntryFieldTypes.Text, undefined>>(mocks.stringValue)
+expectAssignable<ResolvedField<EntryFieldTypes.Text<'a' | 'b'>, undefined>>('a')
+expectAssignable<ResolvedField<EntryFieldTypes.Text<'a' | 'b'>, undefined>>('b')
+expectNotAssignable<ResolvedField<EntryFieldTypes.Text<'a' | 'b'>, undefined>>('c')
+
 expectAssignable<ResolvedField<EntryFieldTypes.Integer, undefined>>(mocks.numberValue)
+expectAssignable<ResolvedField<EntryFieldTypes.Integer<1 | 2>, undefined>>(1)
+expectAssignable<ResolvedField<EntryFieldTypes.Integer<1 | 2>, undefined>>(2)
+expectNotAssignable<ResolvedField<EntryFieldTypes.Integer<1 | 2>, undefined>>(3)
+
 expectAssignable<ResolvedField<EntryFieldTypes.Number, undefined>>(mocks.numberValue)
+expectAssignable<ResolvedField<EntryFieldTypes.Number<1 | 2>, undefined>>(1)
+expectAssignable<ResolvedField<EntryFieldTypes.Number<1 | 2>, undefined>>(2)
+expectNotAssignable<ResolvedField<EntryFieldTypes.Number<1 | 2>, undefined>>(3)
+
 expectAssignable<ResolvedField<EntryFieldTypes.Date, undefined>>(mocks.dateValue)
 expectAssignable<ResolvedField<EntryFieldTypes.Boolean, undefined>>(mocks.booleanValue)
 expectAssignable<ResolvedField<EntryFieldTypes.Location, undefined>>(mocks.locationValue)
+
 expectAssignable<ResolvedField<EntryFieldTypes.Array<EntryFieldTypes.Symbol>, undefined>>([
   mocks.stringValue,
 ])
+expectAssignable<
+  ResolvedField<EntryFieldTypes.Array<EntryFieldTypes.Symbol<'a' | 'b'>>, undefined>
+>(['a', 'b'])
+expectNotAssignable<
+  ResolvedField<EntryFieldTypes.Array<EntryFieldTypes.Symbol<'a' | 'b'>>, undefined>
+>(['c'])
+
 expectAssignable<ResolvedField<EntryFieldTypes.Object, undefined>>(mocks.jsonValue)
 
 // entries in links


### PR DESCRIPTION
## Summary

Add support for the `in` validation in field types allowing users to narrow down number and text field values.

## Description

For example, take a content type field with the following validation.

```
{
  "id": "textField",
  "name": "text field",
  "type": "Symbol",
  "validations": [
    {
      "in": ['option 1', 'option 2']
    }
  ],
  …
}
```

We can translate this to the following types.

```typescript
type ExampleEntrySkeleton = EntrySkeletonType<{
  textField: EntryFieldTypes.Symbol<'option 1' | 'option 2'>,
}>

type ExampleEntry = Entry<ExampleEntrySkeleton>
```

## Motivation and Context

In contentful.js v9 this was already possible because we used native types to describe fields. Since we’re using abstract types in v10 we have to explicitly allow this.