### PR TITLE
chore: created with change-repo-ownership-v2 [PHX-2957]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     circleci.com/project-slug: github/contentful/contentful.js
     github.com/project-slug: contentful/contentful.js
-    contentful.com/ci-alert-slack: prd-phoenix-ci-alerts
+    contentful.com/ci-alert-slack: prd-developer-experience-ci-alerts
 spec:
   type: library
   lifecycle: production
-  owner: group:team-phoenix
+  owner: group:team-developer-experience


### PR DESCRIPTION
Update all ownership relevant data with new team name `developer-experience`.