### PR TITLE
chore(ci): add semantic-release policy to github actions, remove circleCI policies entirely [DX-505]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,7 +3,4 @@ services:
   github-action:
     policies:
       - dependabot
-  circleci:
-    policies:
-      - semantic-release-ecosystem
-      - packages-read
+      - semantic-release


### PR DESCRIPTION
as titled.