### PR TITLE
build(deps): bump contentful-resolve-response to v1.9.4 [DX-424]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@contentful/content-source-maps": "^0.11.33",
         "@contentful/rich-text-types": "^16.6.1",
         "axios": "^1.12.2",
-        "contentful-resolve-response": "^1.9.0",
+        "contentful-resolve-response": "^1.9.4",
         "contentful-sdk-core": "^9.0.1",
         "json-stringify-safe": "^5.0.1",
         "type-fest": "^4.0.0"
@@ -5404,22 +5404,16 @@
       "license": "ISC"
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.9.3.tgz",
-      "integrity": "sha512-1mPTz7bJLZsLdWAOEyjoVKys/eTXa7o3aV3EYLH7sqqF8V1fnRHlJqlDoxGZFsPxQPBYag+V89B1E/HYE0ENnQ==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.9.4.tgz",
+      "integrity": "sha512-8qu2dM2IMoVQhBhp81BVGB9ISantPmPTZ3EELGxuM8e/t+jSe+xmsVk5yHE+a9AYMBKSwgupBnkjGZE4RzFowQ==",
       "license": "MIT",
       "dependencies": {
-        "fast-copy": "^2.1.7"
+        "fast-copy": "^3.0.2"
       },
       "engines": {
         "node": ">=4.7.2"
       }
-    },
-    "node_modules/contentful-resolve-response/node_modules/fast-copy": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
-      "license": "MIT"
     },
     "node_modules/contentful-sdk-core": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@contentful/content-source-maps": "^0.11.33",
     "@contentful/rich-text-types": "^16.6.1",
     "axios": "^1.12.2",
-    "contentful-resolve-response": "^1.9.0",
+    "contentful-resolve-response": "^1.9.4",
     "contentful-sdk-core": "^9.0.1",
     "json-stringify-safe": "^5.0.1",
     "type-fest": "^4.0.0"


### PR DESCRIPTION
## Summary
Bump `contentful-resolve-response` package to `v1.9.4` to remove duplicate dependencies on `fast-copy`, detailed in this [GH issue](https://github.com/contentful/contentful-resolve-response/issues/455).

Now both `contentful.js` and `contentful-resolve-response` both use `fast-copy ^3.0.2` 
