### PR TITLE
fix(timeline): use exact domain match for CPA host validation [ES-323]

### DIFF
--- a/lib/utils/validate-params.ts
+++ b/lib/utils/validate-params.ts
@@ -88,9 +88,13 @@ export function checkEnableTimelinePreviewIsAllowed(
   const isValidConfig = isValidTimelinePreviewConfig(timelinePreview)
 
   // Show error if used outside of CPA.
-  // Opt-out of the error if a custom domain is used and CPA could not be idenfified
-  const isValidHost =
-    typeof host === 'string' && (!host.includes('contentful') || host.startsWith('preview'))
+  // Opt-out of the error if a custom domain is used and CPA could not be identified.
+  // Use an exact domain match to avoid false-positives on proxy hostnames that contain
+  // "contentful" as a substring (e.g. api-contentful-proxy.example.com).
+  const PREVIEW_HOST_REGEX = /^preview(\.eu)?\.contentful\.com$/
+  const isContentfulHost = typeof host === 'string' && PREVIEW_HOST_REGEX.test(host)
+  const isCustomHost = typeof host !== 'string' || !host.endsWith('.contentful.com')
+  const isValidHost = isContentfulHost || isCustomHost
 
   if (isValidConfig && !isValidHost) {
     throw new ValidationError(

--- a/test/unit/utils/validate-params.test.ts
+++ b/test/unit/utils/validate-params.test.ts
@@ -104,4 +104,13 @@ describe('checkEnableTimelinePreviewIsAllowed', () => {
     expect(checkEnableTimelinePreviewIsAllowed('my-proxy.example.com', validRelease)).toBe(true)
     expect(checkEnableTimelinePreviewIsAllowed('localhost', validTimestamp)).toBe(true)
   })
+
+  it('opts out of host validation for custom proxy hosts whose name contains "contentful" as a substring', () => {
+    expect(
+      checkEnableTimelinePreviewIsAllowed(
+        'pers-api-contentful-proxy-preview.np.gke.telus.digital',
+        validRelease,
+      ),
+    ).toBe(true)
+  })
 })


### PR DESCRIPTION
## Problem

The `host.includes('contentful')` substring check introduced in ES-323 false-positives on proxy hostnames that contain `contentful` as a substring (e.g. `api-contentful-proxy.example.com`). Such proxies are treated as Contentful-owned CDN hosts and the `timelinePreview` validation incorrectly rejects them, leaving customers with no way to enable Timeline Preview through a custom proxy.

## Solution

Replace the substring check with an exact regex match against the two known Contentful preview hosts:

```
/^preview(\.eu)?\.contentful\.com$/
```

Any host that does **not** match `.contentful.com` as a domain suffix is treated as a custom host and bypasses the CPA-only guard, preserving the original opt-out behaviour for non-Contentful domains.

## Changes

- `lib/utils/validate-params.ts` — replace `host.includes('contentful')` with a regex test against `preview.contentful.com` / `preview.eu.contentful.com`
- `test/unit/utils/validate-params.test.ts` — add regression test covering a proxy hostname that contains `contentful` as a substring

## Test plan

- [ ] New test `opts out of host validation for custom proxy hosts whose name contains "contentful" as a substring` passes
- [ ] Existing CDN host (`cdn.contentful.com`) still throws `ValidationError`
- [ ] Existing preview hosts (`preview.contentful.com`, `preview.eu.contentful.com`) still return `true`
- [ ] Custom hosts with no Contentful reference (`localhost`, `my-proxy.example.com`) still return `true`
- [ ] Full unit suite passes (`npm run test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bug in the Timeline Preview host validation logic that caused false positives for custom proxy hostnames containing 'contentful' as a substring. The fix replaces the loose substring check with exact domain matching using a regex for Contentful preview hosts and a domain suffix check for identifying Contentful-owned CDN hosts.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Replaces `host.includes('contentful')` substring check in `checkEnableTimelinePreviewIsAllowed` with precise regex matching (`/^preview(\.eu)?\.contentful\.com$/`) to correctly identify Contentful preview hosts and avoid false positives on proxy hostnames containing 'contentful'.</li>

<li>Adds `isCustomHost` logic using `host.endsWith('.contentful.com')` to distinguish between Contentful-owned hosts and custom proxy hosts that happen to include 'contentful' as a substring.</li>

<li>Introduces regression test covering a real-world proxy hostname (`pers-api-contentful-proxy-preview.np.gke.telus.digital`) to prevent future false positives.</li>

<li>Maintains backward compatibility: existing preview hosts (`preview.contentful.com`, `preview.eu.contentful.com`) continue to return `true`, CDN host (`cdn.contentful.com`) continues to throw `ValidationError`, and custom hosts (`localhost`, `my-proxy.example.com`) continue to opt-out.</li>

</ul>
</details>

</div>