### PR TITLE
chore: Add Typescript support to filter by a multi-reference field

### DIFF
--- a/lib/types/query/reference.ts
+++ b/lib/types/query/reference.ts
@@ -1,7 +1,7 @@
 import { EntryFieldTypes } from '../entry'
 import { ConditionalPick } from 'type-fest'
 
-type SupportedTypes = EntryFieldTypes.EntryLink<any> | undefined
+type SupportedTypes = EntryFieldTypes.EntryLink<any> | EntryFieldTypes.Array<EntryFieldTypes.EntryLink<any>> | undefined
 
 /**
  * Search on references in provided fields


### PR DESCRIPTION
## Summary

Add Typescript support to filter by a multi-reference field, as it is supported in runtime

## Description

Adding `EntryFieldTypes.Array` to the `SupportedTypes` type, used by `ReferenceSearchFilters`  -> `EntryFieldsQueries` -> `EntriesQueries` -> `getEntries()`.

## Motivation and Context

Improve Typescript support on the library.

## Todos

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):

N/A

## patch-package output

Thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `contentful@10.9.3` for the project I'm working on.

<!-- 🔺️🔺️🔺️ PLEASE REPLACE THIS BLOCK with a description of your problem, and any other relevant context 🔺️🔺️🔺️ -->

Here is the diff that solved my problem:

```diff
diff --git a/node_modules/contentful/dist/types/types/query/reference.d.ts b/node_modules/contentful/dist/types/types/query/reference.d.ts
index 2ed780b..df64799 100644
--- a/node_modules/contentful/dist/types/types/query/reference.d.ts
+++ b/node_modules/contentful/dist/types/types/query/reference.d.ts
@@ -1,6 +1,6 @@
 import { EntryFieldTypes } from '../entry';
 import { ConditionalPick } from 'type-fest';
-type SupportedTypes = EntryFieldTypes.EntryLink<any> | undefined;
+type SupportedTypes = EntryFieldTypes.EntryLink<any> | EntryFieldTypes.Array<EntryFieldTypes.EntryLink<any>> | undefined;
 /**
  * Search on references in provided fields
  * @see {@link https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/search-on-references | Documentation}
```

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>

