### PR TITLE
build(deps): patch axios security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/content-source-maps": "^0.11.33",
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
+        "axios": "^1.13.5",
         "contentful-resolve-response": "^1.9.4",
         "contentful-sdk-core": "^9.4.2",
         "json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@contentful/content-source-maps": "^0.11.33",
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.12.2",
+    "axios": "^1.13.5",
     "contentful-resolve-response": "^1.9.4",
     "contentful-sdk-core": "^9.4.2",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
## Summary
Patch a security vulnerability in axios.

https://contentful.atlassian.net/browse/ZEND-7612

https://contentful.atlassian.net/browse/DX-728

https://security.snyk.io/package/npm/axios/1.13.4

> Affected versions of this package are vulnerable to Prototype Pollution via the mergeConfig function. An attacker can cause the application to crash by supplying a malicious configuration object containing a __proto__ property, typically by leveraging JSON.parse().
> How to fix Prototype Pollution?
> Upgrade axios to version 1.13.5 or higher.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes
