### PR TITLE
fix: allow null type for validation message

### DIFF
--- a/lib/types/content-type.ts
+++ b/lib/types/content-type.ts
@@ -76,7 +76,7 @@ export interface ContentTypeFieldValidation {
   linkMimetypeGroup?: string[]
   in?: string[]
   linkContentType?: string[]
-  message?: string
+  message?: string | null
   nodes?: {
     [BLOCKS.EMBEDDED_ENTRY]?: Pick<
       ContentTypeFieldValidation,


### PR DESCRIPTION
## Summary

Allow `null` value for validation `message`

## Description

It turns out the `message` value for validations can be set to `null`. This PR updates the Typescript type to reflect this.

## Motivation and Context

The Typescript type is not correct for the possible value set for `message`

## Screenshots (if appropriate):
