### PR TITLE
feat: add explicit unresolved link type

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -113,7 +113,7 @@ The link resolution is applied to one level deep by default. If you need it to b
 
 **We resolve links by default**. If this behaviour is not what you want, you can use the chain modifier `withoutLinkResolution` on the Contentful client to keep the link objects instead of the inlined entries in your response object. See [client chain modifiers](README.md#client-chain-modifiers).
 
-**Links which could not get resolved will be kept by default**. If you want to completely remove fields which could not be resolved, you can use the chain modifier `withoutUnresolvableLinks`.
+**Links which could not get resolved will be kept by default** as `UnresolvedLink`. If you want to completely remove fields which could not be resolved, you can use the chain modifier `withoutUnresolvableLinks`.
 
 Please see the notes below for link resolution prior to v.10.0.0 and v.7.0.0.
 

--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -1,7 +1,7 @@
 import { Document as RichTextDocument } from '@contentful/rich-text-types'
 import { Asset } from './asset'
 import { ContentfulCollection } from './collection'
-import { AssetLink, ContentTypeLink, Link } from './link'
+import { AssetLink, ContentTypeLink, UnresolvedLink } from './link'
 import { LocaleCode } from './locale'
 import { Metadata } from './metadata'
 import { EntrySkeletonType } from './query'
@@ -174,12 +174,12 @@ export type ResolvedEntryLink<
   Locales extends LocaleCode,
   LinkedEntry extends EntrySkeletonType
 > = ChainModifiers extends Modifiers
-  ? Entry<LinkedEntry, Modifiers, Locales> | { sys: Link<'Entry'> } | undefined
+  ? Entry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'> | undefined
   : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
-  ? { sys: Link<'Entry'> }
+  ? UnresolvedLink<'Entry'>
   : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
   ? Entry<LinkedEntry, Modifiers, Locales> | undefined
-  : Entry<LinkedEntry, Modifiers, Locales> | { sys: Link<'Entry'> }
+  : Entry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'>
 
 /**
  * A single resolved reference link to another entry in a different space
@@ -219,12 +219,12 @@ export type ResolvedAssetLink<
   Modifiers extends ChainModifiers,
   Locales extends LocaleCode
 > = ChainModifiers extends Modifiers
-  ? Asset<Modifiers, Locales> | { sys: AssetLink } | undefined
+  ? Asset<Modifiers, Locales> | UnresolvedLink<'Asset'> | undefined
   : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
-  ? { sys: AssetLink }
+  ? UnresolvedLink<'Asset'>
   : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
   ? Asset<Modifiers, Locales> | undefined
-  : Asset<Modifiers, Locales> | { sys: AssetLink }
+  : Asset<Modifiers, Locales> | UnresolvedLink<'Asset'>
 
 /**
  * A single resolved link to another resource

--- a/lib/types/link.ts
+++ b/lib/types/link.ts
@@ -16,6 +16,12 @@ export interface Link<T extends LinkType> {
 }
 
 /**
+ * Unresolved link field of a specific link type
+ * @category Link
+ */
+export type UnresolvedLink<T extends LinkType> = { sys: Link<T> }
+
+/**
  * Space link type
  * @category Entity
  */


### PR DESCRIPTION
## Summary

Introduce new `UnresolvedLink` type to better represent why there is a link where users expect a resolved entity.

## Motivation and Context

contentful.js includes link objects in returned entries if linked entities could not be resolved. This is also represented in the types for linked entities which contain a union of an entity (for the resolved case) and a link (for the unresolved case). When users try to access the fields of a linked entry without checking whether the entity has been resolved it results in an error which doesn’t explain what happens. This PR introduces an explicit type for unresolved links which makes the error messages easier to understand by connecting the presence of the link in the type to the concept of link resolution.

## Screenshots

Before:
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/1296628/237052767-2f367dce-277d-406b-8e0a-214d71b8d938.png">

After:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/1296628/237052063-cfad05f6-b82f-4485-9a3f-e7f1384c8172.png">
