### PR TITLE
fix(deps): bump contentful-sdk-core version [DX-704]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@size-limit/file": "^11.1.6",
         "@types/json-stringify-safe": "^5.0.0",
+        "@types/node": "^25.0.10",
         "contentful-sdk-jsdoc": "^3.1.2",
         "cz-conventional-changelog": "^3.3.0",
         "es-check": "^7.0.0",
@@ -4165,6 +4166,17 @@
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
+      "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -15973,8 +15985,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@size-limit/file": "^11.1.6",
     "@types/json-stringify-safe": "^5.0.0",
+    "@types/node": "^25.0.10",
     "contentful-sdk-jsdoc": "^3.1.2",
     "cz-conventional-changelog": "^3.3.0",
     "es-check": "^7.0.0",


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

Bump `contentful-sdk-core` to update lodash dependency to a secure version and add `@types/node` as a dev dependency. That package was in the lock file but not in the package.json. CI checks failed initially since it was removed from the lock file.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
