### PR TITLE
BREAKING CHANGE: adding dry run flag, BC commit tag to force major

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "test:prepush": "npm run build && npm run test:unit && npm run test:size",
     "prepublishOnly": "export PUBLISH_RUN=true && npm run build && unset PUBLISH_RUN",
     "postpublish": "npm run docs:publish && npm run clean",
-    "semantic-release": "semantic-release",
+    "semantic-release": "semantic-release --dry-run",
     "precommit": "npm run lint && npm run prettier:check",
     "prepush": "npm run test:prepush"
   },


### PR DESCRIPTION
Due to a accidentally published v11 version,
<img width="856" alt="image" src="https://github.com/user-attachments/assets/8f358029-5379-47dd-ba5d-ac486d17f0fb">

we are not able to completely verify what semantic release will do when we publish another `BREAKING CHANGE` commit.

This PR seeks to do two things:
- Critically, add `--dry-run` flag https://semantic-release.gitbook.io/semantic-release/usage/configuration#dryrun to semantic release to prevent an actual publish.
- Create a merge commit on master, which given the CI vault token is the only way to publish commits, is our only way to truly test this.


If this works (and outputs 11.0.2 as the _potential_ new version) we'll go ahead and remove that flag in the contentful v11 feature branch and merge+deploy it knowing that it will do what we want.

If this doesn't work, we'll remove that dry-run flag in another PR and see what we can do to correct the issue.