### PR TITLE
feat: give includes basic entry and asset types instead of any

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -339,7 +339,7 @@ export type EntryCollection<
 > = ContentfulCollection<Entry<EntrySkeleton, Modifiers, Locales>> & {
   errors?: Array<any>
   includes?: {
-    Entry?: any[]
-    Asset?: any[]
+    Entry?: Entry<EntrySkeletonType, Modifiers, Locales>[]
+    Asset?: Asset<Modifiers, Locales>[]
   }
 }

--- a/test/types/client/getEntries.test-d.ts
+++ b/test/types/client/getEntries.test-d.ts
@@ -18,105 +18,192 @@ type Fields = {
   moreLinks: Entry<LinkedSkeleton>[]
 }
 
-type EntrySkeleton = EntrySkeletonType<Fields, 'content-type-id'>
+// A skeleton with no fields
+type BaseEntrySkeleton = EntrySkeletonType
+
+// Skeleton with some specific fields
+type TestEntrySkeleton = EntrySkeletonType<Fields, 'content-type-id'>
 
 type Locale = 'en'
 
-expectType<Entry<EntrySkeleton, undefined>>(await client.getEntry('entry-id'))
-expectType<Entry<EntrySkeleton, undefined>>(await client.getEntry<EntrySkeleton>('entry-id'))
-expectType<EntryCollection<EntrySkeleton, undefined>>(await client.getEntries())
-expectType<EntryCollection<EntrySkeleton, undefined>>(await client.getEntries<EntrySkeleton>())
+/**
+ * With no extra parameters
+ */
+expectType<Entry<TestEntrySkeleton, undefined>>(await client.getEntry('entry-id'))
 
-expectType<EntryCollection<EntrySkeleton, undefined>>(
-  await client.getEntries<EntrySkeleton>({ content_type: 'content-type-id' }),
+expectType<Entry<TestEntrySkeleton, undefined>>(
+  await client.getEntry<TestEntrySkeleton>('entry-id'),
+)
+expectType<EntryCollection<TestEntrySkeleton, undefined>>(await client.getEntries())
+
+expectType<EntryCollection<TestEntrySkeleton, undefined>>(
+  await client.getEntries<TestEntrySkeleton>(),
+)
+expectType<Entry<BaseEntrySkeleton, undefined>>((await client.getEntries()).includes!.Entry![0])
+
+expectType<EntryCollection<TestEntrySkeleton, undefined>>(
+  await client.getEntries<TestEntrySkeleton>({ content_type: 'content-type-id' }),
 )
 
-expectError(await client.getEntries<EntrySkeleton>({ content_type: 'unexpected' }))
-expectType<EntryCollection<EntrySkeleton | LinkedSkeleton, undefined>>(
-  await client.getEntries<EntrySkeleton | LinkedSkeleton>({
+expectError(await client.getEntries<TestEntrySkeleton>({ content_type: 'unexpected' }))
+
+expectType<EntryCollection<TestEntrySkeleton | LinkedSkeleton, undefined>>(
+  await client.getEntries<TestEntrySkeleton | LinkedSkeleton>({
     content_type: 'content-type-id',
   }),
 )
 
-expectType<Entry<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+/**
+ * Without unresolvable Links
+ */
+expectType<Entry<TestEntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntry('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntry<EntrySkeleton>('entry-id'),
+expectType<Entry<TestEntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntry<TestEntrySkeleton>('entry-id'),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withoutUnresolvableLinks.getEntries(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withoutUnresolvableLinks.getEntries<EntrySkeleton>(),
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withoutUnresolvableLinks.getEntries<TestEntrySkeleton>(),
 )
 
-expectType<Entry<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<Entry<BaseEntrySkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  (await client.withoutUnresolvableLinks.getEntries()).includes!.Entry![0],
+)
+
+/**
+ * Without link resolution
+ */
+expectType<Entry<TestEntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntry('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntry<EntrySkeleton>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntry<TestEntrySkeleton>('entry-id'),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withoutLinkResolution.getEntries(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withoutLinkResolution.getEntries<EntrySkeleton>(),
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withoutLinkResolution.getEntries<TestEntrySkeleton>(),
 )
 
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
+expectType<Entry<BaseEntrySkeleton, 'WITHOUT_LINK_RESOLUTION'>>(
+  (await client.withoutLinkResolution.getEntries()).includes!.Entry![0],
+)
+
+/**
+ * With all Locales
+ */
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntry('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntry<EntrySkeleton>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntry<TestEntrySkeleton>('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntry<EntrySkeleton, Locale>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntry<TestEntrySkeleton, Locale>('entry-id'),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES'>>(
   await client.withAllLocales.getEntries(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES'>>(
-  await client.withAllLocales.getEntries<EntrySkeleton>(),
-)
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
-  await client.withAllLocales.getEntries<EntrySkeleton, Locale>(),
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  await client.withAllLocales.getEntries<TestEntrySkeleton>(),
 )
 
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
+  await client.withAllLocales.getEntries<TestEntrySkeleton, Locale>(),
+)
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES', Locale>>(
+  (await client.withAllLocales.getEntries<TestEntrySkeleton, Locale>()).includes!.Entry![0],
+)
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES'>>(
+  (await client.withAllLocales.getEntries<TestEntrySkeleton>()).includes!.Entry![0],
+)
+
+/**
+ * With all Locales and without unresolvable Links
+ */
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntry('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<EntrySkeleton>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<TestEntrySkeleton>('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntry<EntrySkeleton, Locale>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntry<TestEntrySkeleton, Locale>(
+    'entry-id',
+  ),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
   await client.withAllLocales.withoutUnresolvableLinks.getEntries(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
-  await client.withAllLocales.withoutUnresolvableLinks.getEntries<EntrySkeleton>(),
-)
-expectType<
-  EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>
->(await client.withAllLocales.withoutUnresolvableLinks.getEntries<EntrySkeleton, Locale>())
 
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  await client.withAllLocales.withoutUnresolvableLinks.getEntries<TestEntrySkeleton>(),
+)
+
+expectType<
+  EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>
+>(await client.withAllLocales.withoutUnresolvableLinks.getEntries<TestEntrySkeleton, Locale>())
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS'>>(
+  (await client.withAllLocales.withoutUnresolvableLinks.getEntries<TestEntrySkeleton>()).includes!
+    .Entry![0],
+)
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_UNRESOLVABLE_LINKS', Locale>>(
+  (await client.withAllLocales.withoutUnresolvableLinks.getEntries<TestEntrySkeleton, Locale>())
+    .includes!.Entry![0],
+)
+
+/**
+ * With all Locales and without link resolution
+ */
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withAllLocales.withoutLinkResolution.getEntry('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<EntrySkeleton>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<TestEntrySkeleton>('entry-id'),
 )
-expectType<Entry<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
-  await client.withAllLocales.withoutLinkResolution.getEntry<EntrySkeleton, Locale>('entry-id'),
+
+expectType<Entry<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  await client.withAllLocales.withoutLinkResolution.getEntry<TestEntrySkeleton, Locale>('entry-id'),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
   await client.withAllLocales.withoutLinkResolution.getEntries(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries<EntrySkeleton>(),
+
+expectType<EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  await client.withAllLocales.withoutLinkResolution.getEntries<TestEntrySkeleton>(),
 )
-expectType<EntryCollection<EntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
-  await client.withAllLocales.withoutLinkResolution.getEntries<EntrySkeleton, Locale>(),
+
+expectType<
+  EntryCollection<TestEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>
+>(await client.withAllLocales.withoutLinkResolution.getEntries<TestEntrySkeleton, Locale>())
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION'>>(
+  (await client.withAllLocales.withoutLinkResolution.getEntries()).includes!.Entry![0],
+)
+
+expectType<Entry<BaseEntrySkeleton, 'WITH_ALL_LOCALES' | 'WITHOUT_LINK_RESOLUTION', Locale>>(
+  (await client.withAllLocales.withoutLinkResolution.getEntries<TestEntrySkeleton, Locale>())
+    .includes!.Entry![0],
 )


### PR DESCRIPTION
## Summary

Gives includes Entry and Asset arrays at least basic skeleton types.
From there they can then conveniently be narrowed down to the desired types.

## Description

Currently the types are `any`, which is difficult to work with.
Casting from the outside is awkward too especially since we have the modifiers that should propagate.
So we should just set the correct types from the start.

## Motivation and Context

I need to do some processing on the includes and don't want to cast them all the time.

