### PR TITLE
chore: bump package size limit for contentful.node.min.js to 65KB []

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     },
     {
       "path": "./dist/contentful.node.min.js",
-      "maxSize": "55Kb"
+      "maxSize": "65Kb"
     },
     {
       "path": "./dist/contentful.browser.js",


### PR DESCRIPTION
## Summary

Need to bump package size limit, as it is now 55.02KB, which is higher than the previous limit of 55KB. 
