### PR TITLE
fix: bump axios and add shared .npmrc config [DX-422]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ gh-pages
 *.dockerfile
 *.dockerignore
 
-# NPM config
-.npmrc
-
 # Created by https://www.gitignore.io/api/node,windows,osx,linux,vim
 
 ### Linux ###

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@contentful:registry=https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/content-source-maps": "^0.11.33",
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "contentful-resolve-response": "^1.9.0",
         "contentful-sdk-core": "^9.0.1",
         "json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@contentful/content-source-maps": "^0.11.33",
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "contentful-resolve-response": "^1.9.0",
     "contentful-sdk-core": "^9.0.1",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

Addresses two issues:
- Explicitly bump axios version to stable version to address security vulnerabilities
- Add a shared `.npmrc` config to add npm as the registry for `@contentful` scoped packages

## Description

The `package-lock.json` file was already updated to `12.2.2` for axios, this now explicitly sets it in the `package.json` file. Also adding the `.npmrc` to ensure that packages are installed from the correct registry. 

## Motivation and Context

Addresses: #2567

## Todos

<!--
In case your PR is not finished yet, feel free to add checkboxes in this section
to give other people an overview of your current state.
-->

-   [x] Implemented feature
-   [ ] Feature with pending implementation

## Screenshots (if appropriate):
