### PR TITLE
feat: add publishedVersion to EntitySys

### DIFF
--- a/lib/types/sys.ts
+++ b/lib/types/sys.ts
@@ -24,4 +24,5 @@ export interface EntitySys extends BaseSys {
   locale?: string
   contentSourceMaps?: CPAContentSourceMaps
   contentSourceMapsLookup?: ContentSourceMapsLookup
+  publishedVersion: number
 }

--- a/test/types/mocks.ts
+++ b/test/types/mocks.ts
@@ -65,6 +65,7 @@ export const entrySys: EntrySys = {
   updatedAt: dateValue,
   id: stringValue,
   createdAt: dateValue,
+  publishedVersion: numberValue,
 }
 
 export const entryBasics = {
@@ -117,6 +118,7 @@ export const assetSys: AssetSys = {
   updatedAt: dateValue,
   id: stringValue,
   createdAt: dateValue,
+  publishedVersion: numberValue,
 }
 
 export const assetBasics = {

--- a/test/unit/mocks.ts
+++ b/test/unit/mocks.ts
@@ -66,6 +66,7 @@ const tagSysMock: TagSys = {
   updatedBy: { sys: copy(userLinkMock) },
   space: { sys: copy(spaceLinkMock) },
   environment: { sys: copy(environmentLinkMock) },
+  publishedVersion: 1,
 }
 
 const sysMock: EntrySys = {
@@ -78,6 +79,7 @@ const sysMock: EntrySys = {
   space: { sys: copy(spaceLinkMock) },
   contentType: { sys: copy(contentTypeLinkMock) },
   environment: { sys: copy(environmentLinkMock) },
+  publishedVersion: 1,
 }
 
 const contentTypeMock: ContentType = {


### PR DESCRIPTION
## Summary

Adds the `publishedVersion` field to the `EntitySys` type.

Closes #2408 

## Motivation and Context

We'd like to reference the published version of a given entry, but the current typing does not include this field despite it existing on the data returned from the `getEntries` call (and also mentioned in the [docs](https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes)).

## Notes
The doc also mentions the `publishedVersion` field applies to content types, but I did not see that field returned in my testing so I did not add it to the `ContentTypeSys` type. 
