### PR TITLE
feat(taxonomy): add concepts to entry metadata [GROOT-1440]

### DIFF
--- a/lib/types/asset.ts
+++ b/lib/types/asset.ts
@@ -1,6 +1,6 @@
 import { ContentfulCollection } from './collection'
 import { LocaleCode } from './locale'
-import { Metadata } from './metadata'
+import { AssetMetadata } from './metadata'
 import { EntitySys } from './sys'
 import { ChainModifiers } from './client'
 
@@ -53,7 +53,7 @@ export interface Asset<
     : 'WITH_ALL_LOCALES' extends Modifiers
       ? { [FieldName in keyof AssetFields]: { [LocaleName in Locales]?: AssetFields[FieldName] } }
       : AssetFields
-  metadata: Metadata
+  metadata: AssetMetadata
 }
 
 /**

--- a/lib/types/link.ts
+++ b/lib/types/link.ts
@@ -3,7 +3,15 @@ import { ResourceLink } from './resource-link'
 /**
  * @category Link
  */
-export type LinkType = 'Space' | 'ContentType' | 'Environment' | 'Entry' | 'Tag' | 'User' | 'Asset'
+export type LinkType =
+  | 'Space'
+  | 'ContentType'
+  | 'Environment'
+  | 'Entry'
+  | 'Tag'
+  | 'User'
+  | 'Asset'
+  | 'TaxonomyConcept'
 
 /**
  * Link definition of a specific link type
@@ -62,3 +70,9 @@ export type TagLink = Link<'Tag'>
  * @category Entity
  */
 export type UserLink = Link<'User'>
+
+/**
+ * Taxonomy Concept link type
+ * @category Entity
+ */
+export type TaxonomyConceptLink = Link<'TaxonomyConcept'>

--- a/lib/types/metadata.ts
+++ b/lib/types/metadata.ts
@@ -1,4 +1,4 @@
-import { TagLink } from './link'
+import { TagLink, TaxonomyConceptLink } from './link'
 
 /**
  * User-controlled metadata
@@ -6,4 +6,7 @@ import { TagLink } from './link'
  */
 export type Metadata = {
   tags: { sys: TagLink }[]
+  concepts?: { sys: TaxonomyConceptLink }[]
 }
+
+export type AssetMetadata = Omit<Metadata, 'concepts'>

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -1,5 +1,9 @@
 import { AssetDetails, AssetFile, AssetMimeType, AssetSys } from '../asset'
+import { ChainModifiers } from '../client'
 import { EntrySys } from '../entry'
+import { TagLink, TaxonomyConceptLink } from '../link'
+import { Metadata } from '../metadata'
+import { TagSys } from '../tag'
 import {
   EntryFieldsEqualityFilter,
   EntryFieldsInequalityFilter,
@@ -8,28 +12,24 @@ import {
 } from './equality'
 import { EntryFieldsExistenceFilter, ExistenceFilter } from './existence'
 import { LocationSearchFilters } from './location'
-import { EntryFieldsRangeFilters, RangeFilters } from './range'
-import { EntryFieldsFullTextSearchFilters, FullTextSearchFilters } from './search'
-import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
-import { EntryFieldsSubsetFilters, SubsetFilters } from './subset'
-import {
-  ConditionalFixedQueries,
-  ConditionalListQueries,
-  FieldsType,
-  EntrySkeletonType,
-} from './util'
-import { ReferenceSearchFilters } from './reference'
-import { TagSys } from '../tag'
-import { Metadata } from '../metadata'
-import { TagLink, TaxonomyConceptLink } from '../link'
 import {
   AssetOrderFilter,
   EntryOrderFilter,
   EntryOrderFilterWithFields,
   TagOrderFilter,
 } from './order'
+import { EntryFieldsRangeFilters, RangeFilters } from './range'
+import { ReferenceSearchFilters } from './reference'
+import { EntryFieldsFullTextSearchFilters, FullTextSearchFilters } from './search'
+import { AssetSelectFilter, EntrySelectFilter, EntrySelectFilterWithFields } from './select'
 import { EntryFieldsSetFilter } from './set'
-import { ChainModifiers } from '../client'
+import { EntryFieldsSubsetFilters, SubsetFilters } from './subset'
+import {
+  ConditionalFixedQueries,
+  ConditionalListQueries,
+  EntrySkeletonType,
+  FieldsType,
+} from './util'
 
 export type FixedPagedOptions = {
   skip?: number
@@ -76,15 +76,10 @@ export type MetadataConceptsQueries =
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[all]'>
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[in]'>
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[nin]'>
-  | ConditionalListQueries<
-      Pick<TaxonomyConceptLink, 'id'>,
-      any,
-      'metadata.concepts.descendants',
-      '[in]'
-    >
+  | ConditionalListQueries<{ descendants: string }, any, 'metadata.concepts', '[in]'>
 
 /**
- * All queries appliable to entry fields
+ * All queries applicable to entry fields
  * @typeParam Fields - Shape of entry fields used to calculate dynamic keys
  */
 export type EntryFieldsQueries<Fields extends FieldsType> =

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -21,7 +21,7 @@ import {
 import { ReferenceSearchFilters } from './reference'
 import { TagSys } from '../tag'
 import { Metadata } from '../metadata'
-import { TagLink } from '../link'
+import { TagLink, TaxonomyConceptLink } from '../link'
 import {
   AssetOrderFilter,
   EntryOrderFilter,
@@ -51,7 +51,7 @@ export type LocaleOption = {
 }
 
 /**
- * All queries appliable to sys fields
+ * All queries applicable to sys fields
  */
 export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   EqualityFilter<Sys, 'sys'> &
@@ -60,13 +60,22 @@ export type SysQueries<Sys extends FieldsType> = ExistenceFilter<Sys, 'sys'> &
   RangeFilters<Sys, 'sys'>
 
 /**
- * All queries appliable to metadata fields
+ * All queries applicable to metadata tags fields
  */
 export type MetadataTagsQueries =
   | ConditionalFixedQueries<Pick<Metadata, 'tags'>, any, boolean, 'metadata', '[exists]'>
   | ConditionalListQueries<Pick<TagLink, 'id'>, any, 'metadata.tags.sys', '[all]'>
   | ConditionalListQueries<Pick<TagLink, 'id'>, any, 'metadata.tags.sys', '[in]'>
   | ConditionalListQueries<Pick<TagLink, 'id'>, any, 'metadata.tags.sys', '[nin]'>
+
+/**
+ * All queries applicable to metadata concepts fields
+ */
+export type MetadataConceptsQueries =
+  | ConditionalFixedQueries<Pick<Metadata, 'concepts'>, any, boolean, 'metadata', '[exists]'>
+  | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[all]'>
+  | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[in]'>
+  | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[nin]'>
 
 /**
  * All queries appliable to entry fields
@@ -103,6 +112,7 @@ export type EntriesQueries<
       EntryContentTypeQuery<EntrySkeleton['contentTypeId']>)
   | ((SysQueries<Pick<EntrySys, 'createdAt' | 'updatedAt' | 'revision' | 'id' | 'type'>> &
       MetadataTagsQueries &
+      MetadataConceptsQueries &
       EntrySelectFilter &
       EntryOrderFilter &
       FixedQueryOptions &

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -76,6 +76,12 @@ export type MetadataConceptsQueries =
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[all]'>
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[in]'>
   | ConditionalListQueries<Pick<TaxonomyConceptLink, 'id'>, any, 'metadata.concepts.sys', '[nin]'>
+  | ConditionalListQueries<
+      Pick<TaxonomyConceptLink, 'id'>,
+      any,
+      'metadata.concepts.descendants',
+      '[in]'
+    >
 
 /**
  * All queries appliable to entry fields

--- a/lib/types/query/select.ts
+++ b/lib/types/query/select.ts
@@ -1,7 +1,7 @@
 import { FieldsType } from './util'
 import { EntrySys } from '../entry'
 import { AssetSys } from '../asset'
-import { Metadata } from '../metadata'
+import { AssetMetadata, Metadata } from '../metadata'
 
 export type SelectFilterPaths<
   Fields extends FieldsType,
@@ -51,6 +51,6 @@ export type AssetSelectFilter<Fields extends FieldsType> = {
     | 'fields'
     | SelectFilterPaths<Fields, 'fields'>
     | 'metadata'
-    | SelectFilterPaths<Metadata, 'metadata'>
+    | SelectFilterPaths<AssetMetadata, 'metadata'>
   )[]
 }

--- a/test/types/queries/asset-queries.test-d.ts
+++ b/test/types/queries/asset-queries.test-d.ts
@@ -10,6 +10,10 @@ expectAssignable<DefaultAssetQueries>({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
 })
 
+expectNotAssignable<DefaultAssetQueries>({
+  'metadata.concepts.sys.id[all]': mocks.stringArrayValue,
+})
+
 // equality operator
 
 expectAssignable<DefaultAssetQueries>({
@@ -24,6 +28,7 @@ expectAssignable<DefaultAssetQueries>({
 expectNotAssignable<DefaultAssetQueries>({
   'fields.unknownField': mocks.anyValue,
 })
+
 expectNotAssignable<DefaultAssetQueries>({
   'sys.unknownProp': mocks.anyValue,
 })

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -15,6 +15,7 @@ expectAssignable<
 >({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
   'metadata.concepts.sys.id[all]': mocks.stringArrayValue,
+  'metadata.concepts.descendants.id[in]': mocks.stringArrayValue,
 })
 expectNotAssignable<
   EntriesQueries<
@@ -90,6 +91,7 @@ expectAssignable<
   EntriesQueries<EntrySkeletonType<{ someField: EntryFieldTypes.Symbol }>, undefined>
 >({
   'metadata.tags[exists]': mocks.booleanValue,
+  'metadata.concepts[exists]': mocks.booleanValue,
   'sys.updatedAt[exists]': mocks.booleanValue,
 })
 expectNotAssignable<
@@ -190,6 +192,7 @@ expectAssignable<
   >
 >({
   'metadata.tags.sys.id[in]': mocks.stringArrayValue,
+  'metadata.concepts.sys.id[in]': mocks.stringArrayValue,
   'sys.updatedAt[in]': mocks.dateArrayValue,
 })
 expectNotAssignable<
@@ -381,6 +384,7 @@ expectAssignable<
   >
 >({
   'metadata.tags.sys.id[nin]': mocks.stringArrayValue,
+  'metadata.concepts.sys.id[nin]': mocks.stringArrayValue,
   'sys.updatedAt[nin]': mocks.dateArrayValue,
 })
 expectNotAssignable<

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -14,6 +14,7 @@ expectAssignable<
   >
 >({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
+  'metadata.concepts.sys.id[all]': mocks.stringArrayValue,
 })
 expectNotAssignable<
   EntriesQueries<

--- a/test/types/queries/entry-queries.test-d.ts
+++ b/test/types/queries/entry-queries.test-d.ts
@@ -15,8 +15,22 @@ expectAssignable<
 >({
   'metadata.tags.sys.id[all]': mocks.stringArrayValue,
   'metadata.concepts.sys.id[all]': mocks.stringArrayValue,
-  'metadata.concepts.descendants.id[in]': mocks.stringArrayValue,
 })
+
+expectAssignable<
+  EntriesQueries<
+    EntrySkeletonType<{
+      stringField: EntryFieldTypes.Symbol
+      stringArrayField: EntryFieldTypes.Array<EntryFieldTypes.Symbol>
+    }>,
+    undefined
+  >
+>({
+  'metadata.tags.sys.id[all]': mocks.stringArrayValue,
+  'metadata.concepts.sys.id[all]': mocks.stringArrayValue,
+  'metadata.concepts.descendants[in]': mocks.stringArrayValue,
+})
+
 expectNotAssignable<
   EntriesQueries<
     EntrySkeletonType<{


### PR DESCRIPTION
## Summary

Add [Taxonomy concept](https://www.contentful.com/help/taxonomies-overview/) links to entries (This feature i currently in beta).

## Description

To allow beta customers to use the newly exposed `concepts` field on `metadata`, we add it as an optional field.
For now, taxonomy concepts are exclusive to Entry. The change introduces the smallest possible footprint to introduce this variation for Entry metadata. It should also allow for easy adoption of the feature on assets at a later point in time.  
