### PR TITLE
build(deps): update @contentful/rich-text-types from v16 to v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/content-source-maps": "^0.11.33",
-        "@contentful/rich-text-types": "^16.6.1",
+        "@contentful/rich-text-types": "^17.2.7",
         "axios": "^1.15.0",
         "contentful-resolve-response": "^1.9.4",
         "contentful-sdk-core": "^9.4.4",
@@ -1729,12 +1729,12 @@
       }
     },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
-      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "version": "17.2.7",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.7.tgz",
+      "integrity": "sha512-aIdozk8vk5gsYcallOrwEiL6+GSlMXZorDOmiVELfpbVaXMJPJPlf2CBw3LUzviAqCw0UPQcKHHCwG7SdY7u5w==",
       "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@dabh/diagnostics": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@contentful/content-source-maps": "^0.11.33",
-    "@contentful/rich-text-types": "^16.6.1",
+    "@contentful/rich-text-types": "^17.2.7",
     "axios": "^1.15.0",
     "contentful-resolve-response": "^1.9.4",
     "contentful-sdk-core": "^9.4.4",


### PR DESCRIPTION
As titled. Resolves issue: https://github.com/contentful/contentful.js/issues/2708

Summary of changes in v16 - v17:
https://github.com/contentful/rich-text/pull/694

> removed getSchemaWithNodeType in favor of validateRichTextDocument no longer bundle dependencies

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the @contentful/rich-text-types dependency from v16.6.1 to v17.2.7, a TypeScript type definition package used by the SDK's content type and entry type definitions. The update provides newer type definitions for rich text document handling without requiring any code changes to the consuming files.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updated dependency @contentful/rich-text-types from ^16.6.1 to ^17.2.7 in package.json</li>

<li>Type definitions in content-type.ts (imports BLOCKS, INLINES enums) remain compatible with the new version</li>

<li>Type definitions in entry.ts (imports Document type as RichTextDocument) remain compatible with the new version</li>

</ul>
</details>

</div>