### PR TITLE
fix: correct asset localization

### DIFF
--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -48,14 +48,10 @@ export interface Asset<
   sys: AssetSys
   fields: ChainModifiers extends Modifiers
     ?
-        | {
-            [LocaleName in Locales]?: AssetFields
-          }
+        | { [FieldName in keyof AssetFields]: { [LocaleName in Locales]?: AssetFields[FieldName] } }
         | AssetFields
     : 'WITH_ALL_LOCALES' extends Modifiers
-    ? {
-        [LocaleName in Locales]?: AssetFields
-      }
+    ? { [FieldName in keyof AssetFields]: { [LocaleName in Locales]?: AssetFields[FieldName] } }
     : AssetFields
   metadata: Metadata
 }

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -215,13 +215,16 @@ export type ResolvedEntryResourceLink<
  * @typeParam Modifiers - The chain modifiers used to configure the client. They’re set automatically when using the client chain modifiers.
  * @internal
  */
-export type ResolvedAssetLink<Modifiers extends ChainModifiers> = ChainModifiers extends Modifiers
-  ? Asset | { sys: AssetLink } | undefined
+export type ResolvedAssetLink<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode
+> = ChainModifiers extends Modifiers
+  ? Asset<Modifiers, Locales> | { sys: AssetLink } | undefined
   : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
   ? { sys: AssetLink }
   : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
-  ? Asset | undefined
-  : Asset | { sys: AssetLink }
+  ? Asset<Modifiers, Locales> | undefined
+  : Asset<Modifiers, Locales> | { sys: AssetLink }
 
 /**
  * A single resolved link to another resource
@@ -240,7 +243,7 @@ export type ResolvedLink<
   : Field extends EntryFieldTypes.EntryResourceLink<infer LinkedEntry>
   ? ResolvedEntryResourceLink<Modifiers, Locales, LinkedEntry>
   : Field extends EntryFieldTypes.AssetLink
-  ? ResolvedAssetLink<Modifiers>
+  ? ResolvedAssetLink<Modifiers, Locales>
   : BaseFieldMap<Field>
 
 /**

--- a/test/types/asset-d.ts
+++ b/test/types/asset-d.ts
@@ -18,26 +18,18 @@ import * as mocks from './mocks'
 
 type AssetLocales = 'US' | 'DE'
 
-const assetWithAllLocales: Asset<'WITH_ALL_LOCALES', AssetLocales> = {
-  ...mocks.assetBasics,
-  fields: {
-    US: mocks.assetFields,
-    DE: mocks.assetFields,
-  },
-}
-
-const assetCollection: AssetCollection = {
+const assetCollection = {
   total: mocks.numberValue,
   skip: mocks.numberValue,
   limit: mocks.numberValue,
   items: [mocks.asset],
 }
 
-const assetCollectionWithAllLocales: AssetCollection<'WITH_ALL_LOCALES', AssetLocales> = {
+const assetCollectionWithAllLocales = {
   total: mocks.numberValue,
   skip: mocks.numberValue,
   limit: mocks.numberValue,
-  items: [assetWithAllLocales],
+  items: [mocks.localizedAsset],
 }
 
 expectAssignable<AssetDetails>(mocks.assetDetails)
@@ -45,10 +37,10 @@ expectAssignable<AssetFile>(mocks.assetFile)
 expectAssignable<AssetFields>(mocks.assetFields)
 
 expectAssignable<Asset<undefined>>(mocks.asset)
-expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(assetWithAllLocales)
+expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(mocks.localizedAsset)
 
 expectAssignable<Asset<ChainModifiers, AssetLocales>>(mocks.asset)
-expectAssignable<Asset<ChainModifiers, AssetLocales>>(assetWithAllLocales)
+expectAssignable<Asset<ChainModifiers, AssetLocales>>(mocks.localizedAsset)
 
 expectAssignable<AssetCollection<undefined>>(assetCollection)
 expectAssignable<AssetCollection<'WITH_ALL_LOCALES', AssetLocales>>(assetCollectionWithAllLocales)
@@ -57,20 +49,20 @@ expectAssignable<AssetCollection<ChainModifiers, AssetLocales>>(assetCollection)
 expectAssignable<AssetCollection<ChainModifiers, AssetLocales>>(assetCollectionWithAllLocales)
 
 expectNotAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(mocks.asset)
-expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(assetWithAllLocales)
+expectAssignable<Asset<'WITH_ALL_LOCALES', AssetLocales>>(mocks.localizedAsset)
 
 expectNotAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
   mocks.asset
 )
 expectAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', AssetLocales>>(
-  assetWithAllLocales
+  mocks.localizedAsset
 )
 
 expectNotAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
   mocks.asset
 )
 expectAssignable<Asset<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(
-  assetWithAllLocales
+  mocks.localizedAsset
 )
 
 expectNotAssignable<AssetCollection<'WITH_ALL_LOCALES', AssetLocales>>(assetCollection)
@@ -91,13 +83,13 @@ expectAssignable<AssetCollection<'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINK
 )
 
 expectAssignable<Asset<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(mocks.asset)
-expectNotAssignable<Asset<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(assetWithAllLocales)
+expectNotAssignable<Asset<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(mocks.localizedAsset)
 
 expectAssignable<Asset<undefined, AssetLocales>>(mocks.asset)
-expectNotAssignable<Asset<undefined, AssetLocales>>(assetWithAllLocales)
+expectNotAssignable<Asset<undefined, AssetLocales>>(mocks.localizedAsset)
 
 expectAssignable<Asset<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(mocks.asset)
-expectNotAssignable<Asset<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(assetWithAllLocales)
+expectNotAssignable<Asset<'WITHOUT_UNRESOLVABLE_LINKS', AssetLocales>>(mocks.localizedAsset)
 
 expectAssignable<AssetCollection<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(assetCollection)
 expectNotAssignable<AssetCollection<'WITHOUT_LINK_RESOLUTION', AssetLocales>>(

--- a/test/types/entry-d.ts
+++ b/test/types/entry-d.ts
@@ -328,13 +328,13 @@ expectAssignable<
       DE: [mocks.localizedEntry, mocks.entryLink],
       US: [mocks.localizedEntry, mocks.entryLink],
     },
-    resolvableAssetReferenceField: { DE: mocks.asset, US: mocks.asset },
+    resolvableAssetReferenceField: { DE: mocks.localizedAsset, US: mocks.localizedAsset },
     unresolvableAssetReferenceField: { US: mocks.assetLink, DE: mocks.assetLink },
-    resolvableMultiAssetReferenceField: { DE: [mocks.asset], US: [mocks.asset] },
+    resolvableMultiAssetReferenceField: { DE: [mocks.localizedAsset], US: [mocks.localizedAsset] },
     unresolvableMultiAssetReferenceField: { DE: [mocks.assetLink], US: [mocks.assetLink] },
     mixedMultiAssetReferenceField: {
-      DE: [mocks.asset, mocks.assetLink],
-      US: [mocks.asset, mocks.assetLink],
+      DE: [mocks.localizedAsset, mocks.assetLink],
+      US: [mocks.localizedAsset, mocks.assetLink],
     },
   },
 })
@@ -484,11 +484,14 @@ expectAssignable<
       US: [mocks.localizedEntry, undefined],
       DE: [mocks.localizedEntry, undefined],
     },
-    resolvableAssetReferenceField: { US: mocks.asset, DE: mocks.asset },
+    resolvableAssetReferenceField: { US: mocks.localizedAsset, DE: mocks.localizedAsset },
     unresolvableAssetReferenceField: { US: undefined, DE: undefined },
-    resolvableMultiAssetReferenceField: { US: [mocks.asset], DE: [mocks.asset] },
+    resolvableMultiAssetReferenceField: { US: [mocks.localizedAsset], DE: [mocks.localizedAsset] },
     unresolvableMultiAssetReferenceField: { US: [undefined], DE: [undefined] },
-    mixedMultiAssetReferenceField: { US: [mocks.asset, undefined], DE: [mocks.asset, undefined] },
+    mixedMultiAssetReferenceField: {
+      US: [mocks.localizedAsset, undefined],
+      DE: [mocks.localizedAsset, undefined],
+    },
   })
 )
 

--- a/test/types/mocks.ts
+++ b/test/types/mocks.ts
@@ -139,4 +139,12 @@ export const assetFields: AssetFields = {
   file: assetFile,
 }
 
-export const asset: Asset = { ...assetBasics, fields: assetFields }
+export const localizedAssetFields = {
+  title: { US: stringValue, DE: stringValue },
+  description: { US: stringValue, DE: stringValue },
+  file: { US: assetFile, DE: assetFile },
+}
+
+export const asset = { ...assetBasics, fields: assetFields }
+
+export const localizedAsset = { ...assetBasics, fields: localizedAssetFields }


### PR DESCRIPTION
## Summary

Fix localization of asset types.

## Description

Fix two issues related to asset localization.

* Chain modifiers were not passed down when resolving asset links causing types to be generic (representing both the localized and unlocalized version).
* Asset localization was on the wrong level: on the asset instead instead of on each field.
