### PR TITLE
normalize babel syntax transforms with other public CTF libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "main": "./dist/contentful.node.min.js",
   "browser": "./dist/contentful.browser.min.js",
   "types": "./dist/types/index.d.ts",
+  "engines": {
+    "node": ">=18"
+  },
   "browserslist": [
     ">0.3%",
     "Chrome >= 75",
@@ -117,9 +120,6 @@
     "typescript": "^4.8.4",
     "webpack": "^5.67.0",
     "webpack-cli": "^5.0.0"
-  },
-  "engines": {
-    "node": ">=12"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This will make sure the core, CDA and CMA libs all support the very same browsers and node versions.

Partner PRs:

* https://github.com/contentful/contentful-sdk-core/pull/437
* https://github.com/contentful/contentful-management.js/pull/2176