### PR TITLE
chore: update ci []

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,17 +26,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # required for browser output-integration tests
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v2
-        with:
-          install-chromedriver: true
-
       - name: Build
         run: npm run build
-        env:
-          # required for browser output-integration tests
-          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
 
       - name: Save Build folders
         uses: actions/cache/save@v4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -84,6 +84,7 @@ jobs:
       # required for browser output-integration tests
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v2
+        id: chrome
         with:
           install-chromedriver: true
 
@@ -91,7 +92,7 @@ jobs:
         run: npm run test:demo-projects
         env:
           # required for browser output-integration tests
-          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.chrome.outputs.chrome-path }}
 
   test-bundle-size:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -81,8 +81,17 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # required for browser output-integration tests
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          install-chromedriver: true
+
       - name: Run demo tests
         run: npm run test:demo-projects
+        env:
+          # required for browser output-integration tests
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
 
   test-bundle-size:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thank you for opening a pull request.

Please fill in as much of the template below as you're able. Feel free to remove
any section you want to skip.
-->

## Summary

Root cause: The check.yaml test job — the one that actually runs browser tests via npm run test:demo-projects — has no Chrome installed.

The Setup Chrome step + PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome env are wired up in build.yaml (line 30-39) and release.yaml, but neither of those jobs runs the browser tests. npm run build just compiles TS and bundles — it never launchespuppeteer. The browser tests run in check.yaml → test job → Run demo tests step (line 84-85), and that job has no Chrome setup at all.

When CI runs:
1. npm ci in test/output-integration/browser/ runs with ignore-scripts=true (from root .npmrc line 2), so puppeteer's postinstall Chrome download is skipped.
2. The setup-test-env script tries to recover via:
  - setup-puppeteer: runs install.mjs — but downloadBrowsers() isn't awaited, so the process can exit before download finishes (note the suspicious 2 sec runtime in your logs).
  - install:browser: runs npx puppeteer browser install — typo, the CLI command is browsers install (plural). Silently no-ops in puppeteer v23.
4. Vitest launches puppeteer → no Chrome cached → boom. 

The fix: add to .github/workflows/check.yaml in the test job (mirroring what build.yaml already does)

## PR Checklist

- [x] I have read the `CONTRIBUTING.md` file
- [x] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (if necessary)
- [x] PR doesn't contain any sensitive information
- [x] There are no breaking changes 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes the CI test workflow by adding Chrome browser setup to the test job in check.yaml. The change enables browser output-integration tests to run successfully by providing the necessary Chrome installation and Puppeteer configuration that was previously missing from this job.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds Chrome setup step using browser-actions/setup-chrome@v2 with install-chromedriver in the test job in check.yaml</li>

<li>Sets PUPPETEER_EXECUTABLE_PATH environment variable to /usr/bin/google-chrome for the test:demo-projects command in check.yaml</li>

</ul>
</details>

</div>