### PR TITLE
fix: change entry points to prod versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "Client for Contentful's Content Delivery API",
   "version": "0.0.0-determined-by-semantic-release",
   "homepage": "https://www.contentful.com/developers/documentation/content-delivery-api/",
-  "main": "./dist/contentful.node.js",
-  "browser": "./dist/contentful.browser.js",
+  "main": "./dist/contentful.node.min.js",
+  "browser": "./dist/contentful.browser.min.js",
   "types": "./dist/types/index.d.ts",
   "browserslist": [
     "extends @contentful/browserslist-config"


### PR DESCRIPTION
## Summary

Change entry points to point to production versions to get rid of debug logic and reduce bundle size.