### PR TITLE
fix(ci): semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,6 @@
 name: CI
 permissions:
   contents: read
-  issues: write
 
 on:
   push:
@@ -23,6 +22,8 @@ jobs:
       id-token: write
       actions: read
     uses: ./.github/workflows/release.yaml
+    secrets:
+      VAULT_URL: ${{ secrets.VAULT_URL }}
 
   notify-failure:
     if: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,6 +2,9 @@ name: release
 
 on:
   workflow_call:
+    secrets:
+      VAULT_URL:
+        required: true
 
 jobs:
   release:
@@ -11,6 +14,29 @@ jobs:
       id-token: write # Required for OIDC trusted publishing
     runs-on: ubuntu-latest
     steps:
+      - name: 'Retrieve Secrets from Vault'
+        id: vault
+        uses: hashicorp/vault-action@v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN;
+
+      - name: Get Automation Bot User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/contentful-automation[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+
+      - name: Setting up Git User Credentials
+        run: |
+          git config --global user.name 'contentful-automation[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+contentful-automation[bot]@users.noreply.github.com'
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
@@ -36,10 +62,7 @@ jobs:
             dist
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
 
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v2
-        with:
-          install-chromedriver: true
-
       - name: Run semantic release
         run: npm run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
1. Fix [semantic-release](https://github.com/contentful/contentful.js/actions/runs/19315085378/job/55245285043), which is running into the following github token permissions error:

```
[6:15:04 PM] [semantic-release] › ✘  Failed step "fail" of plugin "@semantic-release/github"
[6:15:04 PM] [semantic-release] › ✘  ENOGHTOKEN No GitHub token specified.
A GitHub personal token (https://github.com/semantic-release/github/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment.

Please make sure to create a GitHub personal token (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment. The token must allow to push to the repository contentful/contentful.js.

[6:15:04 PM] [semantic-release] › ✘  ENOGHTOKEN No GitHub token specified.
A GitHub personal token (https://github.com/semantic-release/github/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment.

Please make sure to create a GitHub personal token (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment. The token must allow to push to the repository contentful/contentful.js.
```

Resolution is to retrieve the github token, using vault secret and then pass that as an env var to the `npm run semantic-release` step.


2. Add github tags/releases that will be authored by Contentful automation bot.

3. remove unccessary steps from release.yaml
-  Restore the build folders
- name: Setup Chrome

