### PR TITLE
fix: downgrade browseslist to support old browsers [PHX-2717]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ $RECYCLE.BIN/
 *.patch
 
 .idea
+.tool-versions
 
 # End of https://www.gitignore.io/api/node,windows,osx,linux,vim
 /lib/temp.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "type-fest": "^3.1.0"
       },
       "devDependencies": {
-        "@contentful/browserslist-config": "^3.0.0",
         "@semantic-release/changelog": "^6.0.1",
         "@types/jest": "^27.0.2",
         "@types/json-stringify-safe": "^5.0.0",
@@ -890,12 +889,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@contentful/browserslist-config": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/browserslist-config/-/browserslist-config-3.0.0.tgz",
-      "integrity": "sha512-e2OQlbOHMPZCI6BMA3OkTgOszPs2dhkbm+EXlllhBqmIvCOzLuA5iOGfoCEddkCqM8VHI+Zhdumq8XnFtSF+Jw==",
-      "dev": true
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.2.0",
@@ -20466,12 +20459,6 @@
           }
         }
       }
-    },
-    "@contentful/browserslist-config": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/browserslist-config/-/browserslist-config-3.0.0.tgz",
-      "integrity": "sha512-e2OQlbOHMPZCI6BMA3OkTgOszPs2dhkbm+EXlllhBqmIvCOzLuA5iOGfoCEddkCqM8VHI+Zhdumq8XnFtSF+Jw==",
-      "dev": true
     },
     "@contentful/rich-text-types": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "browser": "./dist/contentful.browser.min.js",
   "types": "./dist/types/index.d.ts",
   "browserslist": [
-    "extends @contentful/browserslist-config"
+    "Chrome >= 79",
+    "Edge >= 79",
+    "Firefox >= 73",
+    "Safari >= 13"
   ],
   "tsd": {
     "directory": "test/types",
@@ -75,7 +78,6 @@
     "type-fest": "^3.1.0"
   },
   "devDependencies": {
-    "@contentful/browserslist-config": "^3.0.0",
     "@semantic-release/changelog": "^6.0.1",
     "@types/jest": "^27.0.2",
     "@types/json-stringify-safe": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "browser": "./dist/contentful.browser.min.js",
   "types": "./dist/types/index.d.ts",
   "browserslist": [
-    "Chrome >= 79",
-    "Edge >= 79",
+    ">0.3%",
+    "Chrome >= 75",
+    "Edge >= 74",
     "Firefox >= 73",
     "Safari >= 13"
   ],


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Customers reported issues with javascript language features (optional chaining) on old browsers. 
By Downgrading the min supported browserslist config, we expect the build to polyfill unknown language features. 

The version is selected based on [this list](https://caniuse.com/?search=optional%20chaining).

Solves: #1901 
