### PR TITLE
fix: typescript for queries on array references

### DIFF
--- a/lib/types/query/reference.ts
+++ b/lib/types/query/reference.ts
@@ -1,7 +1,10 @@
 import { EntryFieldTypes } from '../entry'
 import { ConditionalPick } from 'type-fest'
 
-type SupportedTypes = EntryFieldTypes.EntryLink<any> | undefined
+type SupportedTypes =
+  | EntryFieldTypes.Array<EntryFieldTypes.EntryLink<any>>
+  | EntryFieldTypes.EntryLink<any>
+  | undefined
 
 /**
  * Search on references in provided fields


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

According the docs the queries on references are allowed. While it works for single references, it leads to a ts error on arrays. As it appears to be a typing problem on CDK's side.

https://github.com/contentful/contentful.js/blob/master/TYPESCRIPT.md#limitation

## Description

<!-- Describe your changes in detail -->

Add an array of entries to `ReferenceSearchFilters` type to enable the same behavior for array of entries as for single entries.

Example of the wrong behavior:

```typescript
const entries = client.getEntries<
  EntrySkeletonType<
    {
      tags?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<EntrySkeletonType>>;
    },
    'example'
  >
>({
  content_type: 'example',
  'fields.tags.sys.id[in]': ['foo', 'bar'] // TS Error: Object literal may only specify known properties, and ''fields.tags.sys.id[in]'' does not exist in type 'EntriesQueries<EntrySkeletonType<{ tags?: Array<EntryLink<EntrySkeletonType>> | undefined; }, "example">, undefined>'.ts(2345)
});
const workingEntries = client.getEntries<
  EntrySkeletonType<
    {
      tag?: EntryFieldTypes.EntryLink<EntrySkeletonType>;
    },
    'example'
  >
>({
  content_type: 'example',
  'fields.tag.sys.id': 'foo'
});
``` 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

It solves the described TS problem.

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

None.

## Screenshots (if appropriate):
<img width="618" alt="image" src="https://github.com/user-attachments/assets/7780cce6-b00a-4cc4-b63c-71b12b33d828">


