### PR TITLE
fix: bump axios to ^1.15.0 to address CVE-2026-40175 [DX-930]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@contentful/content-source-maps": "^0.11.33",
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "contentful-resolve-response": "^1.9.4",
         "contentful-sdk-core": "^9.4.4",
         "json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@contentful/content-source-maps": "^0.11.33",
     "@contentful/rich-text-types": "^16.6.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "contentful-resolve-response": "^1.9.4",
     "contentful-sdk-core": "^9.4.4",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
## Summary

- Bumps `axios` lower bound from `^1.13.5` to `^1.15.0` in `dependencies`
- All axios versions below `1.15.0` are affected by CVE-2026-40175 (CVSS 10.0)
- Consumers no longer need `npm overrides` / `yarn resolutions` as a workaround

## Test plan

- [ ] CI passes (unit + integration)
- [ ] Verify `axios@>=1.15.0` resolves in the lockfile
- [ ] No behavior changes expected — lower-bound bump within existing `^1.x` range

Fixes JSDK-57

🤖 Generated with [Claude Code](https://claude.com/claude-code)