### PR TITLE
fix(deps): remediate Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3135,9 +3135,9 @@
       }
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5920,12 +5920,6 @@
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
-    },
-    "node_modules/contentful-sdk-core/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
     },
     "node_modules/contentful-sdk-jsdoc": {
       "version": "3.1.5",
@@ -9206,10 +9200,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -12727,9 +12720,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12998,16 +12991,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/rc": {
@@ -13535,9 +13518,9 @@
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14057,13 +14040,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {
@@ -14910,9 +14893,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15855,9 +15838,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15941,9 +15924,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -151,6 +151,14 @@
       "limit": "45 Kb"
     }
   ],
+  "overrides": {
+    "lodash": ">= 4.18.0",
+    "serialize-javascript": ">= 7.0.5",
+    "picomatch": ">= 4.0.4",
+    "micromatch": {
+      "picomatch": "2.3.2"
+    }
+  },
   "release": {
     "branches": [
       "master",


### PR DESCRIPTION
## Security Alerts Addressed

| Alert # | CVE | Severity | Package | Fix Type | Scope |
|---------|-----|----------|---------|----------|-------|
| #193, #194 | CVE-2026-4800, CVE-2026-2950 | High / Medium | lodash | npm override: >= 4.18.0 | runtime |
| #197 | CVE-2026-34043 | Medium | serialize-javascript | npm override: >= 7.0.5 | dev |
| #188 | CVE-2026-33672 | Medium | picomatch (2.x stream) | npm override via micromatch scope: 2.3.2 | dev |
| #187 | CVE-2026-33672 | Medium | picomatch (4.x stream) | npm override: >= 4.0.4 | dev |

## Fix Approach

### npm Overrides (Transitive Dependencies)

- **`lodash`: `>= 4.18.0`** — forces all transitive consumers to patched version
  - Dep chain: `@semantic-release/changelog` → `lodash`; `contentful-sdk-core` → `lodash`; `commitizen` → `inquirer` → `lodash`
  - Scope: runtime + dev

- **`serialize-javascript`: `>= 7.0.5`** — forces patched version
  - Dep chain: `@rollup/plugin-terser` → `serialize-javascript`
  - Scope: dev (build tooling only)

- **`picomatch`: `>= 4.0.4`** — covers the 4.x version stream
  - Dep chain: `@rollup/pluginutils` → `picomatch`; `vitest` → `picomatch`; `vite` → `picomatch`; etc.
  - Scope: dev

- **`micromatch` scoped `picomatch`: `2.3.2`** — covers the 2.x version stream (micromatch requires `^2.3.1`)
  - Dep chain: `lint-staged` → `micromatch` → `picomatch`
  - Note: a flat `picomatch: >= 2.3.2` override would resolve to 4.x and break micromatch's constraint; nested scoping is required here.
  - Scope: dev

## Breaking Change Risk Assessment

| Package | Old Version | New Version | Delta | Risk |
|---------|------------|-------------|-------|------|
| lodash | 4.17.21 / 4.17.23 | 4.18.1 (override: >= 4.18.0) | patch | Low |
| serialize-javascript | 6.0.2 | 7.0.5 (override: >= 7.0.5) | major | Low — dev/build only, not shipped |
| picomatch | 2.3.1 | 2.3.2 | patch | Low |
| picomatch | 4.0.2–4.0.3 | 4.0.4 | patch | Low |

## CI Status

| Job | Status | Notes |
|-----|--------|-------|
| build | ✅ PASS | Warnings pre-existing (unresolved deps, circular dep) |
| lint | ✅ PASS | 139 warnings, all pre-existing |
| prettier:check | ✅ PASS | |
| test:unit | ✅ PASS | 111 passed, 2 skipped |
| test:types | ✅ PASS | |

> Integration/E2E tests were not run locally (require live API tokens). CI will validate.

## Verified Resolution

```
$ npm ls lodash
└── lodash@4.18.1 (all chains via override)

$ npm ls serialize-javascript
└── serialize-javascript@7.0.5

$ npm ls picomatch
├── picomatch@2.3.2 (micromatch chain, overridden)
└── picomatch@4.0.4 (all other chains)
```

## Could Not Fix

| Package | Reason | Alert # | Notes |
|---------|--------|---------|-------|
| ip-address | Lives only inside `node_modules/npm/node_modules/` — npm's own bundled deps, not reachable from project code | #211 | Alert dismissed as tolerable_risk |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request addresses multiple Dependabot security alerts by implementing npm overrides in package.json to force patched versions of vulnerable transitive dependencies, ensuring secure dependency resolution without breaking existing functionality.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>adds npm overrides section to package.json forcing secure versions of lodash (>= 4.18.0), serialize-javascript (>= 7.0.5), and picomatch (>= 4.0.4) in package.json</li>

<li>implements scoped override for micromatch's picomatch dependency at version 2.3.2 to maintain compatibility with micromatch's constraints in package.json</li>

</ul>
</details>

</div>