### PR TITLE
fix: [GROOT-1744] fix concept scheme parameter on concept list query

### DIFF
--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -225,6 +225,6 @@ type CursorPaginationOptions = {
 }
 
 export type ConceptsQueries = CursorPaginationOptions &
-  TaxonomyOrderFilter & { concept_scheme?: string }
+  TaxonomyOrderFilter & { conceptScheme?: string }
 
 export type ConceptSchemesQueries = CursorPaginationOptions & TaxonomyOrderFilter

--- a/test/integration/getConcepts.test.ts
+++ b/test/integration/getConcepts.test.ts
@@ -54,7 +54,7 @@ describe('getConcepts', () => {
 
   describe('Concept Scheme', () => {
     it('filters by Concept Scheme', async () => {
-      const response = await client.getConcepts({ concept_scheme: '7lcOh0M5JAu5xvEwWzs00H' })
+      const response = await client.getConcepts({ conceptScheme: '7lcOh0M5JAu5xvEwWzs00H' })
 
       expect(response.items).toHaveLength(2)
     })


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

In the original PR for the taxonomy CDA beta, the concept scheme query parameter for the concept list query was not in the correct format. This PR remedies that issue.

We should also follow up to validate the test scenario - due to the test data set up in the test org, the test that was supposed to catch an issue like this was passing, since the correct param and an incorrect param returned the same data. (reasoning being that there are only two concepts in the whole org, after this PR I will add another concept which should make the test more valid).

Important note: Taxonomy in the CDA is still a beta feature, so there is no worry on this being a breaking change

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature

## Screenshots (if appropriate):
