### PR TITLE
Fix github actions token permissions issue in release.yaml [DX-505]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,12 @@ jobs:
             dist
           key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
 
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          install-chromedriver: true
+
       - name: Run semantic release
         run: npm run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/contentful.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/contentful.cjs"
     }
   },
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
## Summary

Fix failing release job in [this github action](https://github.com/contentful/contentful.js/actions/runs/19344811957/job/55342444401), raised in [this issue](https://github.com/contentful/contentful.js/issues/2597)

## Description
**Error**

```
Run hashicorp/vault-action@v3.4.0
  with:
    url: ***
    role: contentful.js-github-action
    method: jwt
    path: github-actions
    exportEnv: false
    secrets: github/token/contentful.js-semantic-release token | GITHUB_TOKEN;
  
    kubernetesTokenPath: /var/run/secrets/kubernetes.io/serviceaccount/token
    exportToken: false
    outputToken: false
    tlsSkipVerify: false
    jwtTtl: 3600
    ignoreNotFound: false
Get Vault Secrets
Token Info
  

Error: Response code 403 (Forbidden)
```
