### PR TITLE
fix: allow for content source maps to work with preview.eu.contentful…

### DIFF
--- a/lib/utils/validate-params.ts
+++ b/lib/utils/validate-params.ts
@@ -64,12 +64,12 @@ export function checkIncludeContentSourceMapsParamIsAllowed(
     )
   }
 
-  const includeContentSourceMapsIsAllowed = host === 'preview.contentful.com'
+  const includeContentSourceMapsIsAllowed = typeof host === 'string' && host.startsWith('preview')
 
   if (includeContentSourceMaps && !includeContentSourceMapsIsAllowed) {
     throw new ValidationError(
       'includeContentSourceMaps',
-      `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.
+      `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to include Content Source Maps.
       `,
     )
   }
@@ -92,7 +92,7 @@ export function checkEnableTimelinePreviewIsAllowed(
   if (isValidConfig && !isValidHost) {
     throw new ValidationError(
       'timelinePreview',
-      `The 'timelinePreview' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to enable Timeline Preview.
+      `The 'timelinePreview' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to enable Timeline Preview.
       `,
     )
   }

--- a/test/integration/getAsset.test.ts
+++ b/test/integration/getAsset.test.ts
@@ -40,7 +40,7 @@ describe('getAsset', () => {
   describe('has includeContentSourceMaps enabled', () => {
     test('cdn client', async () => {
       await expect(invalidClient.getAsset(asset)).rejects.toThrow(
-        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,
+        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to include Content Source Maps.`,
       )
       await expect(invalidClient.getAsset(asset)).rejects.toThrow(ValidationError)
     })

--- a/test/integration/getAssets.test.ts
+++ b/test/integration/getAssets.test.ts
@@ -48,7 +48,7 @@ describe('getAssets', () => {
   describe('has includeContentSourceMaps enabled', () => {
     test('cdn client', async () => {
       await expect(invalidClient.getAssets()).rejects.toThrow(
-        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,
+        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to include Content Source Maps.`,
       )
       await expect(invalidClient.getAssets()).rejects.toThrow(ValidationError)
     })

--- a/test/integration/getEntries.test.ts
+++ b/test/integration/getEntries.test.ts
@@ -365,7 +365,7 @@ describe('getEntries via client chain modifiers', () => {
       ).toBeDefined()
       expect(
         response.items[0].fields.bestFriend &&
-          response.items[0].fields.bestFriend['en-US']?.sys.type,
+        response.items[0].fields.bestFriend['en-US']?.sys.type,
       ).toBe('Link')
     })
 
@@ -385,7 +385,7 @@ describe('getEntries via client chain modifiers', () => {
   describe('has includeContentSourceMaps enabled', () => {
     test('invalid client', async () => {
       await expect(invalidClient.getEntries()).rejects.toThrow(
-        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,
+        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to include Content Source Maps.`,
       )
       await expect(invalidClient.getEntries()).rejects.toThrow(ValidationError)
     })
@@ -437,7 +437,7 @@ describe('getEntries via client chain modifiers', () => {
       ).toBeDefined()
       expect(
         response.items[0].fields.bestFriend &&
-          response.items[0].fields.bestFriend['en-US']?.sys.type,
+        response.items[0].fields.bestFriend['en-US']?.sys.type,
       ).toBe('Link')
     })
 
@@ -489,7 +489,7 @@ describe('getEntries via client chain modifiers', () => {
       ).toBeDefined()
       expect(
         response.items[0].fields.bestFriend &&
-          response.items[0].fields.bestFriend['en-US']?.sys.type,
+        response.items[0].fields.bestFriend['en-US']?.sys.type,
       ).toBe('Link')
     })
   })

--- a/test/integration/getEntry.test.ts
+++ b/test/integration/getEntry.test.ts
@@ -197,7 +197,7 @@ describe('getEntry via client chain modifiers', () => {
   describe('preview client has includeContentSourceMaps enabled', () => {
     test('invalid client', async () => {
       await expect(invalidClient.getEntry(entryWithResolvableLink)).rejects.toThrow(
-        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.`,
+        `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' or 'preview.eu.contentful.com' to include Content Source Maps.`,
       )
       await expect(invalidClient.getEntry(entryWithResolvableLink)).rejects.toThrow(ValidationError)
     })

--- a/test/unit/utils/validate-params.test.ts
+++ b/test/unit/utils/validate-params.test.ts
@@ -26,6 +26,10 @@ describe('checkIncludeContentSourceMapsParamIsAllowed', () => {
     expect(checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', true)).toBe(true)
   })
 
+  it('returns true if includeContentSourceMaps is true and host is preview.eu.contentful.com', () => {
+    expect(checkIncludeContentSourceMapsParamIsAllowed('preview.eu.contentful.com', true)).toBe(true)
+  })
+
   it('returns false if includeContentSourceMaps is false, regardless of host', () => {
     expect(checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', false)).toBe(false)
     expect(checkIncludeContentSourceMapsParamIsAllowed('cdn.contentful.com', false)).toBe(false)


### PR DESCRIPTION
….com

## Summary


using 
```
import { createClient } from "contentful";
export const previewClient = createClient({
	space: config.CONTENTFUL_SPACE_ID,
	accessToken: config.CONTENTFUL_PREVIEW_TOKEN,
	environment: config.CONTENTFUL_ENVIRONMENT,
	host: "preview.eu.contentful.com",
	includeContentSourceMaps: true,
});
```

returns the following error: 
```
ValidationError: Invalid "includeContentSourceMaps" provided, The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.
```

because 

```
export function checkIncludeContentSourceMapsParamIsAllowed(
  host?: string,
  includeContentSourceMaps?: boolean,
) {
  if (includeContentSourceMaps === undefined) {
    return false
  }

  if (typeof includeContentSourceMaps !== 'boolean') {
    throw new ValidationError(
      'includeContentSourceMaps',
      `The 'includeContentSourceMaps' parameter must be a boolean.`,
    )
  }

  const includeContentSourceMapsIsAllowed = host === 'preview.contentful.com'

  if (includeContentSourceMaps && !includeContentSourceMapsIsAllowed) {
    throw new ValidationError(
      'includeContentSourceMaps',
      `The 'includeContentSourceMaps' parameter can only be used with the CPA. Please set host to 'preview.contentful.com' to include Content Source Maps.
      `,
    )
  }

  return includeContentSourceMaps as boolean
}
```

I have changed this to 
`const includeContentSourceMapsIsAllowed = typeof host === 'string' && host.startsWith('preview')` to match the function `checkEnableTimelinePreviewIsAllowed`.
I've added a unit test and adjusted the error messages.
