### PR TITLE
feat: add additional types for nodes validations

### DIFF
--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -2,7 +2,7 @@ import { ContentfulCollection } from './collection'
 import { EntryFields } from './entry'
 import { SpaceLink, EnvironmentLink } from './link'
 import { BaseSys } from './sys'
-import { BLOCKS, INLINES } from '@contentful/rich-text-types'
+import type { BLOCKS, INLINES } from '@contentful/rich-text-types'
 
 /**
  * System managed metadata for content type

--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -2,6 +2,7 @@ import { ContentfulCollection } from './collection'
 import { EntryFields } from './entry'
 import { SpaceLink, EnvironmentLink } from './link'
 import { BaseSys } from './sys'
+import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 
 /**
  * System managed metadata for content type
@@ -77,11 +78,26 @@ export interface ContentTypeFieldValidation {
   linkContentType?: string[]
   message?: string
   nodes?: {
-    'entry-hyperlink'?: ContentTypeFieldValidation[]
-    'embedded-entry-block'?: ContentTypeFieldValidation[]
-    'embedded-entry-inline'?: ContentTypeFieldValidation[]
+    [BLOCKS.EMBEDDED_ENTRY]?: Pick<
+      ContentTypeFieldValidation,
+      'size' | 'linkContentType' | 'message'
+    >[]
+    [INLINES.EMBEDDED_ENTRY]?: Pick<
+      ContentTypeFieldValidation,
+      'size' | 'linkContentType' | 'message'
+    >[]
+    [INLINES.ENTRY_HYPERLINK]?: Pick<
+      ContentTypeFieldValidation,
+      'size' | 'linkContentType' | 'message'
+    >[]
+    [BLOCKS.EMBEDDED_ASSET]?: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+    [INLINES.ASSET_HYPERLINK]?: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+    [BLOCKS.EMBEDDED_RESOURCE]?: {
+      validations: Pick<ContentTypeFieldValidation, 'size' | 'message'>[]
+      allowedResources: ContentTypeAllowedResources[]
+    }
   }
-  enabledNodeTypes?: string[]
+  enabledNodeTypes?: (`${BLOCKS}` | `${INLINES}`)[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds types for `nodes` validation object in `FieldItem.validations`

## Description

* Changes enabledNodeTypes validation to only allow valid string values
* Adds validation type for the new embedded-resource-block node

## Motivation and Context

This PR adresses both the addition of validations for the `embedded-resource-block` RichText node and also adds some missing RichText nodes to the validations object.

This PR is very similar to [the PR in contentful-management.js](https://github.com/contentful/contentful-management.js/pull/1858)
