### PR TITLE
fix(timeline): opt-out of validation with custom host [ES-323]

### DIFF
--- a/lib/utils/validate-params.ts
+++ b/lib/utils/validate-params.ts
@@ -87,7 +87,10 @@ export function checkEnableTimelinePreviewIsAllowed(
 
   const isValidConfig = isValidTimelinePreviewConfig(timelinePreview)
 
-  const isValidHost = typeof host === 'string' && host.startsWith('preview')
+  // Show error if used outside of CPA.
+  // Opt-out of the error if a custom domain is used and CPA could not be idenfified
+  const isValidHost =
+    typeof host === 'string' && (!host.includes('contentful') || host.startsWith('preview'))
 
   if (isValidConfig && !isValidHost) {
     throw new ValidationError(

--- a/test/unit/utils/validate-params.test.ts
+++ b/test/unit/utils/validate-params.test.ts
@@ -1,4 +1,7 @@
-import { checkIncludeContentSourceMapsParamIsAllowed } from '../../../lib/utils/validate-params'
+import {
+  checkEnableTimelinePreviewIsAllowed,
+  checkIncludeContentSourceMapsParamIsAllowed,
+} from '../../../lib/utils/validate-params'
 import { ValidationError } from '../../../lib/utils/validation-error'
 
 describe('checkIncludeContentSourceMapsParamIsAllowed', () => {
@@ -35,5 +38,70 @@ describe('checkIncludeContentSourceMapsParamIsAllowed', () => {
   it('returns false if includeContentSourceMaps is false, regardless of host', () => {
     expect(checkIncludeContentSourceMapsParamIsAllowed('preview.contentful.com', false)).toBe(false)
     expect(checkIncludeContentSourceMapsParamIsAllowed('cdn.contentful.com', false)).toBe(false)
+  })
+})
+
+describe('checkEnableTimelinePreviewIsAllowed', () => {
+  const validRelease = { release: { lte: 'release-id' } }
+  const validTimestamp = { timestamp: { lte: '2026-01-01T00:00:00Z' } }
+  const validTimestampDate = { timestamp: { lte: new Date('2026-01-01') } }
+
+  it('returns false if timelinePreview is not provided', () => {
+    expect(checkEnableTimelinePreviewIsAllowed('preview.contentful.com')).toBe(false)
+    expect(checkEnableTimelinePreviewIsAllowed('preview.contentful.com', undefined)).toBe(false)
+  })
+
+  it('throws ValidationError if timelinePreview is not an object', () => {
+    expect(() =>
+      checkEnableTimelinePreviewIsAllowed('preview.contentful.com', 'not-an-object' as any),
+    ).toThrow(ValidationError)
+    expect(() =>
+      checkEnableTimelinePreviewIsAllowed('preview.contentful.com', null as any),
+    ).toThrow(ValidationError)
+    expect(() => checkEnableTimelinePreviewIsAllowed('preview.contentful.com', [] as any)).toThrow(
+      ValidationError,
+    )
+  })
+
+  it('throws ValidationError if timelinePreview has neither valid release nor valid timestamp', () => {
+    expect(() => checkEnableTimelinePreviewIsAllowed('preview.contentful.com', {} as any)).toThrow(
+      ValidationError,
+    )
+    expect(() =>
+      checkEnableTimelinePreviewIsAllowed('preview.contentful.com', { release: {} } as any),
+    ).toThrow(ValidationError)
+    expect(() =>
+      checkEnableTimelinePreviewIsAllowed('preview.contentful.com', {
+        timestamp: { lte: 123 },
+      } as any),
+    ).toThrow(ValidationError)
+  })
+
+  it('returns true for a valid release config on a preview host', () => {
+    expect(checkEnableTimelinePreviewIsAllowed('preview.contentful.com', validRelease)).toBe(true)
+    expect(checkEnableTimelinePreviewIsAllowed('preview.eu.contentful.com', validRelease)).toBe(
+      true,
+    )
+  })
+
+  it('returns true for a valid timestamp config (string or Date) on a preview host', () => {
+    expect(checkEnableTimelinePreviewIsAllowed('preview.contentful.com', validTimestamp)).toBe(true)
+    expect(checkEnableTimelinePreviewIsAllowed('preview.contentful.com', validTimestampDate)).toBe(
+      true,
+    )
+  })
+
+  it('throws ValidationError if a valid config is used with the CDN host', () => {
+    expect(() => checkEnableTimelinePreviewIsAllowed('cdn.contentful.com', validRelease)).toThrow(
+      ValidationError,
+    )
+    expect(() => checkEnableTimelinePreviewIsAllowed('cdn.contentful.com', validTimestamp)).toThrow(
+      ValidationError,
+    )
+  })
+
+  it('opts out of host validation for custom hosts that do not include "contentful"', () => {
+    expect(checkEnableTimelinePreviewIsAllowed('my-proxy.example.com', validRelease)).toBe(true)
+    expect(checkEnableTimelinePreviewIsAllowed('localhost', validTimestamp)).toBe(true)
   })
 })


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

- If a custom host is used, we can't detect if the CPA is used behind the scenes, and the check on timeline provides a false/positive
- Theoretically, it would be the same on content-source-maps, but this is already enabled on CDN and the validation will be removed later.

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a false positive validation error in the timeline preview feature when custom hosts are used. The validation logic previously required preview hosts to start with 'preview', but this check fails for custom domains where Contentful's Content Preview API (CPA) cannot be detected. The fix adds an opt-out condition for custom hosts that don't contain 'contentful', allowing timeline preview to work correctly behind proxies or custom domains.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates `isValidHost` condition in `checkEnableTimelinePreviewIsAllowed` from `host.startsWith('preview')` to `!host.includes('contentful') || host.startsWith('preview')`, enabling timeline preview on custom domains where CPA detection is not possible</li>

<li>Adds clarifying comments explaining the opt-out logic for custom domains that prevent Contentful's CPA identification</li>

<li>Adds comprehensive test suite for `checkEnableTimelinePreviewIsAllowed` covering valid/invalid configs, preview hosts, CDN host validation, and the new custom host opt-out behavior</li>

</ul>
</details>

</div>