### PR TITLE
feat(taxonomy): add getConceptAncestors and getConceptDescendants functions []

### DIFF
--- a/lib/create-contentful-api.ts
+++ b/lib/create-contentful-api.ts
@@ -592,6 +592,54 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
     }
   }
 
+  function getConceptAncestors<Locales extends LocaleCode>(
+    id: string,
+    query: Record<string, any> = {},
+  ): Promise<ConceptCollection<Locales>> {
+    return internalGetConceptAncestors<Locales>(id, query)
+  }
+
+  async function internalGetConceptAncestors<Locales extends LocaleCode>(
+    id: string,
+    query: Record<string, any> = {},
+  ): Promise<ConceptCollection<Locales>> {
+    try {
+      return get({
+        context: 'environment',
+        path: `taxonomy/concepts/${id}/ancestors`,
+        config: createRequestConfig({
+          query: normalizeSearchParameters(normalizeSelect(query)),
+        }),
+      })
+    } catch (error) {
+      errorHandler(error)
+    }
+  }
+
+  function getConceptDescendants<Locales extends LocaleCode>(
+    id: string,
+    query: Record<string, any> = {},
+  ): Promise<ConceptCollection<Locales>> {
+    return internalGetConceptDescendants<Locales>(id, query)
+  }
+
+  async function internalGetConceptDescendants<Locales extends LocaleCode>(
+    id: string,
+    query: Record<string, any> = {},
+  ): Promise<ConceptCollection<Locales>> {
+    try {
+      return get({
+        context: 'environment',
+        path: `taxonomy/concepts/${id}/descendants`,
+        config: createRequestConfig({
+          query: normalizeSearchParameters(normalizeSelect(query)),
+        }),
+      })
+    } catch (error) {
+      errorHandler(error)
+    }
+  }
+
   /*
    * Switches BaseURL to use /environments path
    * */
@@ -625,6 +673,9 @@ export default function createContentfulApi<OptionType extends ChainOptions>(
 
     getConcept,
     getConcepts,
+
+    getConceptAncestors,
+    getConceptDescendants,
 
     createAssetKey,
   } as unknown as ContentfulClientApi<undefined>

--- a/lib/types/client.ts
+++ b/lib/types/client.ts
@@ -4,6 +4,7 @@ import type { LocaleCode, LocaleCollection } from './locale.js'
 import type {
   AssetQueries,
   AssetsQueries,
+  ConceptAncestorsDescendantsQueries,
   ConceptSchemesQueries,
   ConceptsQueries,
   EntriesQueries,
@@ -224,6 +225,50 @@ export interface ContentfulClientApi<Modifiers extends ChainModifiers> {
    * ```
    */
   getConcept(id: string): Promise<Concept<'en-US'>>
+
+  /**
+   * Fetches a Concept Ancestors traversing the concept hierarchy by depth
+   * @param id - The concept’s ID
+   * @returns Promise for a concept
+   * @example
+   * ```typescript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const concept = await client.getConceptAncestors('<concept_id>', { depth: 5, order: 'sys.updatedAt' })
+   * console.log(concept)
+   * ```
+   */
+  getConceptAncestors(
+    id: string,
+    query?: ConceptAncestorsDescendantsQueries,
+  ): Promise<ConceptCollection<'en-US'>>
+
+  /**
+   * Fetches a Concept Descendants traversing the concept hierarchy by depth
+   * @param id - The concept’s ID
+   * @returns Promise for a concept
+   * @example
+   * ```typescript
+   * const contentful = require('contentful')
+   *
+   * const client = contentful.createClient({
+   *   space: '<space_id>',
+   *   accessToken: '<content_delivery_api_key>'
+   * })
+   *
+   * const concept = await client.getConceptDescendants('<concept_id>', { depth: 5, order: 'sys.updatedAt' })
+   * console.log(concept)
+   * ```
+   */
+  getConceptDescendants(
+    id: string,
+    query?: ConceptAncestorsDescendantsQueries,
+  ): Promise<ConceptCollection<'en-US'>>
 
   /**
    * Fetches a collection of Concepts

--- a/lib/types/query/query.ts
+++ b/lib/types/query/query.ts
@@ -228,3 +228,5 @@ export type ConceptsQueries = CursorPaginationOptions &
   TaxonomyOrderFilter & { conceptScheme?: string }
 
 export type ConceptSchemesQueries = CursorPaginationOptions & TaxonomyOrderFilter
+export type ConceptAncestorsDescendantsQueries = CursorPaginationOptions &
+  TaxonomyOrderFilter & { depth?: number }

--- a/test/integration/getConceptAncestors.test.ts
+++ b/test/integration/getConceptAncestors.test.ts
@@ -1,0 +1,17 @@
+import * as contentful from '../../lib/contentful'
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe('getConcept', () => {
+  it('returns a single concept', async () => {
+    const response = await client.getConceptAncestors('3eXhEIEzcZqwHyYWHbzSoS')
+
+    expect(response.sys.type).toBe('TaxonomyConcept')
+  })
+})

--- a/test/integration/getConceptDescendants.test.ts
+++ b/test/integration/getConceptDescendants.test.ts
@@ -1,0 +1,17 @@
+import * as contentful from '../../lib/contentful'
+import { params } from './utils'
+
+if (process.env.API_INTEGRATION_TESTS) {
+  params.host = '127.0.0.1:5000'
+  params.insecure = true
+}
+
+const client = contentful.createClient(params)
+
+describe('getConcept', () => {
+  it('returns a single concept', async () => {
+    const response = await client.getConceptDescendants('3eXhEIEzcZqwHyYWHbzSoS')
+
+    expect(response.sys.type).toBe('TaxonomyConcept')
+  })
+})


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

- adds `client.getConceptAncestors('conceptId', { depth: 2})`
- adds `client.getConceptDescendants('conceptId', { depth: 5 })`

<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
