### PR TITLE
build(ci): trigger CI workflow on dependabot merge [DX-665]

### DIFF
--- a/.github/workflows/dependabot-approve-and-request-merge.yaml
+++ b/.github/workflows/dependabot-approve-and-request-merge.yaml
@@ -10,6 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
     steps:
-      - uses: contentful/github-auto-merge@v1
+      - uses: contentful/github-auto-merge@b995e4ecd10bed72105998808b1fe666d6b0892d # v2
+        id: auto-merge
         with:
           VAULT_URL: ${{ secrets.VAULT_URL }}
+
+      # After merge, explicitly trigger CI workflow.
+      # The auto-merge action uses the auto-generated workflow token for the merge,
+      # which by design doesn't trigger push-based workflows (prevents infinite loops).
+      - name: 'Retrieve Secrets from Vault'
+        id: vault
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN;
+
+      - name: Trigger CI workflow on master
+        run: gh workflow run main.yaml --ref master
+        env:
+          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` trigger to main CI workflow and configure dependabot workflow to explicitly trigger CI after auto-merge.

## Description

- Added `workflow_dispatch` to `main.yaml` to allow manual workflow triggering
- Updated `dependabot-approve-and-request-merge.yaml` to retrieve Vault secrets and trigger CI workflow after merge
- Pinned GitHub Actions to commit SHAs for security

## Motivation and Context

When dependabot PRs are auto-merged, the workflow token used doesn't trigger push-based workflows by design. This change explicitly triggers the CI workflow after merge.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes