### PR TITLE
fix: adjust types for resolved entry links

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -179,7 +179,7 @@ export type ResolvedEntryLink<
   ? { sys: Link<'Entry'> }
   : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
   ? Entry<LinkedEntry, Modifiers, Locales> | undefined
-  : Entry<LinkedEntry, Modifiers, Locales> | { sys: Link<'Entry'> }
+  : Entry<LinkedEntry, Modifiers, Locales>
 
 /**
  * A single resolved reference link to another entry in a different space


### PR DESCRIPTION
For types of linked entries within entry fields, they do not get properly inferred, e.g.:

![image](https://user-images.githubusercontent.com/43542437/236229089-34338565-9fb4-49cd-8f7e-b131314031bb.png)

The reason for this seems to be that while determining the type here: https://github.com/contentful/contentful.js/blob/master/lib/types/entry.ts#L182 typescript tries to satisfy the condition `{ sys: Link<'Entry'> }` which does not have fields.

This PR removes it. However, there are for sure other dependencies of this type which will break, so we need to double checking as to why this was introduced in the first place.