### PR TITLE
fix(ci): release browser integration tests [DX-505]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,3 +71,5 @@ jobs:
         run: npm run semantic-release
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+          # required for browser output-integration tests
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome


### PR DESCRIPTION
## Summary
Fix release CI/CD error.  [GHA build logs](https://github.com/contentful/contentful.js/actions/runs/19372568142/job/55432144025)

## Description
**Bug:** 
```
Error: Failed to launch the browser process!
[2870:2870:1114/173512.639554:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[1114/173512.646566:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[1114/173512.646603:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)
```
**Root cause:**
Puppeteer needs an env var to `PUPPETEER_EXECUTABLE_PATH`.

This can be reproduced in the build step by removing that env var, as proven in this GHA build:

https://github.com/contentful/contentful.js/actions/runs/19372935338/job/55433100438?pr=2604
