### PR TITLE
chore: bump contentful-resolve-response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.2",
         "axios": "^1.4.0",
-        "contentful-resolve-response": "^1.8.0",
+        "contentful-resolve-response": "^1.8.1",
         "contentful-sdk-core": "^8.1.0",
         "json-stringify-safe": "^5.0.1",
         "type-fest": "^4.0.0"
@@ -5194,9 +5194,9 @@
       }
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.0.tgz",
-      "integrity": "sha512-rXBL3FI3UG7RtYpb/WX8i8XSmYbwwBeCDeFPuL3v+jW1Tuj5P3jqkm6QwiCN0573w+RKal8aPJoFmfBReUMAVw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+      "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
       "dependencies": {
         "fast-copy": "^2.1.7"
       },
@@ -23987,9 +23987,9 @@
       "dev": true
     },
     "contentful-resolve-response": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.0.tgz",
-      "integrity": "sha512-rXBL3FI3UG7RtYpb/WX8i8XSmYbwwBeCDeFPuL3v+jW1Tuj5P3jqkm6QwiCN0573w+RKal8aPJoFmfBReUMAVw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+      "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
       "requires": {
         "fast-copy": "^2.1.7"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@contentful/rich-text-types": "^16.0.2",
     "axios": "^1.4.0",
-    "contentful-resolve-response": "^1.8.0",
+    "contentful-resolve-response": "^1.8.1",
     "contentful-sdk-core": "^8.1.0",
     "json-stringify-safe": "^5.0.1",
     "type-fest": "^4.0.0"


### PR DESCRIPTION
- Bump contentful-resolve-response to remove regex named capture group
