### PR TITLE
chore(ci): trigger gha workflows on pull request []

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,9 +4,9 @@ permissions:
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - main
   pull_request:
-    branches: ['**']
 
 jobs:
   build:


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

<!-- Give a short summary what your PR is introducing/fixing. -->

- Adds config to trigger CI on pull request
- For branches, only trigger CI on main branch

## Description

<!-- Describe your changes in detail -->

GHA CI workflows are not running for PRs from forked repos. [Example](https://github.com/contentful/contentful.js/pull/2588)
This updates the trigger so that it also runs for pull requests.

To address issues with concurrent tests running, update to only trigger on main branch.

## Motivation and Context


<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
