### PR TITLE
fix(types): distribute Entry over union skeletons in resolved links

### DIFF
--- a/lib/types/entry.ts
+++ b/lib/types/entry.ts
@@ -165,6 +165,22 @@ export type BaseFieldMap<Field extends EntryFieldType<EntrySkeletonType>> =
                     : never
 
 /**
+ * Resolves a (possibly union) linked-entry skeleton into the corresponding
+ * `Entry` type, distributing over the union so that `EntryLink<A | B>` becomes
+ * `Entry<A> | Entry<B>` instead of collapsing `fields` to the keys common to
+ * every member. `Entry` itself is intentionally non-distributive to remain
+ * inferrable in `getEntry`/`getEntries`, so distribution is applied here at the
+ * link-resolution boundary where the linked skeleton is already known.
+ * @category Entry
+ * @internal
+ */
+export type DistributiveEntry<
+  EntrySkeleton extends EntrySkeletonType,
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = EntrySkeleton extends EntrySkeletonType ? Entry<EntrySkeleton, Modifiers, Locales> : never
+
+/**
  * A single resolved link to another entry in the same space
  * If the current client configuration includes `withoutLinkResolution` chain option,
  * the returned type will not resolve linked entities, but keep them as objects
@@ -181,12 +197,12 @@ export type ResolvedEntryLink<
   Locales extends LocaleCode,
   LinkedEntry extends EntrySkeletonType,
 > = ChainModifiers extends Modifiers
-  ? Entry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'> | undefined
+  ? DistributiveEntry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'> | undefined
   : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? UnresolvedLink<'Entry'>
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
-      ? Entry<LinkedEntry, Modifiers, Locales> | undefined
-      : Entry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'>
+      ? DistributiveEntry<LinkedEntry, Modifiers, Locales> | undefined
+      : DistributiveEntry<LinkedEntry, Modifiers, Locales> | UnresolvedLink<'Entry'>
 
 /**
  * A single resolved reference link to another entry in a different space
@@ -205,12 +221,12 @@ export type ResolvedEntryResourceLink<
   Locales extends LocaleCode,
   LinkedEntry extends EntrySkeletonType,
 > = ChainModifiers extends Modifiers
-  ? Entry<LinkedEntry, Modifiers, Locales> | { sys: ResourceLink } | undefined
+  ? DistributiveEntry<LinkedEntry, Modifiers, Locales> | { sys: ResourceLink } | undefined
   : 'WITHOUT_LINK_RESOLUTION' extends Modifiers
     ? { sys: ResourceLink }
     : 'WITHOUT_UNRESOLVABLE_LINKS' extends Modifiers
-      ? Entry<LinkedEntry, Modifiers, Locales> | undefined
-      : Entry<LinkedEntry, Modifiers, Locales> | { sys: ResourceLink }
+      ? DistributiveEntry<LinkedEntry, Modifiers, Locales> | undefined
+      : DistributiveEntry<LinkedEntry, Modifiers, Locales> | { sys: ResourceLink }
 
 /**
  * A single resolved link to another asset

--- a/test/types/entry-union-links.test-d.ts
+++ b/test/types/entry-union-links.test-d.ts
@@ -1,0 +1,102 @@
+// As tsd does not pick up the global.d.ts located in /lib we
+// explicitly reference it here once.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../lib/global.d.ts" />
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd'
+import { Entry, EntryFieldTypes, EntrySkeletonType } from '../../lib'
+
+// @ts-ignore
+import * as mocks from './mocks'
+
+/**
+ * Two distinct skeletons that share a single field (`internalName`) but each
+ * carry a member-specific field (`headline` / `ctaText`).
+ */
+interface HeroSkeleton extends EntrySkeletonType {
+  contentTypeId: 'hero'
+  fields: {
+    internalName: EntryFieldTypes.Symbol
+    headline: EntryFieldTypes.Symbol
+  }
+}
+
+interface CtaSkeleton extends EntrySkeletonType {
+  contentTypeId: 'cta'
+  fields: {
+    internalName: EntryFieldTypes.Symbol
+    ctaText: EntryFieldTypes.Symbol
+  }
+}
+
+type SectionSkeleton = HeroSkeleton | CtaSkeleton
+
+type HeroEntry = Entry<HeroSkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>
+type CtaEntry = Entry<CtaSkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>
+
+/**
+ * A page whose `section` / `sections` fields link to a *union* of section
+ * skeletons. The resolved field must distribute into `Entry<A> | Entry<B>`,
+ * preserving each member's fields, rather than collapsing `fields` to the keys
+ * common to all members (which would drop `headline` / `ctaText`).
+ */
+type PageSkeleton = EntrySkeletonType<{
+  section: EntryFieldTypes.EntryLink<SectionSkeleton>
+  sections: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<SectionSkeleton>>
+}>
+
+// Single linked reference resolved with `WITHOUT_UNRESOLVABLE_LINKS`:
+// `Entry<Hero> | Entry<Cta> | undefined`.
+type ResolvedSection = Entry<PageSkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>['fields']['section']
+
+expectType<HeroEntry | CtaEntry | undefined>(null as unknown as ResolvedSection)
+
+// Multi reference resolved with `WITHOUT_UNRESOLVABLE_LINKS`:
+// `(Entry<Hero> | Entry<Cta> | undefined)[]`.
+type ResolvedSections = Entry<PageSkeleton, 'WITHOUT_UNRESOLVABLE_LINKS'>['fields']['sections']
+
+expectType<(HeroEntry | CtaEntry | undefined)[]>(null as unknown as ResolvedSections)
+
+// A resolved member entry carrying a member-specific field must be assignable.
+// This fails before the fix because the resolved link collapses to
+// `fields: { internalName }`, dropping `headline` / `ctaText`.
+const heroValue = {
+  ...mocks.entryBasics,
+  sys: {
+    ...mocks.entrySys,
+    contentType: { sys: { ...mocks.entrySys.contentType.sys, id: 'hero' as const } },
+  },
+  fields: {
+    internalName: mocks.stringValue,
+    headline: mocks.stringValue,
+  },
+}
+
+expectAssignable<NonNullable<ResolvedSection>>(heroValue)
+
+const ctaValue = {
+  ...mocks.entryBasics,
+  sys: {
+    ...mocks.entrySys,
+    contentType: { sys: { ...mocks.entrySys.contentType.sys, id: 'cta' as const } },
+  },
+  fields: {
+    internalName: mocks.stringValue,
+    ctaText: mocks.stringValue,
+  },
+}
+
+expectAssignable<NonNullable<ResolvedSection>>(ctaValue)
+
+// A `hero`-tagged entry must NOT be allowed to carry a `cta`-only field —
+// discrimination on `sys.contentType.sys.id` is preserved by distribution.
+expectNotAssignable<NonNullable<ResolvedSection>>({
+  ...mocks.entryBasics,
+  sys: {
+    ...mocks.entrySys,
+    contentType: { sys: { ...mocks.entrySys.contentType.sys, id: 'hero' as const } },
+  },
+  fields: {
+    internalName: mocks.stringValue,
+    ctaText: mocks.stringValue,
+  },
+})


### PR DESCRIPTION
## Context

When a linked field targets a **union** of skeletons — e.g. one `EntryLink` referencing several content types:

```ts
type SectionSkeleton = HeroSkeleton | CtaSkeleton | FeatureSkeleton | BannerSkeleton | PricingTableSkeleton

interface PageSkeleton extends EntrySkeletonType {
  contentTypeId: 'page'
  fields: {
    sections?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<SectionSkeleton>>
  }
}
```

…the resolved field collapsed to a single type carrying only the fields common to **every** member:

```ts
const sections: (BaseEntry & {
    sys: { contentType: { sys: { id: "hero" | "cta" | "feature" | "banner" | "pricingTable" } } }
    fields: { internalName: string }   // ← only the field present in ALL members
})[]
```

rather than the expected discriminated union of member entries (`HeroEntry | CtaEntry | …`).

## Root cause

`Entry<>` is a non-distributive mapped type. With a union skeleton, `keyof EntrySkeleton['fields']` resolves over `keyof (A | B)` — the **intersection** of keys — so `fields` drops every member-specific field. (The `id` correctly becomes the union; only `fields` collapses.) The link-resolution path `ResolvedField → ResolvedLink → ResolvedEntryLink → Entry<Union, …>` captures the full union via `infer LinkedEntry`; the collapse happens inside `Entry`.

## Fix

Add `DistributiveEntry<S, M, L>`, which distributes `Entry<A | B>` into `Entry<A> | Entry<B>` (a no-op for a single skeleton), and use it in `ResolvedEntryLink` / `ResolvedEntryResourceLink`.

Distribution is applied **at the link-resolution boundary** (where the linked skeleton is already known) rather than in `Entry` itself. Making `Entry` distributive directly breaks contextual inference in `getEntry`/`getEntries` (e.g. `expectType<Entry<TestEntrySkeleton>>(client.getEntry('id'))` would fall back to the default skeleton), so `Entry` is intentionally kept non-distributive.

> Note: directly instantiating `Entry<Union>` at the top level (not via a link) remains non-distributive by design, for the inference reason above. This PR targets the link-resolution case described in the report.

## Tests

- New `test/types/entry-union-links.test-d.ts` asserts that a resolved `EntryLink<Union>` (single + array, `WITHOUT_UNRESOLVABLE_LINKS`) yields `(Entry<Hero> | Entry<Cta> | undefined)[]`, accepts member-specific fields, and stays discriminable on `sys.contentType.sys.id`. Fails before the fix (2 errors at the collapse sites), passes after.
- `npx tsd` → 0 errors (new + all existing type tests).
- `npm run lint` → 0 errors; `npm run test:unit` → 119 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)