### PR TITLE
fix: pin axios to 1.6.x and prevent dependabot from overwriting the package manifest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ registries:
     token: ${{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}
 updates:
   - package-ecosystem: npm
+    versioning-strategy: lockfile-only
     registries:
       - npm-github
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/content-source-maps": "^0.6.0",
         "@contentful/rich-text-types": "^16.0.2",
-        "axios": "~1.7.2",
+        "axios": "~1.6.8",
         "contentful-resolve-response": "^1.8.1",
         "contentful-sdk-core": "^8.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -5405,9 +5405,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -26018,9 +26018,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@contentful/content-source-maps": "^0.6.0",
     "@contentful/rich-text-types": "^16.0.2",
-    "axios": "~1.7.2",
+    "axios": "~1.6.8",
     "contentful-resolve-response": "^1.8.1",
     "contentful-sdk-core": "^8.1.0",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
[Dependabot forced an update](https://github.com/contentful/contentful.js/pull/2255) to a known incompatible minor version (1.7.x) of axios after we had attempted to pin it at the latest known compatible version (1.6.x). This reverts that change, and also updates the dependabot config to prevent this from happening again.