### PR TITLE
fix: explicitly upgrade axios to 1.7.9 [ZEND-5815]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/content-source-maps": "^0.11.7",
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "contentful-resolve-response": "^1.9.0",
         "contentful-sdk-core": "^9.0.1",
         "json-stringify-safe": "^5.0.1",
@@ -5622,11 +5622,10 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@contentful/content-source-maps": "^0.11.7",
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.7.4",
+    "axios": "^1.7.9",
     "contentful-resolve-response": "^1.9.0",
     "contentful-sdk-core": "^9.0.1",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
## Summary

Explicitly upgrades axios to latest 1.7.9 to ensure installers get the latest version without needing to regen their package-lock.json files or run `npm audit fix` 

