### PR TITLE
chore: adjust bundle size limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,19 +129,19 @@
   "bundlesize": [
     {
       "path": "./dist/contentful.node.js",
-      "maxSize": "105Kb"
+      "maxSize": "125Kb"
     },
     {
       "path": "./dist/contentful.node.min.js",
-      "maxSize": "65Kb"
+      "maxSize": "66Kb"
     },
     {
       "path": "./dist/contentful.browser.js",
-      "maxSize": "55Kb"
+      "maxSize": "70Kb"
     },
     {
       "path": "./dist/contentful.browser.min.js",
-      "maxSize": "25Kb"
+      "maxSize": "30Kb"
     }
   ],
   "release": {


### PR DESCRIPTION
Unfortunately we have to adjust the bundle size expectations a bit to enable further version bumps from `contentful-sdk-core`. This is just to unblock updates, on the long run we might look into getting rid of additional dependencies if this becomes too big.

[Blocked PR](https://github.com/contentful/contentful.js/pull/2084)