### PR TITLE
feat: remove alpha for content source maps [TOL-2045]

### DIFF
--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -109,15 +109,18 @@ export interface CreateClientParams {
    * Interceptor called on every response. Takes Axios response object as an arg.
    */
   responseLogger?: (response: AxiosResponse<any> | Error) => unknown
-
+  /**
+   * Enable Content Source Maps.
+   * @remarks
+   * This feature is only available when using the Content Preview API.
+   */
+  includeContentSourceMaps?: boolean
   /**
    * Enable alpha features.
    */
   alphaFeatures?: {
     /**
-     * Enable Content Source Maps.
-     * @remarks
-     * This feature is only available when using the Content Preview API.
+     * @deprecated Use the `includeContentSourceMaps` option directly instead.
      */
     includeContentSourceMaps?: boolean
   }

--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -101,11 +101,13 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
   }
 
   function maybeEnableSourceMaps(query: Record<string, any> = {}): Record<string, any> {
-    const alphaFeatures = (http.httpClientParams as any as CreateClientParams)?.alphaFeatures
+    const params = http.httpClientParams as CreateClientParams
+    const includeContentSourceMaps =
+      params?.includeContentSourceMaps ?? params?.alphaFeatures?.includeContentSourceMaps
 
-    const host = http.httpClientParams?.host
+    const host = params?.host
 
-    const areAllowed = checkIncludeContentSourceMapsParamIsAllowed(host, alphaFeatures)
+    const areAllowed = checkIncludeContentSourceMapsParamIsAllowed(host, includeContentSourceMaps)
 
     if (areAllowed) {
       query.includeContentSourceMaps = true

--- a/lib/utils/validate-params.ts
+++ b/lib/utils/validate-params.ts
@@ -47,39 +47,24 @@ export function validateRemoveUnresolvedParam(query) {
   return
 }
 
-export function checkIncludeContentSourceMapsParamIsValid(alphaFeatures?: Record<string, any>) {
-  if (!alphaFeatures) {
+export function checkIncludeContentSourceMapsParamIsAllowed(
+  host?: string,
+  includeContentSourceMaps?: boolean,
+) {
+  if (includeContentSourceMaps === undefined) {
     return false
   }
 
-  const isValidIncludeContentSourceMaps =
-    'includeContentSourceMaps' in alphaFeatures &&
-    typeof alphaFeatures.includeContentSourceMaps === 'boolean'
-
-  if (!isValidIncludeContentSourceMaps) {
+  if (typeof includeContentSourceMaps !== 'boolean') {
     throw new ValidationError(
       'includeContentSourceMaps',
       `The 'includeContentSourceMaps' parameter must be a boolean.`,
     )
   }
 
-  return true
-}
-
-export function checkIncludeContentSourceMapsParamIsAllowed(
-  host?: string,
-  alphaFeatures?: Record<string, any>,
-) {
-  if (!alphaFeatures || Object.keys(alphaFeatures).length === 0) {
-    return false
-  }
-
   const includeContentSourceMapsIsAllowed = host === 'preview.contentful.com'
 
-  if (
-    checkIncludeContentSourceMapsParamIsValid(alphaFeatures) &&
-    !includeContentSourceMapsIsAllowed
-  ) {
+  if (includeContentSourceMaps && !includeContentSourceMapsIsAllowed) {
     throw new ValidationError(
       'includeContentSourceMaps',
       `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.
@@ -87,5 +72,5 @@ export function checkIncludeContentSourceMapsParamIsAllowed(
     )
   }
 
-  return alphaFeatures.includeContentSourceMaps as boolean
+  return includeContentSourceMaps as boolean
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-determined-by-semantic-release",
       "license": "MIT",
       "dependencies": {
-        "@contentful/content-source-maps": "^0.6.0",
+        "@contentful/content-source-maps": "^0.11.0",
         "@contentful/rich-text-types": "^16.0.2",
         "axios": "^1.7.4",
         "contentful-resolve-response": "^1.9.0",
@@ -2213,10 +2213,9 @@
       }
     },
     "node_modules/@contentful/content-source-maps": {
-      "version": "0.6.1",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/content-source-maps/0.6.1/a12828d287bdcd9f31c132f2a230bd1ac3005b77",
-      "integrity": "sha512-IjsyhakG17OC5xtIa5agVRsnjjxiJf9HZjpDIV6Ix036Pd5YHJrbyyiF4KNEmLlIqe3hQ0kHGWEs9S/HfECmRQ==",
-      "license": "MIT",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.11.0.tgz",
+      "integrity": "sha512-eS/Bm1hzv5C3SyTpP08+sYVQ7fFcNUdANrLsotUWk+uC7WpponQIIY26R9QZhX7tE3r5Nq80Z+aR7uo5u31ksg==",
       "dependencies": {
         "@vercel/stega": "^0.1.2",
         "json-pointer": "^0.6.2"
@@ -23628,9 +23627,9 @@
       }
     },
     "@contentful/content-source-maps": {
-      "version": "0.6.1",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/content-source-maps/0.6.1/a12828d287bdcd9f31c132f2a230bd1ac3005b77",
-      "integrity": "sha512-IjsyhakG17OC5xtIa5agVRsnjjxiJf9HZjpDIV6Ix036Pd5YHJrbyyiF4KNEmLlIqe3hQ0kHGWEs9S/HfECmRQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.11.0.tgz",
+      "integrity": "sha512-eS/Bm1hzv5C3SyTpP08+sYVQ7fFcNUdANrLsotUWk+uC7WpponQIIY26R9QZhX7tE3r5Nq80Z+aR7uo5u31ksg==",
       "requires": {
         "@vercel/stega": "^0.1.2",
         "json-pointer": "^0.6.2"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prepush": "npm run test:prepush"
   },
   "dependencies": {
-    "@contentful/content-source-maps": "^0.6.0",
+    "@contentful/content-source-maps": "^0.11.0",
     "@contentful/rich-text-types": "^16.0.2",
     "axios": "^1.7.4",
     "contentful-resolve-response": "^1.9.0",

--- a/test/integration/getAsset.test.ts
+++ b/test/integration/getAsset.test.ts
@@ -16,7 +16,7 @@ if (process.env.API_INTEGRATION_TESTS) {
 const client = contentful.createClient(params)
 const invalidClient = contentful.createClient({
   ...params,
-  alphaFeatures: { includeContentSourceMaps: true },
+  includeContentSourceMaps: true,
 })
 const previewClient = contentful.createClient(previewParamsWithCSM)
 
@@ -37,7 +37,7 @@ describe('getAsset', () => {
     expect(typeof response.fields.title).toBe('object')
   })
 
-  describe('has (alpha) includeContentSourceMaps enabled', () => {
+  describe('has includeContentSourceMaps enabled', () => {
     test('cdn client', async () => {
       await expect(invalidClient.getAsset(asset)).rejects.toThrow(
         `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,

--- a/test/integration/getAssets.test.ts
+++ b/test/integration/getAssets.test.ts
@@ -16,7 +16,7 @@ if (process.env.API_INTEGRATION_TESTS) {
 const client = contentful.createClient(params)
 const invalidClient = contentful.createClient({
   ...params,
-  alphaFeatures: { includeContentSourceMaps: true },
+  includeContentSourceMaps: true,
 })
 const previewClient = contentful.createClient(previewParamsWithCSM)
 
@@ -45,7 +45,7 @@ describe('getAssets', () => {
     })
   })
 
-  describe('has (alpha) includeContentSourceMaps enabled', () => {
+  describe('has includeContentSourceMaps enabled', () => {
     test('cdn client', async () => {
       await expect(invalidClient.getAssets()).rejects.toThrow(
         `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -11,7 +11,7 @@ if (process.env.API_INTEGRATION_TESTS) {
 const client = contentful.createClient(params)
 const invalidClient = contentful.createClient({
   ...params,
-  alphaFeatures: { includeContentSourceMaps: true },
+  includeContentSourceMaps: true,
 })
 const previewClient = contentful.createClient(previewParamsWithCSM)
 
@@ -375,7 +375,7 @@ describe('getEntries via client chain modifiers', () => {
     })
   })
 
-  describe('has (alpha) includeContentSourceMaps enabled', () => {
+  describe('has includeContentSourceMaps enabled', () => {
     test('invalid client', async () => {
       await expect(invalidClient.getEntries()).rejects.toThrow(
         `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,

--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -11,7 +11,7 @@ if (process.env.API_INTEGRATION_TESTS) {
 const client = contentful.createClient(params)
 const invalidClient = contentful.createClient({
   ...params,
-  alphaFeatures: { includeContentSourceMaps: true },
+  includeContentSourceMaps: true,
 })
 const previewClient = contentful.createClient(previewParamsWithCSM)
 const localeClient = contentful.createClient(localeSpaceParams)
@@ -177,7 +177,7 @@ describe('getEntry via client chain modifiers', () => {
     })
   })
 
-  describe('preview client has (alpha) includeContentSourceMaps enabled', () => {
+  describe('preview client has includeContentSourceMaps enabled', () => {
     test('invalid client', async () => {
       await expect(invalidClient.getEntry(entryWithResolvableLink)).rejects.toThrow(
         `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -53,7 +53,7 @@ export function testEncodingDecoding(encodedResponse: EncodedResponse, mappings:
 
 const mappedAsset = {
   origin: 'contentful.com',
-  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/1x0xpXu4pSGS4OukSyWGUK/?focusedField=title&focusedLocale=en-US',
+  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/1x0xpXu4pSGS4OukSyWGUK/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
   contentful: {
     space: 'ezs1swce23xe',
     environment: 'master',
@@ -71,7 +71,7 @@ const mappedAsset = {
 
 const mappedAssetCollection = {
   origin: 'contentful.com',
-  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/38eGMAzUH5Ezv7mjU0CToA/?focusedField=title&focusedLocale=en-US',
+  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/38eGMAzUH5Ezv7mjU0CToA/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
   contentful: {
     space: 'ezs1swce23xe',
     environment: 'master',
@@ -89,7 +89,7 @@ const mappedAssetCollection = {
 
 const mappedEntryCollection = {
   origin: 'contentful.com',
-  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/38eGMAzUH5Ezv7mjU0CToA/?focusedField=title&focusedLocale=en-US',
+  href: 'https://app.contentful.com/spaces/ezs1swce23xe/environments/master/assets/38eGMAzUH5Ezv7mjU0CToA/?focusedField=title&focusedLocale=en-US?source=vercel-content-link',
   contentful: {
     space: 'ezs1swce23xe',
     environment: 'master',

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -28,7 +28,7 @@ export const previewParams = {
 
 export const previewParamsWithCSM = {
   ...previewParams,
-  alphaFeatures: { includeContentSourceMaps: true },
+  includeContentSourceMaps: true,
 }
 
 export type Mappings = Record<

--- a/test/unit/contentful.test.ts
+++ b/test/unit/contentful.test.ts
@@ -117,15 +117,14 @@ describe('contentful', () => {
     )
   })
 
-  test('Initializes API with alpha features', () => {
+  test('Initializes API with includeContentSourceMaps option', () => {
     createClient({
       accessToken: 'accessToken',
       space: 'spaceId',
-      alphaFeatures: { includeContentSourceMaps: true },
+      includeContentSourceMaps: true,
     })
     const callConfig = createHttpClientMock.mock.calls[0]
 
-    const alphaFeatures = callConfig[1].alphaFeatures
-    expect(alphaFeatures).toEqual({ includeContentSourceMaps: true })
+    expect(callConfig[1].includeContentSourceMaps).toBe(true)
   })
 })

--- a/test/unit/utils/validate-params.test.ts
+++ b/test/unit/utils/validate-params.test.ts
@@ -1,44 +1,33 @@
-import {
-  checkIncludeContentSourceMapsParamIsAllowed,
-  checkIncludeContentSourceMapsParamIsValid,
-} from '../../../lib/utils/validate-params'
+import { checkIncludeContentSourceMapsParamIsAllowed } from '../../../lib/utils/validate-params'
 import { ValidationError } from '../../../lib/utils/validation-error'
 
-describe('checkIncludeContentSourceMapsParamIsValid', () => {
-  it('returns false if host/alphaFeatures is not provided', () => {
-    expect(checkIncludeContentSourceMapsParamIsValid()).toBe(false)
+describe('checkIncludeContentSourceMapsParamIsAllowed', () => {
+  it('returns false if includeContentSourceMaps is not provided', () => {
+    expect(checkIncludeContentSourceMapsParamIsAllowed('http://example.com')).toBe(false)
+    expect(checkIncludeContentSourceMapsParamIsAllowed('http://example.com', undefined)).toBe(false)
   })
 
   it('throws ValidationError if includeContentSourceMaps is not a boolean', () => {
     expect(() =>
-      checkIncludeContentSourceMapsParamIsValid({ includeContentSourceMaps: 'not a boolean' }),
+      checkIncludeContentSourceMapsParamIsAllowed('http://example.com', 'not a boolean' as any),
     ).toThrow(ValidationError)
-  })
-
-  it('returns true if includeContentSourceMaps is a boolean', () => {
-    expect(checkIncludeContentSourceMapsParamIsValid({ includeContentSourceMaps: true })).toBe(true)
-  })
-})
-
-describe('checkIncludeContentSourceMapsParamIsAllowed', () => {
-  it('returns false if alphaFeatures is not provided', () => {
-    expect(checkIncludeContentSourceMapsParamIsAllowed('http://example.com')).toBe(false)
-    expect(checkIncludeContentSourceMapsParamIsAllowed('http://example.com', {})).toBe(false)
-  })
-
-  it('throws ValidationError if includeContentSourceMaps is valid but baseUrl does not include preview.contentful.com', () => {
     expect(() =>
-      checkIncludeContentSourceMapsParamIsAllowed('cdn.contentful.com', {
-        includeContentSourceMaps: true,
-      }),
+      checkIncludeContentSourceMapsParamIsAllowed('http://example.com', 1 as any),
     ).toThrow(ValidationError)
   })
 
-  it('returns true if includeContentSourceMaps is valid and baseUrl includes preview.contentful.com', () => {
-    expect(
-      checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', {
-        includeContentSourceMaps: true,
-      }),
-    ).toBe(true)
+  it('throws ValidationError if includeContentSourceMaps is true but host is not preview.contentful.com', () => {
+    expect(() => checkIncludeContentSourceMapsParamIsAllowed('cdn.contentful.com', true)).toThrow(
+      ValidationError,
+    )
+  })
+
+  it('returns true if includeContentSourceMaps is true and host is preview.contentful.com', () => {
+    expect(checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', true)).toBe(true)
+  })
+
+  it('returns false if includeContentSourceMaps is false, regardless of host', () => {
+    expect(checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', false)).toBe(false)
+    expect(checkIncludeContentSourceMapsParamIsAllowed('cdn.contentful.com', false)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Remove alpha for Content Source Maps. Instead we have a direct option now on the Client initialization parameters.

Also marks the alpha features one as deprecated:
<img width="809" alt="Screenshot 2024-08-16 at 13 37 56" src="https://github.com/user-attachments/assets/7e897a15-6d29-46f0-be2b-8b8e37f10572">
